### PR TITLE
feat(ui): migrate detail summary views to unified SSA EditSession and…

### DIFF
--- a/ui/src/components/DetailPanel.tsx
+++ b/ui/src/components/DetailPanel.tsx
@@ -2118,6 +2118,7 @@ function PodSummary({
     name: c.name,
     status: c.state,
     kind: c.kind,
+    ready: c.ready,
   }));
   const initContainers = d.containers.filter((c) => c.kind === "init");
   const mainContainers = d.containers.filter((c) => c.kind !== "init");
@@ -2903,7 +2904,9 @@ function ContainerCard({
         }}
       >
         <ContainerDots
-          containers={[{ name: c.name, status: c.state, kind: c.kind }]}
+          containers={[
+            { name: c.name, status: c.state, kind: c.kind, ready: c.ready },
+          ]}
           t={t}
           showSeparator={false}
         />

--- a/ui/src/components/Dock.tsx
+++ b/ui/src/components/Dock.tsx
@@ -13,7 +13,16 @@ import jsYaml from "js-yaml";
 import Editor from "@monaco-editor/react";
 import { useAppStore, type DockPlacement, type DockTab, useResolvedTheme } from "../store";
 import { DockChat } from "./chat/DockChat";
-import { FF_MONO, type ThemeMode, R_MD, R_SM, FS_MD, FS_SM, FS_XS } from "../theme";
+import {
+  FF_MONO,
+  type ThemeMode,
+  R_MD,
+  R_SM,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  hexWithAlpha,
+} from "../theme";
 import { Btn, ErrorBlock, IconBtn, Icons, Select } from "./ui";
 import { api } from "../api";
 import type { DocApplyResult } from "../types";
@@ -1006,7 +1015,7 @@ function DockTerminal({
         <div
           style={{
             padding: "6px 10px",
-            background: t.bad + "22",
+            background: hexWithAlpha(t.bad, 0.13),
             borderTop: `1px solid ${t.border}`,
           }}
         >

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -1806,17 +1806,24 @@ function naturalContentWidth(c: ColumnDef, sample: ResourceRow[]): number {
       let dotsWidth = 0;
       if (isPodRow) {
         let inits = 0;
-        let mainsAndSidecars = 0;
+        let sidecars = 0;
+        let mains = 0;
         for (const s of states) {
           if (s.kind === "init") inits++;
-          else mainsAndSidecars++;
+          else if (s.kind === "sidecar") sidecars++;
+          else mains++;
         }
-        const total = inits + mainsAndSidecars;
+        const total = inits + sidecars + mains;
         // Main dots are size+2, init/sidecar are size — average to
         // (size+1) per dot since we don't track which is which here.
         dotsWidth =
           total * (DOT_SIZE + 1) + Math.max(0, total - 1) * DOT_GAP;
-        if (inits > 0 && mainsAndSidecars > 0) dotsWidth += SEP_WIDTH;
+        // Layout: init | sep | sidecar | sep | main. Count active boundaries.
+        const sepCount =
+          (inits > 0 && sidecars > 0 ? 1 : 0) +
+          (sidecars > 0 && mains > 0 ? 1 : 0) +
+          (inits > 0 && sidecars === 0 && mains > 0 ? 1 : 0);
+        dotsWidth += sepCount * SEP_WIDTH;
       }
 
       const gap = pillWidth > 0 && dotsWidth > 0 ? PHASE_WRAP_GAP : 0;
@@ -2057,6 +2064,7 @@ export function renderCell(
             s.kind === "init" || s.kind === "sidecar" || s.kind === "main"
               ? (s.kind as "init" | "main" | "sidecar")
               : "main",
+          ready: typeof s.ready === "boolean" ? s.ready : undefined,
         }));
         const ambient = phase === "Running" || phase === "Terminating";
         return (
@@ -2065,12 +2073,7 @@ export function renderCell(
               <StatusPill status={phase} t={t} mode={mode} dense />
             )}
             {containers.length > 0 && (
-              <ContainerDots
-                containers={containers}
-                t={t}
-                size={7}
-                showSeparator={containers.some((c) => c.kind === "init")}
-              />
+              <ContainerDots containers={containers} t={t} size={7} />
             )}
           </span>
         );

--- a/ui/src/components/chat/ToolApprovalBulkBar.tsx
+++ b/ui/src/components/chat/ToolApprovalBulkBar.tsx
@@ -1,7 +1,7 @@
 import { memo, useState } from "react";
 import { useResolvedTheme } from "../../store";
 import { api } from "../../api";
-import { FF_MONO, type ThemeMode, R_MD, FS_SM } from "../../theme";
+import { FF_MONO, type ThemeMode, R_MD, FS_SM, hexWithAlpha } from "../../theme";
 import { Btn, ErrorBlock } from "../ui";
 import type { ApprovalDecision } from "../../types";
 import type { PendingApproval } from "./chatStreaming";
@@ -89,7 +89,7 @@ function ToolApprovalBulkBarInner({ chatId, approvals }: Props) {
         gap: 8,
         padding: "10px 12px",
         background: t.surfaceAlt,
-        border: `1px solid ${t.warn}66`,
+        border: `1px solid ${hexWithAlpha(t.warn, 0.4)}`,
         borderLeft: `3px solid ${t.warn}`,
         borderRadius: R_MD,
         fontFamily: FF_MONO,

--- a/ui/src/components/chat/ToolApprovalCard.tsx
+++ b/ui/src/components/chat/ToolApprovalCard.tsx
@@ -1,7 +1,15 @@
 import { memo, useMemo, useState } from "react";
 import { useResolvedTheme } from "../../store";
 import { api } from "../../api";
-import { FF_MONO, type ThemeMode, R_MD, FS_MD, FS_SM, FS_XS } from "../../theme";
+import {
+  FF_MONO,
+  type ThemeMode,
+  R_MD,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  hexWithAlpha,
+} from "../../theme";
 import { Btn, ErrorBlock } from "../ui";
 import { useCopyFlash } from "../detail/primitives";
 import type { PendingApproval } from "./chatStreaming";
@@ -75,7 +83,7 @@ function ToolApprovalCardInner({ chatId, approval }: Props) {
           maxWidth: "92%",
           flex: 1,
           background: t.surfaceAlt,
-          border: `1px solid ${t.warn}66`,
+          border: `1px solid ${hexWithAlpha(t.warn, 0.4)}`,
           borderLeft: `3px solid ${t.warn}`,
           borderRadius: R_MD,
           padding: "10px 12px",

--- a/ui/src/components/detail/config/index.tsx
+++ b/ui/src/components/detail/config/index.tsx
@@ -25,6 +25,9 @@ import {
   formatQuantity,
   parseQuantity,
   type DetailNavigate,
+  EditSessionProvider,
+  useEditField,
+  GlobalSaveBar,
 } from "..";
 import type {
   ConfigMapDetail,
@@ -35,11 +38,9 @@ import type {
 import { MetaSection } from "../workload/shared";
 import {
   AddRowButton,
-  ConflictBanner,
   EditModeChrome,
   EditableTextValue,
   RowDeleteButton,
-  useApply,
 } from "../edit";
 
 // ── Local fetch + chrome (mirrors cluster/index.tsx) ───────────────────────
@@ -135,16 +136,26 @@ export function ConfigMapSummary(props: {
 
   const d = state.detail;
   return (
-    <ConfigMapView
-      t={t}
-      mode={props.mode}
-      clusterId={props.clusterId}
-      namespace={ns}
-      name={props.name}
-      detail={d}
-      onNavigate={props.onNavigate}
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "configmaps",
+        namespace: ns,
+        name: props.name,
+      }}
       onSaved={() => setRefetch((r) => r + 1)}
-    />
+    >
+      <ConfigMapView
+        t={t}
+        mode={props.mode}
+        clusterId={props.clusterId}
+        namespace={ns}
+        name={props.name}
+        detail={d}
+        onNavigate={props.onNavigate}
+        onSaved={() => setRefetch((r) => r + 1)}
+      />
+    </EditSessionProvider>
   );
 }
 
@@ -169,12 +180,24 @@ function ConfigMapView({
   onNavigate?: DetailNavigate;
   onSaved: () => void;
 }) {
-  const edit = useApply<ConfigMapBuffer>({
-    target: { clusterId, kindId: "configmaps", namespace, name },
+  const edit = useEditField<ConfigMapBuffer>({
+    id: "configmap",
     initial: () => bufferFromConfigMap(d),
     serialize: serializeConfigMapBuffer,
     dirtyCount: configMapDirtyCount,
-    onSaved,
+    validate: (b) => {
+      const v = validateConfigMapBuffer(b);
+      if (v.duplicate.size > 0) {
+        return `duplicate keys are not allowed: ${Array.from(v.duplicate).join(", ")}`;
+      }
+      for (const r of b.rows) {
+        if (r.deleted) continue;
+        if (!isValidConfigKey(r.key)) {
+          return `invalid key name: "${r.key}"`;
+        }
+      }
+      return null;
+    },
   });
 
   // Re-seed the buffer if the underlying detail changes while we're editing
@@ -232,7 +255,6 @@ function ConfigMapView({
             saving={edit.saving}
             onEnter={edit.enter}
             onCancel={edit.cancel}
-            onSave={edit.save}
             rightExtra={
               <span
                 style={{
@@ -248,18 +270,7 @@ function ConfigMapView({
         }
       />
 
-      {edit.conflict && (
-        <ConflictBanner
-          t={t}
-          conflict={edit.conflict}
-          saving={edit.saving}
-          onForce={edit.forceSave}
-          onDismiss={edit.dismissConflict}
-        />
-      )}
-      {edit.error && (
-        <SaveErrorBanner t={t} message={edit.error} kindLabel="configmap" />
-      )}
+
       {edit.editing && validation.duplicate.size > 0 && (
         <InlineError
           t={t}
@@ -324,6 +335,7 @@ function ConfigMapView({
           />
         )}
       </div>
+      <GlobalSaveBar t={t} />
     </Frame>
   );
 }
@@ -574,41 +586,6 @@ function InlineError({ t, message }: { t: Tokens; message: string }) {
   );
 }
 
-// Save-error banner — same chrome as InlineError but renders the message
-// through the shared `ErrorBlock` classifier so a 403 from SSA reads
-// "Access denied" instead of `kube error: <noun> is forbidden: ...`. Use
-// for `edit.error` (API-shaped) sites; keep `InlineError` for validation
-// strings the editor produces itself.
-function SaveErrorBanner({
-  t,
-  message,
-  kindLabel,
-}: {
-  t: Tokens;
-  message: string;
-  kindLabel: string;
-}) {
-  return (
-    <div
-      style={{
-        margin: "0 0 12px",
-        padding: "8px 10px",
-        background: "rgba(244,63,94,0.10)",
-        border: "1px solid rgba(244,63,94,0.4)",
-        borderRadius: R_SM,
-      }}
-    >
-      <ErrorBlock
-        t={t}
-        message={message}
-        kindLabel={kindLabel}
-        verb="save"
-        inline
-      />
-    </div>
-  );
-}
-
 function InlineWarn({ t, message }: { t: Tokens; message: string }) {
   return (
     <div
@@ -718,23 +695,32 @@ export function SecretSummary(props: {
   if (state.kind === "error")
     return <ErrorBlock t={t} message={state.message} kindLabel="secret" />;
 
+  const d = state.detail;
   return (
-    <SecretView
-      t={t}
-      mode={props.mode}
-      clusterId={props.clusterId}
-      namespace={ns}
-      name={props.name}
-      detail={state.detail}
-      onNavigate={props.onNavigate}
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "secrets",
+        namespace: ns,
+        name: props.name,
+      }}
       onSaved={() => setRefetch((r) => r + 1)}
-    />
+    >
+      <SecretView
+        t={t}
+        clusterId={props.clusterId}
+        namespace={ns}
+        name={props.name}
+        detail={d}
+        onNavigate={props.onNavigate}
+        onSaved={() => setRefetch((r) => r + 1)}
+      />
+    </EditSessionProvider>
   );
 }
 
 function SecretView({
   t,
-  mode: 
   clusterId,
   namespace,
   name,
@@ -743,7 +729,6 @@ function SecretView({
   onSaved,
 }: {
   t: Tokens;
-  mode: ThemeMode;
   clusterId: string;
   namespace: string;
   name: string;
@@ -751,12 +736,27 @@ function SecretView({
   onNavigate?: DetailNavigate;
   onSaved: () => void;
 }) {
-  const edit = useApply<SecretBuffer>({
-    target: { clusterId, kindId: "secrets", namespace, name },
+  const edit = useEditField<SecretBuffer>({
+    id: "secret",
     initial: () => bufferFromSecret(d),
     serialize: serializeSecretBuffer,
     dirtyCount: secretDirtyCount,
-    onSaved,
+    validate: (b) => {
+      const v = validateSecretBuffer(b);
+      if (v.duplicate.size > 0) {
+        return `duplicate keys are not allowed: ${Array.from(v.duplicate).join(", ")}`;
+      }
+      if (v.invalidRows.length > 0) {
+        return `invalid base64 in: ${v.invalidRows.join(", ")}`;
+      }
+      for (const r of b.rows) {
+        if (r.deleted) continue;
+        if (!isValidConfigKey(r.key)) {
+          return `invalid key name: "${r.key}"`;
+        }
+      }
+      return null;
+    },
   });
 
   const validation = useMemo(
@@ -804,7 +804,6 @@ function SecretView({
             saving={edit.saving}
             onEnter={edit.enter}
             onCancel={edit.cancel}
-            onSave={edit.save}
             rightExtra={
               <span
                 style={{
@@ -820,18 +819,6 @@ function SecretView({
         }
       />
 
-      {edit.conflict && (
-        <ConflictBanner
-          t={t}
-          conflict={edit.conflict}
-          saving={edit.saving}
-          onForce={edit.forceSave}
-          onDismiss={edit.dismissConflict}
-        />
-      )}
-      {edit.error && (
-        <SaveErrorBanner t={t} message={edit.error} kindLabel="secret" />
-      )}
       {edit.editing && validation.duplicate.size > 0 && (
         <InlineError
           t={t}
@@ -897,6 +884,7 @@ function SecretView({
           />
         )}
       </div>
+      <GlobalSaveBar t={t} />
     </Frame>
   );
 }
@@ -1356,16 +1344,27 @@ export function ResourceQuotaSummary(props: {
   if (state.kind === "error")
     return <ErrorBlock t={t} message={state.message} kindLabel="resource quota" />;
 
+  const d = state.detail;
   return (
-    <ResourceQuotaView
-      t={t}
-      clusterId={props.clusterId}
-      namespace={ns}
-      name={props.name}
-      detail={state.detail}
-      onNavigate={props.onNavigate}
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "resourcequotas",
+        namespace: ns,
+        name: props.name,
+      }}
       onSaved={() => setRefetch((r) => r + 1)}
-    />
+    >
+      <ResourceQuotaView
+        t={t}
+        clusterId={props.clusterId}
+        namespace={ns}
+        name={props.name}
+        detail={d}
+        onNavigate={props.onNavigate}
+        onSaved={() => setRefetch((r) => r + 1)}
+      />
+    </EditSessionProvider>
   );
 }
 
@@ -1386,12 +1385,27 @@ function ResourceQuotaView({
   onNavigate?: DetailNavigate;
   onSaved: () => void;
 }) {
-  const edit = useApply<QuotaBuffer>({
-    target: { clusterId, kindId: "resourcequotas", namespace, name },
+  const edit = useEditField<QuotaBuffer>({
+    id: "resourcequota",
     initial: () => bufferFromQuota(d),
     serialize: serializeQuotaBuffer,
     dirtyCount: quotaDirtyCount,
-    onSaved,
+    validate: (b) => {
+      const v = validateQuotaBuffer(b);
+      if (v.duplicate.size > 0) {
+        return `duplicate resources are not allowed: ${Array.from(v.duplicate).join(", ")}`;
+      }
+      if (v.invalidRows.length > 0) {
+        return `invalid quantity in: ${v.invalidRows.join(", ")}`;
+      }
+      for (const r of b.rows) {
+        if (r.deleted) continue;
+        if (r.name !== "" && !isValidQuotaResource(r.name)) {
+          return `invalid resource name: "${r.name}"`;
+        }
+      }
+      return null;
+    },
   });
 
   const validation = useMemo(
@@ -1435,7 +1449,6 @@ function ResourceQuotaView({
             saving={edit.saving}
             onEnter={edit.enter}
             onCancel={edit.cancel}
-            onSave={edit.save}
             rightExtra={
               <span
                 style={{
@@ -1451,18 +1464,6 @@ function ResourceQuotaView({
         }
       />
 
-      {edit.conflict && (
-        <ConflictBanner
-          t={t}
-          conflict={edit.conflict}
-          saving={edit.saving}
-          onForce={edit.forceSave}
-          onDismiss={edit.dismissConflict}
-        />
-      )}
-      {edit.error && (
-        <SaveErrorBanner t={t} message={edit.error} kindLabel="resource quota" />
-      )}
       {edit.editing && validation.duplicate.size > 0 && (
         <InlineError
           t={t}
@@ -1560,6 +1561,7 @@ function ResourceQuotaView({
           </div>
         </>
       )}
+      <GlobalSaveBar t={t} />
     </Frame>
   );
 }
@@ -1847,16 +1849,27 @@ export function LimitRangeSummary(props: {
   if (state.kind === "error")
     return <ErrorBlock t={t} message={state.message} kindLabel="limit range" />;
 
+  const d = state.detail;
   return (
-    <LimitRangeView
-      t={t}
-      clusterId={props.clusterId}
-      namespace={ns}
-      name={props.name}
-      detail={state.detail}
-      onNavigate={props.onNavigate}
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "limitranges",
+        namespace: ns,
+        name: props.name,
+      }}
       onSaved={() => setRefetch((r) => r + 1)}
-    />
+    >
+      <LimitRangeView
+        t={t}
+        clusterId={props.clusterId}
+        namespace={ns}
+        name={props.name}
+        detail={d}
+        onNavigate={props.onNavigate}
+        onSaved={() => setRefetch((r) => r + 1)}
+      />
+    </EditSessionProvider>
   );
 }
 
@@ -1877,12 +1890,18 @@ function LimitRangeView({
   onNavigate?: DetailNavigate;
   onSaved: () => void;
 }) {
-  const edit = useApply<LimitRangeBuffer>({
-    target: { clusterId, kindId: "limitranges", namespace, name },
+  const edit = useEditField<LimitRangeBuffer>({
+    id: "limitrange",
     initial: () => bufferFromLimitRange(d),
     serialize: serializeLimitRangeBuffer,
     dirtyCount: limitRangeDirtyCount,
-    onSaved,
+    validate: (b) => {
+      const v = validateLimitRangeBuffer(b);
+      if (v.invalidCells.length > 0) {
+        return `invalid quantity in: ${v.invalidCells.join(", ")}`;
+      }
+      return null;
+    },
   });
 
   const validation = useMemo(
@@ -1927,7 +1946,6 @@ function LimitRangeView({
               saving={edit.saving}
               onEnter={edit.enter}
               onCancel={edit.cancel}
-              onSave={edit.save}
               rightExtra={
                 <span
                   style={{
@@ -1944,18 +1962,6 @@ function LimitRangeView({
         />
       </div>
 
-      {edit.conflict && (
-        <ConflictBanner
-          t={t}
-          conflict={edit.conflict}
-          saving={edit.saving}
-          onForce={edit.forceSave}
-          onDismiss={edit.dismissConflict}
-        />
-      )}
-      {edit.error && (
-        <SaveErrorBanner t={t} message={edit.error} kindLabel="limit range" />
-      )}
       {edit.editing && validation.invalidCells.length > 0 && (
         <InlineError
           t={t}
@@ -2014,6 +2020,7 @@ function LimitRangeView({
           <LimitRangeItemBlock key={`${item.type_}-${idx}`} t={t} item={item} />
         ))
       )}
+      <GlobalSaveBar t={t} />
     </Frame>
   );
 }

--- a/ui/src/components/detail/config/index.tsx
+++ b/ui/src/components/detail/config/index.tsx
@@ -147,7 +147,6 @@ export function ConfigMapSummary(props: {
     >
       <ConfigMapView
         t={t}
-        mode={props.mode}
         clusterId={props.clusterId}
         namespace={ns}
         name={props.name}
@@ -163,7 +162,6 @@ export function ConfigMapSummary(props: {
 // fetch effect on every keystroke.
 function ConfigMapView({
   t,
-  mode: 
   clusterId,
   namespace,
   name,
@@ -172,7 +170,6 @@ function ConfigMapView({
   onSaved,
 }: {
   t: Tokens;
-  mode: ThemeMode;
   clusterId: string;
   namespace: string;
   name: string;
@@ -269,7 +266,6 @@ function ConfigMapView({
           />
         }
       />
-
 
       {edit.editing && validation.duplicate.size > 0 && (
         <InlineError

--- a/ui/src/components/detail/edit.expanded.test.tsx
+++ b/ui/src/components/detail/edit.expanded.test.tsx
@@ -1,12 +1,10 @@
 // Additional coverage for the edit kit:
 //   • listBuffer helpers (env / ports / volumes editors)
 //   • EditModeChrome / EditableTextValue / AddRowButton / ConflictBanner render
-//   • useApply hook — save / conflict / force / error state machine
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, act, fireEvent } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { renderHook } from "@testing-library/react";
 import {
   AddRowButton,
   ConflictBanner,
@@ -21,19 +19,11 @@ import {
   listBufferReplace,
   listBufferToArray,
   listBufferToggleDelete,
-  useApply,
-  type ApplyTarget,
 } from "./edit";
 import { tokens } from "../../theme";
-import { setMockInvoke, resetMockInvoke } from "../../test/tauri-mock";
+import { resetMockInvoke } from "../../test/tauri-mock";
 
 const t = tokens("dark");
-const TARGET: ApplyTarget = {
-  clusterId: "ctx",
-  kindId: "configmaps",
-  namespace: "default",
-  name: "hello",
-};
 
 beforeEach(() => {
   resetMockInvoke();
@@ -358,146 +348,3 @@ describe("KvEditor", () => {
   });
 });
 
-// ── useApply state machine ───────────────────────────────────────────────
-
-describe("useApply", () => {
-  it("save → applied transitions through saving:true → applied, calls onSaved", async () => {
-    setMockInvoke((cmd) => {
-      expect(cmd).toBe("apply_resource_cmd");
-      return { kind: "applied", resource_version: "42" };
-    });
-    const onSaved = vi.fn();
-    const { result } = renderHook(() =>
-      useApply<{ value: string }>({
-        target: TARGET,
-        initial: () => ({ value: "" }),
-        serialize: (b) => ({ data: { K: b.value } }),
-        dirtyCount: () => 1,
-        onSaved,
-      }),
-    );
-
-    expect(result.current.saving).toBe(false);
-    await act(async () => {
-      result.current.enter();
-    });
-    await act(async () => {
-      result.current.setBuffer({ value: "new" });
-    });
-    await act(async () => {
-      await result.current.save();
-    });
-    expect(onSaved).toHaveBeenCalled();
-    expect(result.current.editing).toBe(false);
-    expect(result.current.saving).toBe(false);
-  });
-
-  it("save → conflict surfaces managers/fields/message; dismissConflict clears", async () => {
-    setMockInvoke(() => ({
-      kind: "conflict",
-      managers: ["argocd"],
-      fields: ["spec.replicas"],
-      message: "owned",
-    }));
-    const { result } = renderHook(() =>
-      useApply<unknown>({
-        target: TARGET,
-        initial: () => ({}),
-        serialize: () => ({}),
-        dirtyCount: () => 1,
-        onSaved: () => {},
-      }),
-    );
-    await act(async () => {
-      result.current.enter();
-    });
-    await act(async () => {
-      await result.current.save();
-    });
-    expect(result.current.conflict).toEqual({
-      kind: "conflict",
-      managers: ["argocd"],
-      fields: ["spec.replicas"],
-      message: "owned",
-    });
-    await act(async () => {
-      result.current.dismissConflict();
-    });
-    expect(result.current.conflict).toBeNull();
-  });
-
-  it("forceSave passes force=true to apply_resource_cmd", async () => {
-    let receivedForce: unknown = null;
-    setMockInvoke((_cmd, args) => {
-      receivedForce = args?.force;
-      return { kind: "applied" };
-    });
-    const { result } = renderHook(() =>
-      useApply<unknown>({
-        target: TARGET,
-        initial: () => ({}),
-        serialize: () => ({ data: { K: "v" } }),
-        dirtyCount: () => 1,
-        onSaved: () => {},
-      }),
-    );
-    await act(async () => {
-      result.current.enter();
-    });
-    await act(async () => {
-      await result.current.forceSave();
-    });
-    expect(receivedForce).toBe(true);
-  });
-
-  it("save → throw surfaces as error state without onSaved firing", async () => {
-    setMockInvoke(() => {
-      throw new Error("network down");
-    });
-    const onSaved = vi.fn();
-    const { result } = renderHook(() =>
-      useApply<unknown>({
-        target: TARGET,
-        initial: () => ({}),
-        serialize: () => ({}),
-        dirtyCount: () => 1,
-        onSaved,
-      }),
-    );
-    await act(async () => {
-      result.current.enter();
-    });
-    await act(async () => {
-      await result.current.save();
-    });
-    expect(result.current.error).toMatch(/network down/);
-    expect(onSaved).not.toHaveBeenCalled();
-  });
-
-  it("cancel exits edit mode and clears any error", async () => {
-    setMockInvoke(() => {
-      throw new Error("nope");
-    });
-    const { result } = renderHook(() =>
-      useApply<unknown>({
-        target: TARGET,
-        initial: () => ({}),
-        serialize: () => ({}),
-        dirtyCount: () => 0,
-        onSaved: () => {},
-      }),
-    );
-    await act(async () => {
-      result.current.enter();
-    });
-    await act(async () => {
-      await result.current.save();
-    });
-    expect(result.current.error).not.toBeNull();
-    await act(async () => {
-      result.current.cancel();
-    });
-    expect(result.current.editing).toBe(false);
-    expect(result.current.error).toBeNull();
-  });
-});

--- a/ui/src/components/detail/edit.tsx
+++ b/ui/src/components/detail/edit.tsx
@@ -14,17 +14,18 @@
 //     a successful apply so the read-state refreshes.
 
 import {
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
   type CSSProperties,
   type ReactNode,
 } from "react";
-import { api } from "../../api";
 import { FF_MONO, type Tokens, R_SM, FS_MD, FS_SM } from "../../theme";
 import { Icons } from "../ui";
-import type { ApplyResult } from "../../types";
+
+export type ApplyTarget = {
+  clusterId: string;
+  kindId: string;
+  namespace: string | null;
+  name: string;
+};
 
 // ── EditMode header ────────────────────────────────────────────────────────
 //
@@ -609,111 +610,6 @@ export function KvEditor({
       />
     </div>
   );
-}
-
-// ── useApply hook ──────────────────────────────────────────────────────────
-//
-// One-stop edit lifecycle: holds the buffer, dirty count, save state, and
-// conflict surface. Owners pass a `serialize` that turns the current buffer
-// into the SSA payload; the hook handles the apply call + conflict
-// branching + force re-apply.
-
-export type ApplyTarget = {
-  clusterId: string;
-  kindId: string;
-  namespace: string | null;
-  name: string;
-};
-
-type SaveState =
-  | { kind: "idle" }
-  | { kind: "saving" }
-  | { kind: "conflict"; managers: string[]; fields: string[]; message: string }
-  | { kind: "error"; message: string };
-
-export function useApply<B>(opts: {
-  target: ApplyTarget;
-  initial: () => B;
-  // Pure function. Returns a partial-object SSA payload (without
-  // apiVersion/kind/metadata.name — the backend attaches those). The hook
-  // wraps it as the `fields` arg of `apply_resource_cmd`.
-  serialize: (buffer: B) => Record<string, unknown>;
-  // Count of dirty changes, used for the Save button's "(N)" suffix. Keeps
-  // the hook independent of the buffer's internal shape.
-  dirtyCount: (buffer: B) => number;
-  // Called after a successful (non-conflict) apply. Typically the parent
-  // bumps `detailVersion` here to refetch.
-  onSaved: () => void;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [buffer, setBuffer] = useState<B>(opts.initial);
-  const [save, setSave] = useState<SaveState>({ kind: "idle" });
-
-  // Re-seed the buffer on every Edit click so a stale buffer from a prior
-  // edit doesn't carry over after the underlying detail changed.
-  const initialRef = useRef(opts.initial);
-  initialRef.current = opts.initial;
-
-  const enter = useCallback(() => {
-    setBuffer(initialRef.current());
-    setSave({ kind: "idle" });
-    setEditing(true);
-  }, []);
-  const cancel = useCallback(() => {
-    setEditing(false);
-    setSave({ kind: "idle" });
-  }, []);
-
-  const apply = useCallback(
-    async (force: boolean) => {
-      setSave({ kind: "saving" });
-      try {
-        const result: ApplyResult = await api.applyResource(
-          opts.target.clusterId,
-          opts.target.kindId,
-          opts.target.namespace,
-          opts.target.name,
-          opts.serialize(buffer),
-          force,
-        );
-        if (result.kind === "applied") {
-          setEditing(false);
-          setSave({ kind: "idle" });
-          opts.onSaved();
-        } else {
-          setSave({
-            kind: "conflict",
-            managers: result.managers,
-            fields: result.fields,
-            message: result.message,
-          });
-        }
-      } catch (e) {
-        setSave({ kind: "error", message: String(e) });
-      }
-    },
-    // serialize / target / onSaved are read fresh each invocation — buffer
-    // is the only value we capture.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [buffer, opts.target.clusterId, opts.target.kindId, opts.target.namespace, opts.target.name],
-  );
-
-  const dirty = useMemo(() => opts.dirtyCount(buffer), [buffer, opts]);
-
-  return {
-    editing,
-    buffer,
-    setBuffer,
-    enter,
-    cancel,
-    save: () => apply(false),
-    forceSave: () => apply(true),
-    dirty,
-    saving: save.kind === "saving",
-    conflict: save.kind === "conflict" ? save : null,
-    error: save.kind === "error" ? save.message : null,
-    dismissConflict: () => setSave({ kind: "idle" }),
-  };
 }
 
 // ── ListBuffer / ListEditor ────────────────────────────────────────────────

--- a/ui/src/components/detail/editSession.lifecycle.test.tsx
+++ b/ui/src/components/detail/editSession.lifecycle.test.tsx
@@ -1,0 +1,297 @@
+// Lifecycle coverage for the panel-wide edit session — replaces the
+// per-editor `useApply` tests that lived in edit.expanded.test.tsx before
+// the SSA migration. Drives EditSessionProvider + useEditField end-to-end
+// through the GlobalSaveBar so we exercise the same path the panels use.
+//
+//   • save → applied (calls onSaved, collapses editing, clears dirty)
+//   • save → conflict (surfaces managers/fields/message, dismiss clears)
+//   • saveAll(true) → force takeover
+//   • save → throw (surfaces in error state, onSaved not fired)
+//   • cancelAll exits edit mode + resets buffers + clears errors
+//   • validate blocks save and reaches the operator
+//   • mergePatch combines two dirty editors into one apply call
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+import { EditSessionProvider, useEditField } from "./editSession";
+import { GlobalSaveBar } from "./globalSaveBar";
+import type { ApplyTarget } from "./edit";
+import { tokens } from "../../theme";
+import { setMockInvoke, resetMockInvoke } from "../../test/tauri-mock";
+
+const t = tokens("dark");
+const TARGET: ApplyTarget = {
+  clusterId: "ctx",
+  kindId: "configmaps",
+  namespace: "default",
+  name: "hello",
+};
+
+beforeEach(() => {
+  resetMockInvoke();
+});
+
+// Minimal editor that exposes its lifecycle through data-testid attributes
+// + buttons. Avoids spinning up real DetailRow chrome so the assertions
+// stay focused on the session machinery.
+function Editor({
+  id,
+  partial,
+  validate,
+}: {
+  id: string;
+  partial: Record<string, unknown>;
+  validate?: (b: { value: string }) => string | null;
+}) {
+  const field = useEditField<{ value: string }>({
+    id,
+    initial: () => ({ value: "" }),
+    serialize: (b) => ({ ...partial, _value: b.value }),
+    dirtyCount: (b) => (b.value === "" ? 0 : 1),
+    validate,
+  });
+  return (
+    <div>
+      <span data-testid={`${id}-editing`}>{String(field.editing)}</span>
+      <span data-testid={`${id}-dirty`}>{field.dirty}</span>
+      <span data-testid={`${id}-buffer`}>{field.buffer.value}</span>
+      <button data-testid={`${id}-enter`} onClick={field.enter} />
+      <button data-testid={`${id}-cancel`} onClick={field.cancel} />
+      <button
+        data-testid={`${id}-set`}
+        onClick={() => field.setBuffer({ value: "new" })}
+      />
+    </div>
+  );
+}
+
+function renderPanel(opts: {
+  onSaved?: () => void;
+  editors?: Array<{
+    id: string;
+    partial: Record<string, unknown>;
+    validate?: (b: { value: string }) => string | null;
+  }>;
+}) {
+  const onSaved = opts.onSaved ?? (() => {});
+  const editors = opts.editors ?? [{ id: "e1", partial: { data: { k: "v" } } }];
+  return render(
+    <EditSessionProvider target={TARGET} onSaved={onSaved}>
+      {editors.map((e) => (
+        <Editor key={e.id} {...e} />
+      ))}
+      <GlobalSaveBar t={t} />
+    </EditSessionProvider>,
+  );
+}
+
+// Helper — click the Save button on the global bar. Throws if the bar
+// isn't rendered (i.e. nothing is dirty), which is what we want when a
+// test asserts the bar is hidden.
+function clickSave(container: HTMLElement) {
+  const btn = container.querySelector(
+    "button[type='button']:not([disabled])",
+  ) as HTMLButtonElement | null;
+  // The bar renders Cancel before Save — pick by visible text instead.
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const save = buttons.find((b) => /Save \(\d+\)/.test(b.textContent ?? ""));
+  if (!save) throw new Error("Save button not found");
+  fireEvent.click(save);
+  return btn;
+}
+
+// Btn renders a kbd span next to its label, so textContent picks up both
+// strings — match by `includes` rather than equality.
+function clickCancel(container: HTMLElement) {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const cancel = buttons.find((b) => (b.textContent ?? "").includes("Cancel"));
+  if (!cancel) throw new Error("Cancel button not found");
+  fireEvent.click(cancel);
+}
+
+function clickForce(container: HTMLElement) {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const force = buttons.find((b) =>
+    (b.textContent ?? "").includes("Force takeover"),
+  );
+  if (!force) throw new Error("Force takeover button not found");
+  fireEvent.click(force);
+}
+
+describe("EditSessionProvider + useEditField", () => {
+  it("save → applied: fires onSaved, collapses editing, clears dirty", async () => {
+    setMockInvoke((cmd) => {
+      expect(cmd).toBe("apply_resource_cmd");
+      return { kind: "applied", resource_version: "42" };
+    });
+    const onSaved = vi.fn();
+    const { getByTestId, container, queryByText } = renderPanel({ onSaved });
+
+    fireEvent.click(getByTestId("e1-enter"));
+    fireEvent.click(getByTestId("e1-set"));
+    expect(getByTestId("e1-dirty").textContent).toBe("1");
+    expect(getByTestId("e1-editing").textContent).toBe("true");
+
+    await act(async () => {
+      clickSave(container);
+    });
+
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    // Session collapses the editing map on success. The local editor's
+    // dirty count still reads 1 because the buffer holds "new" until the
+    // parent's refetch re-seeds it — that's the contract per editSession's
+    // post-save comment ("Don't reset buffers"). What we *can* check from
+    // the outside is that editing collapsed and saving cleared.
+    expect(getByTestId("e1-editing").textContent).toBe("false");
+    expect(queryByText(/Saving…/)).toBeNull();
+  });
+
+  it("save → conflict surfaces managers/fields/message; dismiss clears", async () => {
+    setMockInvoke(() => ({
+      kind: "conflict",
+      managers: ["argocd"],
+      fields: ["spec.replicas"],
+      message: "owned",
+    }));
+    const { getByTestId, container, queryByText } = renderPanel({});
+
+    fireEvent.click(getByTestId("e1-enter"));
+    fireEvent.click(getByTestId("e1-set"));
+    await act(async () => {
+      clickSave(container);
+    });
+
+    expect(queryByText(/SSA conflict with argocd/)).not.toBeNull();
+    expect(queryByText("spec.replicas")).not.toBeNull();
+    expect(queryByText("owned")).not.toBeNull();
+    expect(queryByText("Force takeover")).not.toBeNull();
+  });
+
+  it("Force takeover calls apply_resource_cmd with force=true", async () => {
+    let firstCall = true;
+    let receivedForce: unknown = null;
+    setMockInvoke((_cmd, args) => {
+      if (firstCall) {
+        firstCall = false;
+        return {
+          kind: "conflict",
+          managers: ["argocd"],
+          fields: ["x"],
+          message: "owned",
+        };
+      }
+      receivedForce = args?.force;
+      return { kind: "applied", resource_version: "1" };
+    });
+    const onSaved = vi.fn();
+    const { getByTestId, container } = renderPanel({ onSaved });
+
+    fireEvent.click(getByTestId("e1-enter"));
+    fireEvent.click(getByTestId("e1-set"));
+    await act(async () => {
+      clickSave(container);
+    });
+    await act(async () => {
+      clickForce(container);
+    });
+    expect(receivedForce).toBe(true);
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("save → throw surfaces as error state without firing onSaved", async () => {
+    setMockInvoke(() => {
+      throw new Error("network down");
+    });
+    const onSaved = vi.fn();
+    const { getByTestId, container, queryByText } = renderPanel({ onSaved });
+
+    fireEvent.click(getByTestId("e1-enter"));
+    fireEvent.click(getByTestId("e1-set"));
+    await act(async () => {
+      clickSave(container);
+    });
+
+    expect(onSaved).not.toHaveBeenCalled();
+    // ErrorBlock classifies + renders the message somewhere in the bar.
+    expect(container.textContent ?? "").toMatch(/network down/);
+    // queryByText silences a lint warning when only used for the
+    // 'not.toBeNull' shape above; the regex is left to keep the failure
+    // message readable.
+    queryByText("Save failed");
+  });
+
+  it("validate blocks save and surfaces the message", async () => {
+    const invokeSpy = vi.fn(() => ({ kind: "applied", resource_version: "1" }));
+    setMockInvoke(invokeSpy);
+    const { getByTestId, container, queryByText } = renderPanel({
+      editors: [
+        {
+          id: "e1",
+          partial: { data: { k: "v" } },
+          validate: (b) => (b.value === "new" ? "no good" : null),
+        },
+      ],
+    });
+
+    fireEvent.click(getByTestId("e1-enter"));
+    fireEvent.click(getByTestId("e1-set"));
+    await act(async () => {
+      clickSave(container);
+    });
+
+    expect(invokeSpy).not.toHaveBeenCalled();
+    expect(queryByText(/no good/)).not.toBeNull();
+  });
+
+  it("cancelAll exits edit mode, resets buffers, clears errors", async () => {
+    setMockInvoke(() => {
+      throw new Error("nope");
+    });
+    const { getByTestId, container } = renderPanel({});
+
+    fireEvent.click(getByTestId("e1-enter"));
+    fireEvent.click(getByTestId("e1-set"));
+    expect(getByTestId("e1-buffer").textContent).toBe("new");
+    await act(async () => {
+      clickSave(container);
+    });
+    // Error surfaced; bar still up because of error state.
+    expect(container.textContent ?? "").toMatch(/nope/);
+
+    // cancelAll fires the Cancel button on the bar.
+    await act(async () => {
+      clickCancel(container);
+    });
+    expect(getByTestId("e1-editing").textContent).toBe("false");
+    expect(getByTestId("e1-buffer").textContent).toBe(""); // reset
+    expect(getByTestId("e1-dirty").textContent).toBe("0");
+  });
+
+  it("merges two dirty editors into one apply call", async () => {
+    let payload: unknown = null;
+    setMockInvoke((_cmd, args) => {
+      payload = args?.fields;
+      return { kind: "applied", resource_version: "1" };
+    });
+    const { getByTestId, container } = renderPanel({
+      editors: [
+        { id: "a", partial: { spec: { replicas: 3 } } },
+        { id: "b", partial: { metadata: { labels: { app: "x" } } } },
+      ],
+    });
+
+    fireEvent.click(getByTestId("a-enter"));
+    fireEvent.click(getByTestId("a-set"));
+    fireEvent.click(getByTestId("b-enter"));
+    fireEvent.click(getByTestId("b-set"));
+    await act(async () => {
+      clickSave(container);
+    });
+
+    // Both partials end up in the merged tree — proves the session sent a
+    // single apply rather than per-editor round-trips.
+    const p = payload as Record<string, unknown>;
+    expect(p.spec).toMatchObject({ replicas: 3 });
+    expect(p.metadata).toMatchObject({ labels: { app: "x" } });
+  });
+});

--- a/ui/src/components/detail/editSession.tsx
+++ b/ui/src/components/detail/editSession.tsx
@@ -77,7 +77,7 @@ export function useEditSession(): SessionApi | null {
 // the underlying resource so the session resets when the operator
 // switches to a different object.
 export function EditSessionProvider({
-  target,
+  target: targetProp,
   onSaved,
   children,
 }: {
@@ -87,6 +87,20 @@ export function EditSessionProvider({
   onSaved: () => void;
   children: ReactNode;
 }) {
+  // Callers usually pass `target={{...}}` inline — that object's identity
+  // changes every render, which would propagate into the context value and
+  // re-run every editor's `useEffect([session, …])`. Normalize by primitive
+  // so the target ref is stable across renders that don't actually retarget.
+  const target = useMemo<ApplyTarget>(
+    () => ({
+      clusterId: targetProp.clusterId,
+      kindId: targetProp.kindId,
+      namespace: targetProp.namespace,
+      name: targetProp.name,
+    }),
+    [targetProp.clusterId, targetProp.kindId, targetProp.namespace, targetProp.name],
+  );
+
   // Mutable callback registry — editors stash fresh closures here every
   // render so the session always sees the latest serialize / reset /
   // validate. Mutating a ref doesn't trigger renders, which is exactly
@@ -152,6 +166,13 @@ export function EditSessionProvider({
   const dirtyMapRef = useRef(dirtyMap);
   dirtyMapRef.current = dirtyMap;
 
+  // Same trick for onSaved — callers commonly pass `onSaved={() => …}`
+  // inline so the prop is a fresh closure every render. Stashing it in a
+  // ref keeps `saveAll`'s identity stable, which is what stops the
+  // context value memo from churning.
+  const onSavedRef = useRef(onSaved);
+  onSavedRef.current = onSaved;
+
   const saveAll = useCallback(
     async (force = false) => {
       const dirtyIds = Object.entries(dirtyMapRef.current)
@@ -205,7 +226,7 @@ export function EditSessionProvider({
           setEditingMap({});
           setDirtyMap({});
           setState({ saving: false, conflict: null, error: null });
-          onSaved();
+          onSavedRef.current();
         } else {
           setState({
             saving: false,
@@ -221,7 +242,7 @@ export function EditSessionProvider({
         setState({ saving: false, conflict: null, error: String(e) });
       }
     },
-    [target.clusterId, target.kindId, target.namespace, target.name, onSaved],
+    [target.clusterId, target.kindId, target.namespace, target.name],
   );
 
   const cancelAll = useCallback(() => {
@@ -235,20 +256,41 @@ export function EditSessionProvider({
     setState((s) => ({ ...s, conflict: null }));
   }, []);
 
-  const value: SessionApi = {
-    target,
-    register,
-    setDirty,
-    dirty,
-    isEditing,
-    setEditing,
-    saving: state.saving,
-    conflict: state.conflict,
-    error: state.error,
-    saveAll,
-    cancelAll,
-    dismissConflict,
-  };
+  // Memoised so consumers' `useEffect([session, ...])` doesn't re-run on
+  // every Provider render. Without this, the cleanup of `useEditField`'s
+  // register-effect calls `setDirtyMap(delete id)`, the setDirty-effect
+  // re-adds it, the Provider re-renders, the session ref changes again —
+  // an infinite loop the moment any editor goes dirty.
+  const value = useMemo<SessionApi>(
+    () => ({
+      target,
+      register,
+      setDirty,
+      dirty,
+      isEditing,
+      setEditing,
+      saving: state.saving,
+      conflict: state.conflict,
+      error: state.error,
+      saveAll,
+      cancelAll,
+      dismissConflict,
+    }),
+    [
+      target,
+      register,
+      setDirty,
+      dirty,
+      isEditing,
+      setEditing,
+      state.saving,
+      state.conflict,
+      state.error,
+      saveAll,
+      cancelAll,
+      dismissConflict,
+    ],
+  );
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }
 

--- a/ui/src/components/detail/extended/index.tsx
+++ b/ui/src/components/detail/extended/index.tsx
@@ -11,6 +11,8 @@ import { ErrorBlock, LoadingLine, Section, StatusPill } from "../../ui";
 import {
   Copyable,
   DetailRow,
+  EditSessionProvider,
+  GlobalSaveBar,
   KeyValueChips,
   LinkValue,
   Mute,
@@ -114,130 +116,140 @@ export function HorizontalPodAutoscalerSummary(props: {
       ) : state.kind === "error" ? (
         <ErrorBlock t={t} message={state.message} kindLabel="hpa" />
       ) : (
-        <Frame t={t}>
-          <MetaSection
-            t={t}
-            meta={state.detail.meta}
-            onNavigate={props.onNavigate}
-            editTarget={{
-              clusterId: props.clusterId,
-              kindId: "horizontalpodautoscalers",
-              namespace: ns,
-              name: props.name,
-            }}
-            onSaved={() => setRefetch((r) => r + 1)}
-          />
-          <Section t={t} title="Scale Target" />
-          <div style={{ marginBottom: 22 }}>
-            {state.detail.scale_target_ref ? (
-              <>
-                <DetailRow t={t} label="Kind">
-                  <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                    {state.detail.scale_target_ref.kind}
-                  </span>
-                </DetailRow>
-                <DetailRow t={t} label="Name">
-                  <LinkValue
-                    t={t}
-                    onClick={() =>
-                      props.onNavigate?.(
-                        state.detail.scale_target_ref!.kind,
-                        ns,
-                        state.detail.scale_target_ref!.name,
-                      )
-                    }
-                    copyText={state.detail.scale_target_ref.name}
-                    enabled={!!props.onNavigate}
-                  >
-                    {state.detail.scale_target_ref.name}
-                  </LinkValue>
-                </DetailRow>
-                {state.detail.scale_target_ref.api_version && (
-                  <DetailRow t={t} label="API Version">
+        <EditSessionProvider
+          target={{
+            clusterId: props.clusterId,
+            kindId: "horizontalpodautoscalers",
+            namespace: ns,
+            name: props.name,
+          }}
+          onSaved={() => setRefetch((r) => r + 1)}
+        >
+          <Frame t={t}>
+            <MetaSection
+              t={t}
+              meta={state.detail.meta}
+              onNavigate={props.onNavigate}
+              editTarget={{
+                clusterId: props.clusterId,
+                kindId: "horizontalpodautoscalers",
+                namespace: ns,
+                name: props.name,
+              }}
+            />
+            <Section t={t} title="Scale Target" />
+            <div style={{ marginBottom: 22 }}>
+              {state.detail.scale_target_ref ? (
+                <>
+                  <DetailRow t={t} label="Kind">
                     <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                      {state.detail.scale_target_ref.api_version}
+                      {state.detail.scale_target_ref.kind}
                     </span>
                   </DetailRow>
-                )}
-              </>
-            ) : (
-              <Mute t={t}>—</Mute>
-            )}
-          </div>
+                  <DetailRow t={t} label="Name">
+                    <LinkValue
+                      t={t}
+                      onClick={() =>
+                        props.onNavigate?.(
+                          state.detail.scale_target_ref!.kind,
+                          ns,
+                          state.detail.scale_target_ref!.name,
+                        )
+                      }
+                      copyText={state.detail.scale_target_ref.name}
+                      enabled={!!props.onNavigate}
+                    >
+                      {state.detail.scale_target_ref.name}
+                    </LinkValue>
+                  </DetailRow>
+                  {state.detail.scale_target_ref.api_version && (
+                    <DetailRow t={t} label="API Version">
+                      <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
+                        {state.detail.scale_target_ref.api_version}
+                      </span>
+                    </DetailRow>
+                  )}
+                </>
+              ) : (
+                <Mute t={t}>—</Mute>
+              )}
+            </div>
 
-          <Section t={t} title="Replicas" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Min">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.min_replicas ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Max">
-              <span style={{ fontSize: FS_MD }}>{state.detail.max_replicas}</span>
-            </DetailRow>
-            <DetailRow t={t} label="Current">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.current_replicas ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Desired">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.desired_replicas ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            {state.detail.last_scale_time && (
-              <DetailRow t={t} label="Last Scaled">
-                <Copyable text={state.detail.last_scale_time}>
-                  <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                    {ageFromIso(state.detail.last_scale_time)} ago
-                  </span>
-                </Copyable>
+            <Section t={t} title="Replicas" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Min">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.min_replicas ?? <Mute t={t}>—</Mute>}
+                </span>
               </DetailRow>
-            )}
-          </div>
-
-          {state.detail.metrics.length > 0 && (
-            <>
-              <Section
-                t={t}
-                title="Metrics"
-                right={`${state.detail.metrics.length} total`}
-              />
-              <div style={{ marginBottom: 22 }}>
-                {state.detail.metrics.map((m, i) => (
-                  <DetailRow key={i} t={t} label={m.type}>
+              <DetailRow t={t} label="Max">
+                <span style={{ fontSize: FS_MD }}>{state.detail.max_replicas}</span>
+              </DetailRow>
+              <DetailRow t={t} label="Current">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.current_replicas ?? <Mute t={t}>—</Mute>}
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Desired">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.desired_replicas ?? <Mute t={t}>—</Mute>}
+                </span>
+              </DetailRow>
+              {state.detail.last_scale_time && (
+                <DetailRow t={t} label="Last Scaled">
+                  <Copyable text={state.detail.last_scale_time}>
                     <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                      {m.name ?? m.metric_name ?? "—"}
-                      {m.target?.average_utilization != null
-                        ? ` @ ${m.target.average_utilization}%`
-                        : m.target?.average_value
-                          ? ` @ avg ${m.target.average_value}`
-                          : m.target?.value
-                            ? ` @ ${m.target.value}`
-                            : ""}
+                      {ageFromIso(state.detail.last_scale_time)} ago
                     </span>
-                  </DetailRow>
-                ))}
-              </div>
-            </>
-          )}
+                  </Copyable>
+                </DetailRow>
+              )}
+            </div>
 
-          {state.detail.conditions.length > 0 && (
-            <>
-              <Section t={t} title="Conditions" />
-              <div style={{ marginBottom: 22 }}>
-                {state.detail.conditions.map((c, i) => (
-                  <DetailRow key={i} t={t} label={c.type}>
-                    <span style={{ fontSize: FS_MD }}>
-                      {c.status}
-                      {c.reason ? ` — ${c.reason}` : ""}
-                    </span>
-                  </DetailRow>
-                ))}
-              </div>
-            </>
-          )}
-        </Frame>
+            {state.detail.metrics.length > 0 && (
+              <>
+                <Section
+                  t={t}
+                  title="Metrics"
+                  right={`${state.detail.metrics.length} total`}
+                />
+                <div style={{ marginBottom: 22 }}>
+                  {state.detail.metrics.map((m, i) => (
+                    <DetailRow key={i} t={t} label={m.type}>
+                      <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
+                        {m.name ?? m.metric_name ?? "—"}
+                        {m.target?.average_utilization != null
+                          ? ` @ ${m.target.average_utilization}%`
+                          : m.target?.average_value
+                            ? ` @ avg ${m.target.average_value}`
+                            : m.target?.value
+                              ? ` @ ${m.target.value}`
+                              : ""}
+                      </span>
+                    </DetailRow>
+                  ))}
+                </div>
+              </>
+            )}
+
+            {state.detail.conditions.length > 0 && (
+              <>
+                <Section t={t} title="Conditions" />
+                <div style={{ marginBottom: 22 }}>
+                  {state.detail.conditions.map((c, i) => (
+                    <DetailRow key={i} t={t} label={c.type}>
+                      <span style={{ fontSize: FS_MD }}>
+                        {c.status}
+                        {c.reason ? ` — ${c.reason}` : ""}
+                      </span>
+                    </DetailRow>
+                  ))}
+                </div>
+              </>
+            )}
+            <GlobalSaveBar t={t} />
+          </Frame>
+        </EditSessionProvider>
       )}
     </NamespaceGuard>
   );
@@ -270,81 +282,91 @@ export function PodDisruptionBudgetSummary(props: {
       ) : state.kind === "error" ? (
         <ErrorBlock t={t} message={state.message} kindLabel="pdb" />
       ) : (
-        <Frame t={t}>
-          <MetaSection
-            t={t}
-            meta={state.detail.meta}
-            onNavigate={props.onNavigate}
-            editTarget={{
-              clusterId: props.clusterId,
-              kindId: "poddisruptionbudgets",
-              namespace: ns,
-              name: props.name,
-            }}
-            onSaved={() => setRefetch((r) => r + 1)}
-          />
-          <Section t={t} title="Spec" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Min Available">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.min_available ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Max Unavailable">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.max_unavailable ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            {state.detail.unhealthy_pod_eviction_policy && (
-              <DetailRow t={t} label="Eviction Policy">
+        <EditSessionProvider
+          target={{
+            clusterId: props.clusterId,
+            kindId: "poddisruptionbudgets",
+            namespace: ns,
+            name: props.name,
+          }}
+          onSaved={() => setRefetch((r) => r + 1)}
+        >
+          <Frame t={t}>
+            <MetaSection
+              t={t}
+              meta={state.detail.meta}
+              onNavigate={props.onNavigate}
+              editTarget={{
+                clusterId: props.clusterId,
+                kindId: "poddisruptionbudgets",
+                namespace: ns,
+                name: props.name,
+              }}
+            />
+            <Section t={t} title="Spec" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Min Available">
                 <span style={{ fontSize: FS_MD }}>
-                  {state.detail.unhealthy_pod_eviction_policy}
+                  {state.detail.min_available ?? <Mute t={t}>—</Mute>}
                 </span>
               </DetailRow>
-            )}
-            {state.detail.selector && (
-              <DetailRow t={t} label="Selector">
-                {state.detail.selector.match_labels.length > 0 ? (
-                  <KeyValueChips t={t} pairs={state.detail.selector.match_labels} />
-                ) : (
-                  <Mute t={t}>—</Mute>
-                )}
+              <DetailRow t={t} label="Max Unavailable">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.max_unavailable ?? <Mute t={t}>—</Mute>}
+                </span>
               </DetailRow>
+              {state.detail.unhealthy_pod_eviction_policy && (
+                <DetailRow t={t} label="Eviction Policy">
+                  <span style={{ fontSize: FS_MD }}>
+                    {state.detail.unhealthy_pod_eviction_policy}
+                  </span>
+                </DetailRow>
+              )}
+              {state.detail.selector && (
+                <DetailRow t={t} label="Selector">
+                  {state.detail.selector.match_labels.length > 0 ? (
+                    <KeyValueChips t={t} pairs={state.detail.selector.match_labels} />
+                  ) : (
+                    <Mute t={t}>—</Mute>
+                  )}
+                </DetailRow>
+              )}
+            </div>
+
+            <Section t={t} title="Status" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Current Healthy">
+                <span style={{ fontSize: FS_MD }}>{state.detail.current_healthy}</span>
+              </DetailRow>
+              <DetailRow t={t} label="Desired Healthy">
+                <span style={{ fontSize: FS_MD }}>{state.detail.desired_healthy}</span>
+              </DetailRow>
+              <DetailRow t={t} label="Expected Pods">
+                <span style={{ fontSize: FS_MD }}>{state.detail.expected_pods}</span>
+              </DetailRow>
+              <DetailRow t={t} label="Disruptions Allowed">
+                <span style={{ fontSize: FS_MD }}>{state.detail.disruptions_allowed}</span>
+              </DetailRow>
+            </div>
+
+            {state.detail.conditions.length > 0 && (
+              <>
+                <Section t={t} title="Conditions" />
+                <div style={{ marginBottom: 22 }}>
+                  {state.detail.conditions.map((c, i) => (
+                    <DetailRow key={i} t={t} label={c.type}>
+                      <span style={{ fontSize: FS_MD }}>
+                        {c.status}
+                        {c.reason ? ` — ${c.reason}` : ""}
+                      </span>
+                    </DetailRow>
+                  ))}
+                </div>
+              </>
             )}
-          </div>
-
-          <Section t={t} title="Status" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Current Healthy">
-              <span style={{ fontSize: FS_MD }}>{state.detail.current_healthy}</span>
-            </DetailRow>
-            <DetailRow t={t} label="Desired Healthy">
-              <span style={{ fontSize: FS_MD }}>{state.detail.desired_healthy}</span>
-            </DetailRow>
-            <DetailRow t={t} label="Expected Pods">
-              <span style={{ fontSize: FS_MD }}>{state.detail.expected_pods}</span>
-            </DetailRow>
-            <DetailRow t={t} label="Disruptions Allowed">
-              <span style={{ fontSize: FS_MD }}>{state.detail.disruptions_allowed}</span>
-            </DetailRow>
-          </div>
-
-          {state.detail.conditions.length > 0 && (
-            <>
-              <Section t={t} title="Conditions" />
-              <div style={{ marginBottom: 22 }}>
-                {state.detail.conditions.map((c, i) => (
-                  <DetailRow key={i} t={t} label={c.type}>
-                    <span style={{ fontSize: FS_MD }}>
-                      {c.status}
-                      {c.reason ? ` — ${c.reason}` : ""}
-                    </span>
-                  </DetailRow>
-                ))}
-              </div>
-            </>
-          )}
-        </Frame>
+            <GlobalSaveBar t={t} />
+          </Frame>
+        </EditSessionProvider>
       )}
     </NamespaceGuard>
   );
@@ -377,68 +399,78 @@ export function PriorityClassSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <span
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "priorityclasses",
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
           style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            color: t.text,
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
           }}
         >
-          value {d.value}
-        </span>
-        {d.global_default && (
-          <StatusPill status="Global Default" t={t} mode={props.mode} dense />
-        )}
-      </div>
-
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "priorityclasses",
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
-
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Value">
-          <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>{d.value}</span>
-        </DetailRow>
-        <DetailRow t={t} label="Global Default">
-          <span style={{ fontSize: FS_MD }}>{d.global_default ? "true" : "false"}</span>
-        </DetailRow>
-        <DetailRow t={t} label="Preemption">
-          <span style={{ fontSize: FS_MD }}>
-            {d.preemption_policy ?? <Mute t={t}>—</Mute>}
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: t.text,
+            }}
+          >
+            value {d.value}
           </span>
-        </DetailRow>
-        {d.description && (
-          <DetailRow t={t} label="Description">
-            <Copyable text={d.description}>
-              <span style={{ fontSize: FS_MD, wordBreak: "break-word" }}>
-                {d.description}
-              </span>
-            </Copyable>
+          {d.global_default && (
+            <StatusPill status="Global Default" t={t} mode={props.mode} dense />
+          )}
+        </div>
+
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "priorityclasses",
+            namespace: null,
+            name: props.name,
+          }}
+        />
+
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Value">
+            <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>{d.value}</span>
           </DetailRow>
-        )}
-      </div>
-    </Frame>
+          <DetailRow t={t} label="Global Default">
+            <span style={{ fontSize: FS_MD }}>{d.global_default ? "true" : "false"}</span>
+          </DetailRow>
+          <DetailRow t={t} label="Preemption">
+            <span style={{ fontSize: FS_MD }}>
+              {d.preemption_policy ?? <Mute t={t}>—</Mute>}
+            </span>
+          </DetailRow>
+          {d.description && (
+            <DetailRow t={t} label="Description">
+              <Copyable text={d.description}>
+                <span style={{ fontSize: FS_MD, wordBreak: "break-word" }}>
+                  {d.description}
+                </span>
+              </Copyable>
+            </DetailRow>
+          )}
+        </div>
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -469,83 +501,93 @@ export function ReplicationControllerSummary(props: {
       ) : state.kind === "error" ? (
         <ErrorBlock t={t} message={state.message} kindLabel="replication controller" />
       ) : (
-        <Frame t={t}>
-          <MetaSection
-            t={t}
-            meta={state.detail.meta}
-            onNavigate={props.onNavigate}
-            editTarget={{
-              clusterId: props.clusterId,
-              kindId: "replicationcontrollers",
-              namespace: ns,
-              name: props.name,
-            }}
-            onSaved={() => setRefetch((r) => r + 1)}
-          />
-          <Section t={t} title="Spec" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Replicas">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.replicas ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Min Ready">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.min_ready_seconds ?? 0}s
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Selector">
-              {state.detail.selector.length > 0 ? (
-                <KeyValueChips t={t} pairs={state.detail.selector} />
-              ) : (
-                <Mute t={t}>—</Mute>
-              )}
-            </DetailRow>
-          </div>
+        <EditSessionProvider
+          target={{
+            clusterId: props.clusterId,
+            kindId: "replicationcontrollers",
+            namespace: ns,
+            name: props.name,
+          }}
+          onSaved={() => setRefetch((r) => r + 1)}
+        >
+          <Frame t={t}>
+            <MetaSection
+              t={t}
+              meta={state.detail.meta}
+              onNavigate={props.onNavigate}
+              editTarget={{
+                clusterId: props.clusterId,
+                kindId: "replicationcontrollers",
+                namespace: ns,
+                name: props.name,
+              }}
+            />
+            <Section t={t} title="Spec" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Replicas">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.replicas ?? <Mute t={t}>—</Mute>}
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Min Ready">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.min_ready_seconds ?? 0}s
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Selector">
+                {state.detail.selector.length > 0 ? (
+                  <KeyValueChips t={t} pairs={state.detail.selector} />
+                ) : (
+                  <Mute t={t}>—</Mute>
+                )}
+              </DetailRow>
+            </div>
 
-          <Section t={t} title="Status" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Current">
-              <span style={{ fontSize: FS_MD }}>{state.detail.current}</span>
-            </DetailRow>
-            <DetailRow t={t} label="Ready">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.ready ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Available">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.available ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Fully Labeled">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.fully_labeled ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Observed Generation">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.observed_generation ?? <Mute t={t}>—</Mute>}
-              </span>
-            </DetailRow>
-          </div>
+            <Section t={t} title="Status" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Current">
+                <span style={{ fontSize: FS_MD }}>{state.detail.current}</span>
+              </DetailRow>
+              <DetailRow t={t} label="Ready">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.ready ?? <Mute t={t}>—</Mute>}
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Available">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.available ?? <Mute t={t}>—</Mute>}
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Fully Labeled">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.fully_labeled ?? <Mute t={t}>—</Mute>}
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Observed Generation">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.observed_generation ?? <Mute t={t}>—</Mute>}
+                </span>
+              </DetailRow>
+            </div>
 
-          {state.detail.conditions.length > 0 && (
-            <>
-              <Section t={t} title="Conditions" />
-              <div style={{ marginBottom: 22 }}>
-                {state.detail.conditions.map((c, i) => (
-                  <DetailRow key={i} t={t} label={c.type}>
-                    <span style={{ fontSize: FS_MD }}>
-                      {c.status}
-                      {c.reason ? ` — ${c.reason}` : ""}
-                    </span>
-                  </DetailRow>
-                ))}
-              </div>
-            </>
-          )}
-        </Frame>
+            {state.detail.conditions.length > 0 && (
+              <>
+                <Section t={t} title="Conditions" />
+                <div style={{ marginBottom: 22 }}>
+                  {state.detail.conditions.map((c, i) => (
+                    <DetailRow key={i} t={t} label={c.type}>
+                      <span style={{ fontSize: FS_MD }}>
+                        {c.status}
+                        {c.reason ? ` — ${c.reason}` : ""}
+                      </span>
+                    </DetailRow>
+                  ))}
+                </div>
+              </>
+            )}
+            <GlobalSaveBar t={t} />
+          </Frame>
+        </EditSessionProvider>
       )}
     </NamespaceGuard>
   );
@@ -578,67 +620,77 @@ export function LeaseSummary(props: {
       ) : state.kind === "error" ? (
         <ErrorBlock t={t} message={state.message} kindLabel="lease" />
       ) : (
-        <Frame t={t}>
-          <MetaSection
-            t={t}
-            meta={state.detail.meta}
-            onNavigate={props.onNavigate}
-            editTarget={{
-              clusterId: props.clusterId,
-              kindId: "leases",
-              namespace: ns,
-              name: props.name,
-            }}
-            onSaved={() => setRefetch((r) => r + 1)}
-          />
-          <Section t={t} title="Spec" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Holder Identity">
-              {state.detail.holder_identity ? (
-                <Copyable text={state.detail.holder_identity}>
-                  <span style={{ fontSize: FS_MD, fontFamily: FF_MONO, wordBreak: "break-all" }}>
-                    {state.detail.holder_identity}
-                  </span>
-                </Copyable>
-              ) : (
-                <Mute t={t}>—</Mute>
-              )}
-            </DetailRow>
-            <DetailRow t={t} label="Duration">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.lease_duration_seconds ?? <Mute t={t}>—</Mute>}
-                {state.detail.lease_duration_seconds != null ? "s" : ""}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Transitions">
-              <span style={{ fontSize: FS_MD }}>
-                {state.detail.lease_transitions ?? 0}
-              </span>
-            </DetailRow>
-            <DetailRow t={t} label="Acquired">
-              {state.detail.acquire_time ? (
-                <Copyable text={state.detail.acquire_time}>
-                  <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                    {ageFromIso(state.detail.acquire_time)} ago
-                  </span>
-                </Copyable>
-              ) : (
-                <Mute t={t}>—</Mute>
-              )}
-            </DetailRow>
-            <DetailRow t={t} label="Renewed">
-              {state.detail.renew_time ? (
-                <Copyable text={state.detail.renew_time}>
-                  <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                    {ageFromIso(state.detail.renew_time)} ago
-                  </span>
-                </Copyable>
-              ) : (
-                <Mute t={t}>—</Mute>
-              )}
-            </DetailRow>
-          </div>
-        </Frame>
+        <EditSessionProvider
+          target={{
+            clusterId: props.clusterId,
+            kindId: "leases",
+            namespace: ns,
+            name: props.name,
+          }}
+          onSaved={() => setRefetch((r) => r + 1)}
+        >
+          <Frame t={t}>
+            <MetaSection
+              t={t}
+              meta={state.detail.meta}
+              onNavigate={props.onNavigate}
+              editTarget={{
+                clusterId: props.clusterId,
+                kindId: "leases",
+                namespace: ns,
+                name: props.name,
+              }}
+            />
+            <Section t={t} title="Spec" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Holder Identity">
+                {state.detail.holder_identity ? (
+                  <Copyable text={state.detail.holder_identity}>
+                    <span style={{ fontSize: FS_MD, fontFamily: FF_MONO, wordBreak: "break-all" }}>
+                      {state.detail.holder_identity}
+                    </span>
+                  </Copyable>
+                ) : (
+                  <Mute t={t}>—</Mute>
+                )}
+              </DetailRow>
+              <DetailRow t={t} label="Duration">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.lease_duration_seconds ?? <Mute t={t}>—</Mute>}
+                  {state.detail.lease_duration_seconds != null ? "s" : ""}
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Transitions">
+                <span style={{ fontSize: FS_MD }}>
+                  {state.detail.lease_transitions ?? 0}
+                </span>
+              </DetailRow>
+              <DetailRow t={t} label="Acquired">
+                {state.detail.acquire_time ? (
+                  <Copyable text={state.detail.acquire_time}>
+                    <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
+                      {ageFromIso(state.detail.acquire_time)} ago
+                    </span>
+                  </Copyable>
+                ) : (
+                  <Mute t={t}>—</Mute>
+                )}
+              </DetailRow>
+              <DetailRow t={t} label="Renewed">
+                {state.detail.renew_time ? (
+                  <Copyable text={state.detail.renew_time}>
+                    <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
+                      {ageFromIso(state.detail.renew_time)} ago
+                    </span>
+                  </Copyable>
+                ) : (
+                  <Mute t={t}>—</Mute>
+                )}
+              </DetailRow>
+            </div>
+            <GlobalSaveBar t={t} />
+          </Frame>
+        </EditSessionProvider>
       )}
     </NamespaceGuard>
   );
@@ -784,26 +836,36 @@ export function MutatingWebhookConfigurationSummary(props: {
     return <ErrorBlock t={t} message={state.message} kindLabel="mutating webhook configuration" />;
 
   return (
-    <Frame t={t}>
-      <MetaSection
-        t={t}
-        meta={state.detail.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "mutatingwebhookconfigurations",
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
-      <WebhookList
-        t={t}
-        webhooks={state.detail.webhooks}
-        mode={props.mode}
-        showReinvocation
-      />
-    </Frame>
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "mutatingwebhookconfigurations",
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <MetaSection
+          t={t}
+          meta={state.detail.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "mutatingwebhookconfigurations",
+            namespace: null,
+            name: props.name,
+          }}
+        />
+        <WebhookList
+          t={t}
+          webhooks={state.detail.webhooks}
+          mode={props.mode}
+          showReinvocation
+        />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -831,25 +893,35 @@ export function ValidatingWebhookConfigurationSummary(props: {
     return <ErrorBlock t={t} message={state.message} kindLabel="validating webhook configuration" />;
 
   return (
-    <Frame t={t}>
-      <MetaSection
-        t={t}
-        meta={state.detail.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "validatingwebhookconfigurations",
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
-      <WebhookList
-        t={t}
-        webhooks={state.detail.webhooks}
-        mode={props.mode}
-        showReinvocation={false}
-      />
-    </Frame>
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "validatingwebhookconfigurations",
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <MetaSection
+          t={t}
+          meta={state.detail.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "validatingwebhookconfigurations",
+            namespace: null,
+            name: props.name,
+          }}
+        />
+        <WebhookList
+          t={t}
+          webhooks={state.detail.webhooks}
+          mode={props.mode}
+          showReinvocation={false}
+        />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }

--- a/ui/src/components/detail/gateway/index.tsx
+++ b/ui/src/components/detail/gateway/index.tsx
@@ -11,6 +11,8 @@ import { ErrorBlock, LoadingLine, Section, StatusPill } from "../../ui";
 import {
   Copyable,
   DetailRow,
+  EditSessionProvider,
+  GlobalSaveBar,
   LinkValue,
   Mute,
   type DetailNavigate,
@@ -126,48 +128,58 @@ export function GatewayClassSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: props.kindId,
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Controller">
-          {d.controller ? (
-            <Copyable text={d.controller}>
-              <span
-                style={{
-                  fontSize: FS_MD,
-                  fontFamily: FF_MONO,
-                  wordBreak: "break-all",
-                }}
-              >
-                {d.controller}
-              </span>
-            </Copyable>
-          ) : (
-            <Mute t={t}>—</Mute>
-          )}
-        </DetailRow>
-        {d.description && (
-          <DetailRow t={t} label="Description">
-            <span style={{ fontSize: FS_MD, wordBreak: "break-word" }}>
-              {d.description}
-            </span>
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: props.kindId,
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: props.kindId,
+            namespace: null,
+            name: props.name,
+          }}
+        />
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Controller">
+            {d.controller ? (
+              <Copyable text={d.controller}>
+                <span
+                  style={{
+                    fontSize: FS_MD,
+                    fontFamily: FF_MONO,
+                    wordBreak: "break-all",
+                  }}
+                >
+                  {d.controller}
+                </span>
+              </Copyable>
+            ) : (
+              <Mute t={t}>—</Mute>
+            )}
           </DetailRow>
-        )}
-      </div>
-      <ConditionsBlock t={t} conditions={d.conditions} />
-    </Frame>
+          {d.description && (
+            <DetailRow t={t} label="Description">
+              <span style={{ fontSize: FS_MD, wordBreak: "break-word" }}>
+                {d.description}
+              </span>
+            </DetailRow>
+          )}
+        </div>
+        <ConditionsBlock t={t} conditions={d.conditions} />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -209,90 +221,100 @@ export function GatewaySummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: props.kindId,
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Class">
-          {d.gateway_class_name ? (
-            <LinkValue
-              t={t}
-              onClick={() =>
-                props.onNavigate?.("GatewayClass", null, d.gateway_class_name!)
-              }
-              copyText={d.gateway_class_name}
-              enabled={!!props.onNavigate}
-            >
-              {d.gateway_class_name}
-            </LinkValue>
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: props.kindId,
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: props.kindId,
+            namespace: ns,
+            name: props.name,
+          }}
+        />
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Class">
+            {d.gateway_class_name ? (
+              <LinkValue
+                t={t}
+                onClick={() =>
+                  props.onNavigate?.("GatewayClass", null, d.gateway_class_name!)
+                }
+                copyText={d.gateway_class_name}
+                enabled={!!props.onNavigate}
+              >
+                {d.gateway_class_name}
+              </LinkValue>
+            ) : (
+              <Mute t={t}>—</Mute>
+            )}
+          </DetailRow>
+        </div>
+
+        <Section t={t} title="Listeners" right={`${d.listeners.length} total`} />
+        <div style={{ marginBottom: 22 }}>
+          {d.listeners.length === 0 ? (
+            <Mute t={t}>No listeners.</Mute>
           ) : (
-            <Mute t={t}>—</Mute>
-          )}
-        </DetailRow>
-      </div>
-
-      <Section t={t} title="Listeners" right={`${d.listeners.length} total`} />
-      <div style={{ marginBottom: 22 }}>
-        {d.listeners.length === 0 ? (
-          <Mute t={t}>No listeners.</Mute>
-        ) : (
-          d.listeners.map((l, i) => {
-            const status = d.listener_status.find((s) => s.name === l.name);
-            return (
-              <DetailRow key={i} t={t} label={l.name ?? `listener-${i}`}>
-                <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                  <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                    {l.protocol ?? "—"}:{l.port ?? "—"}
-                    {l.hostname ? ` host=${l.hostname}` : ""}
-                    {l.tls_mode ? ` tls=${l.tls_mode}` : ""}
-                  </span>
-                  {status?.attached_routes != null && (
-                    <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-                      {status.attached_routes} attached route
-                      {status.attached_routes === 1 ? "" : "s"}
-                    </span>
-                  )}
-                </div>
-              </DetailRow>
-            );
-          })
-        )}
-      </div>
-
-      {d.addresses.length > 0 && (
-        <>
-          <Section t={t} title="Addresses" />
-          <div style={{ marginBottom: 22 }}>
-            {d.addresses.map((a, i) => (
-              <DetailRow key={i} t={t} label={a.type ?? "Address"}>
-                {a.value ? (
-                  <Copyable text={a.value}>
+            d.listeners.map((l, i) => {
+              const status = d.listener_status.find((s) => s.name === l.name);
+              return (
+                <DetailRow key={i} t={t} label={l.name ?? `listener-${i}`}>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
                     <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                      {a.value}
+                      {l.protocol ?? "—"}:{l.port ?? "—"}
+                      {l.hostname ? ` host=${l.hostname}` : ""}
+                      {l.tls_mode ? ` tls=${l.tls_mode}` : ""}
                     </span>
-                  </Copyable>
-                ) : (
-                  <Mute t={t}>—</Mute>
-                )}
-              </DetailRow>
-            ))}
-          </div>
-        </>
-      )}
+                    {status?.attached_routes != null && (
+                      <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+                        {status.attached_routes} attached route
+                        {status.attached_routes === 1 ? "" : "s"}
+                      </span>
+                    )}
+                  </div>
+                </DetailRow>
+              );
+            })
+          )}
+        </div>
 
-      <ConditionsBlock t={t} conditions={d.conditions} />
-    </Frame>
+        {d.addresses.length > 0 && (
+          <>
+            <Section t={t} title="Addresses" />
+            <div style={{ marginBottom: 22 }}>
+              {d.addresses.map((a, i) => (
+                <DetailRow key={i} t={t} label={a.type ?? "Address"}>
+                  {a.value ? (
+                    <Copyable text={a.value}>
+                      <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
+                        {a.value}
+                      </span>
+                    </Copyable>
+                  ) : (
+                    <Mute t={t}>—</Mute>
+                  )}
+                </DetailRow>
+              ))}
+            </div>
+          </>
+        )}
+
+        <ConditionsBlock t={t} conditions={d.conditions} />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -343,166 +365,176 @@ export function RouteSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: props.kindId,
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: props.kindId,
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: props.kindId,
+            namespace: ns,
+            name: props.name,
+          }}
+        />
 
-      {d.hostnames.length > 0 && (
-        <>
-          <Section t={t} title="Hostnames" right={`${d.hostnames.length} total`} />
-          <div style={{ marginBottom: 22 }}>
-            {d.hostnames.map((h, i) => (
-              <DetailRow key={i} t={t} label="">
-                <Copyable text={h}>
-                  <span
-                    style={{
-                      fontSize: FS_MD,
-                      fontFamily: FF_MONO,
-                      wordBreak: "break-all",
-                    }}
-                  >
-                    {h}
-                  </span>
-                </Copyable>
-              </DetailRow>
-            ))}
-          </div>
-        </>
-      )}
-
-      <Section t={t} title="Parents" right={`${d.parent_refs.length} total`} />
-      <div style={{ marginBottom: 22 }}>
-        {d.parent_refs.length === 0 ? (
-          <Mute t={t}>No parent refs.</Mute>
-        ) : (
-          d.parent_refs.map((p, i) => (
-            <DetailRow key={i} t={t} label={p.kind ?? "Gateway"}>
-              {p.name ? (
-                <LinkValue
-                  t={t}
-                  onClick={() =>
-                    props.onNavigate?.(p.kind ?? "Gateway", p.namespace ?? ns, p.name!)
-                  }
-                  copyText={p.name}
-                  enabled={!!props.onNavigate}
-                >
-                  {p.namespace ? `${p.namespace}/${p.name}` : p.name}
-                  {p.section_name ? `:${p.section_name}` : ""}
-                  {p.port != null ? ` :${p.port}` : ""}
-                </LinkValue>
-              ) : (
-                <Mute t={t}>—</Mute>
-              )}
-            </DetailRow>
-          ))
-        )}
-      </div>
-
-      <Section t={t} title="Rules" right={`${d.rules.length} total`} />
-      <div style={{ marginBottom: 22 }}>
-        {d.rules.length === 0 ? (
-          <Mute t={t}>No rules.</Mute>
-        ) : (
-          d.rules.map((r, i) => (
-            <DetailRow key={i} t={t} label={`rule ${i + 1}`}>
-              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-                <span style={{ fontSize: FS_MD }}>
-                  {r.matches} match{r.matches === 1 ? "" : "es"} · {r.filters} filter
-                  {r.filters === 1 ? "" : "s"}
-                </span>
-                {r.backends.map((b, bi) => (
-                  <span
-                    key={bi}
-                    style={{
-                      fontSize: FS_SM,
-                      fontFamily: FF_MONO,
-                      color: t.textMuted,
-                    }}
-                  >
-                    → {b.namespace ? `${b.namespace}/` : ""}
-                    {b.name}
-                    {b.port != null ? `:${b.port}` : ""}
-                    {b.weight != null ? ` w=${b.weight}` : ""}
-                  </span>
-                ))}
-              </div>
-            </DetailRow>
-          ))
-        )}
-      </div>
-
-      {d.parent_status.length > 0 && (
-        <>
-          <Section
-            t={t}
-            title="Parent Status"
-            right={`${d.parent_status.length} total`}
-          />
-          <div style={{ marginBottom: 22 }}>
-            {d.parent_status.map((ps, i) => {
-              const accepted = ps.conditions.find((c) => c.type === "Accepted");
-              const refsResolved = ps.conditions.find(
-                (c) => c.type === "ResolvedRefs",
-              );
-              return (
-                <DetailRow
-                  key={i}
-                  t={t}
-                  label={ps.parent?.name ?? `parent-${i}`}
-                >
-                  <div
-                    style={{
-                      display: "flex",
-                      flexWrap: "wrap",
-                      gap: 6,
-                      alignItems: "center",
-                    }}
-                  >
-                    {accepted && (
-                      <StatusPill
-                        status={`Accepted=${accepted.status}`}
-                        t={t}
-                        mode={props.mode}
-                        dense
-                      />
-                    )}
-                    {refsResolved && (
-                      <StatusPill
-                        status={`ResolvedRefs=${refsResolved.status}`}
-                        t={t}
-                        mode={props.mode}
-                        dense
-                      />
-                    )}
-                    {ps.controller && (
-                      <span
-                        style={{
-                          fontSize: FS_SM,
-                          color: t.textMuted,
-                          fontFamily: FF_MONO,
-                        }}
-                      >
-                        by {ps.controller}
-                      </span>
-                    )}
-                  </div>
+        {d.hostnames.length > 0 && (
+          <>
+            <Section t={t} title="Hostnames" right={`${d.hostnames.length} total`} />
+            <div style={{ marginBottom: 22 }}>
+              {d.hostnames.map((h, i) => (
+                <DetailRow key={i} t={t} label="">
+                  <Copyable text={h}>
+                    <span
+                      style={{
+                        fontSize: FS_MD,
+                        fontFamily: FF_MONO,
+                        wordBreak: "break-all",
+                      }}
+                    >
+                      {h}
+                    </span>
+                  </Copyable>
                 </DetailRow>
-              );
-            })}
-          </div>
-        </>
-      )}
-    </Frame>
+              ))}
+            </div>
+          </>
+        )}
+
+        <Section t={t} title="Parents" right={`${d.parent_refs.length} total`} />
+        <div style={{ marginBottom: 22 }}>
+          {d.parent_refs.length === 0 ? (
+            <Mute t={t}>No parent refs.</Mute>
+          ) : (
+            d.parent_refs.map((p, i) => (
+              <DetailRow key={i} t={t} label={p.kind ?? "Gateway"}>
+                {p.name ? (
+                  <LinkValue
+                    t={t}
+                    onClick={() =>
+                      props.onNavigate?.(p.kind ?? "Gateway", p.namespace ?? ns, p.name!)
+                    }
+                    copyText={p.name}
+                    enabled={!!props.onNavigate}
+                  >
+                    {p.namespace ? `${p.namespace}/${p.name}` : p.name}
+                    {p.section_name ? `:${p.section_name}` : ""}
+                    {p.port != null ? ` :${p.port}` : ""}
+                  </LinkValue>
+                ) : (
+                  <Mute t={t}>—</Mute>
+                )}
+              </DetailRow>
+            ))
+          )}
+        </div>
+
+        <Section t={t} title="Rules" right={`${d.rules.length} total`} />
+        <div style={{ marginBottom: 22 }}>
+          {d.rules.length === 0 ? (
+            <Mute t={t}>No rules.</Mute>
+          ) : (
+            d.rules.map((r, i) => (
+              <DetailRow key={i} t={t} label={`rule ${i + 1}`}>
+                <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                  <span style={{ fontSize: FS_MD }}>
+                    {r.matches} match{r.matches === 1 ? "" : "es"} · {r.filters} filter
+                    {r.filters === 1 ? "" : "s"}
+                  </span>
+                  {r.backends.map((b, bi) => (
+                    <span
+                      key={bi}
+                      style={{
+                        fontSize: FS_SM,
+                        fontFamily: FF_MONO,
+                        color: t.textMuted,
+                      }}
+                    >
+                      → {b.namespace ? `${b.namespace}/` : ""}
+                      {b.name}
+                      {b.port != null ? `:${b.port}` : ""}
+                      {b.weight != null ? ` w=${b.weight}` : ""}
+                    </span>
+                  ))}
+                </div>
+              </DetailRow>
+            ))
+          )}
+        </div>
+
+        {d.parent_status.length > 0 && (
+          <>
+            <Section
+              t={t}
+              title="Parent Status"
+              right={`${d.parent_status.length} total`}
+            />
+            <div style={{ marginBottom: 22 }}>
+              {d.parent_status.map((ps, i) => {
+                const accepted = ps.conditions.find((c) => c.type === "Accepted");
+                const refsResolved = ps.conditions.find(
+                  (c) => c.type === "ResolvedRefs",
+                );
+                return (
+                  <DetailRow
+                    key={i}
+                    t={t}
+                    label={ps.parent?.name ?? `parent-${i}`}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        flexWrap: "wrap",
+                        gap: 6,
+                        alignItems: "center",
+                      }}
+                    >
+                      {accepted && (
+                        <StatusPill
+                          status={`Accepted=${accepted.status}`}
+                          t={t}
+                          mode={props.mode}
+                          dense
+                        />
+                      )}
+                      {refsResolved && (
+                        <StatusPill
+                          status={`ResolvedRefs=${refsResolved.status}`}
+                          t={t}
+                          mode={props.mode}
+                          dense
+                        />
+                      )}
+                      {ps.controller && (
+                        <span
+                          style={{
+                            fontSize: FS_SM,
+                            color: t.textMuted,
+                            fontFamily: FF_MONO,
+                          }}
+                        >
+                          by {ps.controller}
+                        </span>
+                      )}
+                    </div>
+                  </DetailRow>
+                );
+              })}
+            </div>
+          </>
+        )}
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -544,51 +576,61 @@ export function ReferenceGrantSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: props.kindId,
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: props.kindId,
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: props.kindId,
+            namespace: ns,
+            name: props.name,
+          }}
+        />
 
-      <Section t={t} title="From" right={`${d.from.length} total`} />
-      <div style={{ marginBottom: 22 }}>
-        {d.from.length === 0 ? (
-          <Mute t={t}>—</Mute>
-        ) : (
-          d.from.map((f, i) => (
-            <DetailRow key={i} t={t} label={f.kind ?? "—"}>
-              <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                {f.namespace ?? "—"}
-                {f.group ? ` (${f.group})` : ""}
-              </span>
-            </DetailRow>
-          ))
-        )}
-      </div>
+        <Section t={t} title="From" right={`${d.from.length} total`} />
+        <div style={{ marginBottom: 22 }}>
+          {d.from.length === 0 ? (
+            <Mute t={t}>—</Mute>
+          ) : (
+            d.from.map((f, i) => (
+              <DetailRow key={i} t={t} label={f.kind ?? "—"}>
+                <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
+                  {f.namespace ?? "—"}
+                  {f.group ? ` (${f.group})` : ""}
+                </span>
+              </DetailRow>
+            ))
+          )}
+        </div>
 
-      <Section t={t} title="To" right={`${d.to.length} total`} />
-      <div style={{ marginBottom: 22 }}>
-        {d.to.length === 0 ? (
-          <Mute t={t}>—</Mute>
-        ) : (
-          d.to.map((to, i) => (
-            <DetailRow key={i} t={t} label={to.kind ?? "—"}>
-              <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
-                {to.name ?? "*"}
-                {to.group ? ` (${to.group})` : ""}
-              </span>
-            </DetailRow>
-          ))
-        )}
-      </div>
-    </Frame>
+        <Section t={t} title="To" right={`${d.to.length} total`} />
+        <div style={{ marginBottom: 22 }}>
+          {d.to.length === 0 ? (
+            <Mute t={t}>—</Mute>
+          ) : (
+            d.to.map((to, i) => (
+              <DetailRow key={i} t={t} label={to.kind ?? "—"}>
+                <span style={{ fontSize: FS_MD, fontFamily: FF_MONO }}>
+                  {to.name ?? "*"}
+                  {to.group ? ` (${to.group})` : ""}
+                </span>
+              </DetailRow>
+            ))
+          )}
+        </div>
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }

--- a/ui/src/components/detail/network/index.tsx
+++ b/ui/src/components/detail/network/index.tsx
@@ -19,6 +19,9 @@ import {
   Mute,
   ageFromIso,
   type DetailNavigate,
+  EditSessionProvider,
+  useEditField,
+  GlobalSaveBar,
 } from "..";
 import type {
   EndpointAddress,
@@ -45,14 +48,12 @@ import type {
 import { ForwardChip } from "../forwardChip";
 import { MetaSection } from "../workload/shared";
 import {
-  ConflictBanner,
   EditModeChrome,
   EditableTextValue,
   ListEditor,
   listBufferDirty,
   listBufferFrom,
   listBufferToArray,
-  useApply,
   type ApplyTarget,
   type ListBuffer,
 } from "../edit";
@@ -255,200 +256,210 @@ export function ServiceSummary(props: {
   const isExternalName = d.type === "ExternalName";
 
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <StatusPill status={d.type} t={t} mode={props.mode} />
-        {isHeadless && (
-          <StatusPill status="Headless" t={t} mode={props.mode} dense />
-        )}
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            {ageFromIso(d.meta.created_at)} old
-          </span>
-        )}
-        {d.ports.length > 0 && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {d.ports.length} port{d.ports.length === 1 ? "" : "s"}
-          </span>
-        )}
-      </div>
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "services",
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
+          }}
+        >
+          <StatusPill status={d.type} t={t} mode={props.mode} />
+          {isHeadless && (
+            <StatusPill status="Headless" t={t} mode={props.mode} dense />
+          )}
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+          {d.ports.length > 0 && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {d.ports.length} port{d.ports.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
 
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "services",
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "services",
+            namespace: ns,
+            name: props.name,
+          }}
+          onSaved={() => setRefetch((r) => r + 1)}
+        />
 
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Type">
-          <span style={{ fontSize: FS_MD }}>{d.type}</span>
-        </DetailRow>
-        {isExternalName ? (
-          d.external_name && (
-            <DetailRow t={t} label="External Name">
-              <Copyable text={d.external_name}>
-                <span
-                  style={{
-                    fontFamily: FF_MONO,
-                    fontSize: FS_MD,
-                    wordBreak: "break-all",
-                  }}
-                >
-                  {d.external_name}
-                </span>
-              </Copyable>
-            </DetailRow>
-          )
-        ) : (
-          <>
-            {d.cluster_ip && (
-              <DetailRow t={t} label="Cluster IP">
-                <Copyable text={d.cluster_ip}>
-                  <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
-                    {d.cluster_ip}
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Type">
+            <span style={{ fontSize: FS_MD }}>{d.type}</span>
+          </DetailRow>
+          {isExternalName ? (
+            d.external_name && (
+              <DetailRow t={t} label="External Name">
+                <Copyable text={d.external_name}>
+                  <span
+                    style={{
+                      fontFamily: FF_MONO,
+                      fontSize: FS_MD,
+                      wordBreak: "break-all",
+                    }}
+                  >
+                    {d.external_name}
                   </span>
                 </Copyable>
               </DetailRow>
-            )}
-            {d.cluster_ips.length > 1 && (
-              <DetailRow t={t} label="Cluster IPs">
-                <ChipWrap>
-                  {d.cluster_ips.map((ip) => (
-                    <Copyable key={ip} text={ip}>
-                      <Chip t={t} mono>
-                        {ip}
-                      </Chip>
-                    </Copyable>
-                  ))}
-                </ChipWrap>
-              </DetailRow>
-            )}
-            {d.external_ips.length > 0 && (
-              <DetailRow t={t} label="External IPs">
-                <ChipWrap>
-                  {d.external_ips.map((ip) => (
-                    <Copyable key={ip} text={ip}>
-                      <Chip t={t} mono>
-                        {ip}
-                      </Chip>
-                    </Copyable>
-                  ))}
-                </ChipWrap>
-              </DetailRow>
-            )}
-          </>
-        )}
-        {d.session_affinity && d.session_affinity !== "None" && (
-          <DetailRow t={t} label="Session Affinity">
-            <span style={{ fontSize: FS_MD }}>{d.session_affinity}</span>
-          </DetailRow>
-        )}
-        {d.internal_traffic_policy && (
-          <DetailRow t={t} label="Internal Traffic Policy">
-            <span style={{ fontSize: FS_MD }}>{d.internal_traffic_policy}</span>
-          </DetailRow>
-        )}
-        {d.external_traffic_policy && (
-          <DetailRow t={t} label="External Traffic Policy">
-            <span style={{ fontSize: FS_MD }}>{d.external_traffic_policy}</span>
-          </DetailRow>
-        )}
-        {d.ip_families.length > 0 && (
-          <DetailRow t={t} label="IP Families">
-            <ChipWrap>
-              {d.ip_families.map((f) => (
-                <Chip key={f} t={t} mono>
-                  {f}
-                </Chip>
-              ))}
-            </ChipWrap>
-            {d.ip_family_policy && (
-              <span style={{ fontSize: FS_SM, color: t.textDim, marginLeft: 8 }}>
-                {d.ip_family_policy}
-              </span>
-            )}
-          </DetailRow>
-        )}
-        {d.load_balancer_class && (
-          <DetailRow t={t} label="LB Class">
-            <Copyable text={d.load_balancer_class}>
-              <span style={{ fontFamily: FF_MONO, fontSize: FS_SM }}>
-                {d.load_balancer_class}
-              </span>
-            </Copyable>
-          </DetailRow>
-        )}
-        {d.load_balancer_source_ranges.length > 0 && (
-          <DetailRow t={t} label="LB Source Ranges">
-            <ChipWrap>
-              {d.load_balancer_source_ranges.map((c) => (
-                <Copyable key={c} text={c}>
-                  <Chip t={t} mono>
-                    {c}
-                  </Chip>
-                </Copyable>
-              ))}
-            </ChipWrap>
-          </DetailRow>
-        )}
-        {d.health_check_node_port != null && (
-          <DetailRow t={t} label="Health Check NodePort">
-            <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
-              {d.health_check_node_port}
-            </span>
-          </DetailRow>
-        )}
-        {d.publish_not_ready_addresses && (
-          <DetailRow t={t} label="Publish Not Ready">
-            <span style={{ fontSize: FS_MD }}>true</span>
-          </DetailRow>
-        )}
-        {d.allocate_load_balancer_node_ports === false && (
-          <DetailRow t={t} label="Allocate NodePorts">
-            <span style={{ fontSize: FS_MD }}>false</span>
-          </DetailRow>
-        )}
-        <DetailRow t={t} label="Selector">
-          {d.selector.length > 0 ? (
-            <KeyValueChips t={t} pairs={d.selector} />
-          ) : isExternalName ? (
-            <Mute t={t}>(external name — no selector)</Mute>
+            )
           ) : (
-            <Mute t={t}>(no selector — endpoints managed externally)</Mute>
+            <>
+              {d.cluster_ip && (
+                <DetailRow t={t} label="Cluster IP">
+                  <Copyable text={d.cluster_ip}>
+                    <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
+                      {d.cluster_ip}
+                    </span>
+                  </Copyable>
+                </DetailRow>
+              )}
+              {d.cluster_ips.length > 1 && (
+                <DetailRow t={t} label="Cluster IPs">
+                  <ChipWrap>
+                    {d.cluster_ips.map((ip) => (
+                      <Copyable key={ip} text={ip}>
+                        <Chip t={t} mono>
+                          {ip}
+                        </Chip>
+                      </Copyable>
+                    ))}
+                  </ChipWrap>
+                </DetailRow>
+              )}
+              {d.external_ips.length > 0 && (
+                <DetailRow t={t} label="External IPs">
+                  <ChipWrap>
+                    {d.external_ips.map((ip) => (
+                      <Copyable key={ip} text={ip}>
+                        <Chip t={t} mono>
+                          {ip}
+                        </Chip>
+                      </Copyable>
+                    ))}
+                  </ChipWrap>
+                </DetailRow>
+              )}
+            </>
           )}
-        </DetailRow>
-      </div>
+          {d.session_affinity && d.session_affinity !== "None" && (
+            <DetailRow t={t} label="Session Affinity">
+              <span style={{ fontSize: FS_MD }}>{d.session_affinity}</span>
+            </DetailRow>
+          )}
+          {d.internal_traffic_policy && (
+            <DetailRow t={t} label="Internal Traffic Policy">
+              <span style={{ fontSize: FS_MD }}>{d.internal_traffic_policy}</span>
+            </DetailRow>
+          )}
+          {d.external_traffic_policy && (
+            <DetailRow t={t} label="External Traffic Policy">
+              <span style={{ fontSize: FS_MD }}>{d.external_traffic_policy}</span>
+            </DetailRow>
+          )}
+          {d.ip_families.length > 0 && (
+            <DetailRow t={t} label="IP Families">
+              <ChipWrap>
+                {d.ip_families.map((f) => (
+                  <Chip key={f} t={t} mono>
+                    {f}
+                  </Chip>
+                ))}
+              </ChipWrap>
+              {d.ip_family_policy && (
+                <span style={{ fontSize: FS_SM, color: t.textDim, marginLeft: 8 }}>
+                  {d.ip_family_policy}
+                </span>
+              )}
+            </DetailRow>
+          )}
+          {d.load_balancer_class && (
+            <DetailRow t={t} label="LB Class">
+              <Copyable text={d.load_balancer_class}>
+                <span style={{ fontFamily: FF_MONO, fontSize: FS_SM }}>
+                  {d.load_balancer_class}
+                </span>
+              </Copyable>
+            </DetailRow>
+          )}
+          {d.load_balancer_source_ranges.length > 0 && (
+            <DetailRow t={t} label="LB Source Ranges">
+              <ChipWrap>
+                {d.load_balancer_source_ranges.map((c) => (
+                  <Copyable key={c} text={c}>
+                    <Chip t={t} mono>
+                      {c}
+                    </Chip>
+                  </Copyable>
+                ))}
+              </ChipWrap>
+            </DetailRow>
+          )}
+          {d.health_check_node_port != null && (
+            <DetailRow t={t} label="Health Check NodePort">
+              <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
+                {d.health_check_node_port}
+              </span>
+            </DetailRow>
+          )}
+          {d.publish_not_ready_addresses && (
+            <DetailRow t={t} label="Publish Not Ready">
+              <span style={{ fontSize: FS_MD }}>true</span>
+            </DetailRow>
+          )}
+          {d.allocate_load_balancer_node_ports === false && (
+            <DetailRow t={t} label="Allocate NodePorts">
+              <span style={{ fontSize: FS_MD }}>false</span>
+            </DetailRow>
+          )}
+          <DetailRow t={t} label="Selector">
+            {d.selector.length > 0 ? (
+              <KeyValueChips t={t} pairs={d.selector} />
+            ) : isExternalName ? (
+              <Mute t={t}>(external name — no selector)</Mute>
+            ) : (
+              <Mute t={t}>(no selector — endpoints managed externally)</Mute>
+            )}
+          </DetailRow>
+        </div>
 
-      <ServicePortsEditor
-        t={t}
-        ports={d.ports}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "services",
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((r) => r + 1)}
-      />
+        <ServicePortsEditor
+          t={t}
+          ports={d.ports}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "services",
+            namespace: ns,
+            name: props.name,
+          }}
+        />
 
-      <LoadBalancerSection t={t} ingress={d.load_balancer_ingress} />
-    </Frame>
+        <LoadBalancerSection t={t} ingress={d.load_balancer_ingress} />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -519,15 +530,13 @@ function ServicePortsEditor({
   t,
   ports,
   editTarget,
-  onSaved,
 }: {
   t: Tokens;
   ports: ServicePort[];
   editTarget: ApplyTarget;
-  onSaved: () => void;
 }) {
-  const edit = useApply<ListBuffer<ServicePortRowFields>>({
-    target: editTarget,
+  const edit = useEditField<ListBuffer<ServicePortRowFields>>({
+    id: "serviceports",
     initial: () => servicePortsBufferFrom(ports),
     serialize: (b) => ({
       spec: {
@@ -535,7 +544,23 @@ function ServicePortsEditor({
       },
     }),
     dirtyCount: servicePortsDirtyCount,
-    onSaved,
+    validate: (b) => {
+      const counts = new Map<string, number>();
+      for (const r of b.rows) {
+        if (r.deleted) continue;
+        if (r.name === "") continue;
+        counts.set(r.name, (counts.get(r.name) ?? 0) + 1);
+        if (r.port !== "" && Number.isNaN(Number.parseInt(r.port, 10))) {
+          return `invalid port number in: ${r.name || "unnamed port"}`;
+        }
+      }
+      for (const [k, n] of counts) {
+        if (n > 1) {
+          return `duplicate port names are not allowed: ${k}`;
+        }
+      }
+      return null;
+    },
   });
 
   const dupNames = useMemo(() => {
@@ -564,7 +589,6 @@ function ServicePortsEditor({
             saving={edit.saving}
             onEnter={edit.enter}
             onCancel={edit.cancel}
-            onSave={edit.save}
             rightExtra={
               <span
                 style={{
@@ -580,34 +604,6 @@ function ServicePortsEditor({
         }
       />
       <div style={{ marginBottom: 22 }}>
-        {edit.conflict && (
-          <ConflictBanner
-            t={t}
-            conflict={edit.conflict}
-            saving={edit.saving}
-            onForce={edit.forceSave}
-            onDismiss={edit.dismissConflict}
-          />
-        )}
-        {edit.error && (
-          <div
-            style={{
-              margin: "0 0 8px",
-              padding: "6px 8px",
-              background: "rgba(244,63,94,0.10)",
-              border: "1px solid rgba(244,63,94,0.4)",
-              borderRadius: R_SM,
-            }}
-          >
-            <ErrorBlock
-              t={t}
-              message={edit.error}
-              kindLabel="service"
-              verb="save"
-              inline
-            />
-          </div>
-        )}
         {edit.editing && dupNames.size > 0 && (
           <div
             style={{

--- a/ui/src/components/detail/rbac/index.tsx
+++ b/ui/src/components/detail/rbac/index.tsx
@@ -18,6 +18,8 @@ import {
   ChipWrap,
   Copyable,
   DetailRow,
+  EditSessionProvider,
+  GlobalSaveBar,
   KeyValueChips,
   LinkValue,
   Mute,
@@ -387,129 +389,139 @@ export function ServiceAccountSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <span
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "serviceaccounts",
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
           style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            color: t.text,
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
           }}
         >
-          {d.secrets.length} secret{d.secrets.length === 1 ? "" : "s"}
-        </span>
-        {d.image_pull_secrets.length > 0 && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {d.image_pull_secrets.length} pull secret
-            {d.image_pull_secrets.length === 1 ? "" : "s"}
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: t.text,
+            }}
+          >
+            {d.secrets.length} secret{d.secrets.length === 1 ? "" : "s"}
           </span>
-        )}
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {ageFromIso(d.meta.created_at)} old
-          </span>
-        )}
-      </div>
+          {d.image_pull_secrets.length > 0 && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {d.image_pull_secrets.length} pull secret
+              {d.image_pull_secrets.length === 1 ? "" : "s"}
+            </span>
+          )}
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
 
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "serviceaccounts",
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "serviceaccounts",
+            namespace: ns,
+            name: props.name,
+          }}
+        />
 
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Automount Token">
-          <span style={{ fontSize: FS_MD }}>
-            {d.automount_service_account_token === true
-              ? "true"
-              : d.automount_service_account_token === false
-                ? "false"
-                : "(default — true)"}
-          </span>
-        </DetailRow>
-      </div>
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Automount Token">
+            <span style={{ fontSize: FS_MD }}>
+              {d.automount_service_account_token === true
+                ? "true"
+                : d.automount_service_account_token === false
+                  ? "false"
+                  : "(default — true)"}
+            </span>
+          </DetailRow>
+        </div>
 
-      {d.secrets.length > 0 && (
-        <>
-          <Section
-            t={t}
-            title="Secrets"
-            right={
-              <span
-                style={{
-                  fontSize: FS_XS,
-                  color: t.textMuted,
-                  fontFamily: FF_MONO,
-                }}
-              >
-                {d.secrets.length} total
-              </span>
-            }
-          />
-          <div style={{ marginBottom: 22 }}>
-            {d.secrets.map((s) => (
-              <DetailRow key={s.name} t={t} label={s.kind}>
-                <LinkValue
-                  t={t}
-                  onClick={() =>
-                    props.onNavigate?.(s.kind, s.namespace ?? ns, s.name)
-                  }
-                  copyText={s.name}
-                  enabled={!!props.onNavigate}
+        {d.secrets.length > 0 && (
+          <>
+            <Section
+              t={t}
+              title="Secrets"
+              right={
+                <span
+                  style={{
+                    fontSize: FS_XS,
+                    color: t.textMuted,
+                    fontFamily: FF_MONO,
+                  }}
                 >
-                  {s.name}
-                </LinkValue>
-                {s.namespace && s.namespace !== ns && (
-                  <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-                    ns {s.namespace}
-                  </span>
-                )}
-              </DetailRow>
-            ))}
-          </div>
-        </>
-      )}
-
-      {d.image_pull_secrets.length > 0 && (
-        <>
-          <Section t={t} title="Image Pull Secrets" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Pull Secrets">
-              <ChipWrap>
-                {d.image_pull_secrets.map((name) => (
+                  {d.secrets.length} total
+                </span>
+              }
+            />
+            <div style={{ marginBottom: 22 }}>
+              {d.secrets.map((s) => (
+                <DetailRow key={s.name} t={t} label={s.kind}>
                   <LinkValue
-                    key={name}
                     t={t}
-                    onClick={() => props.onNavigate?.("Secret", ns, name)}
-                    copyText={name}
+                    onClick={() =>
+                      props.onNavigate?.(s.kind, s.namespace ?? ns, s.name)
+                    }
+                    copyText={s.name}
                     enabled={!!props.onNavigate}
                   >
-                    {name}
+                    {s.name}
                   </LinkValue>
-                ))}
-              </ChipWrap>
-            </DetailRow>
-          </div>
-        </>
-      )}
-    </Frame>
+                  {s.namespace && s.namespace !== ns && (
+                    <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+                      ns {s.namespace}
+                    </span>
+                  )}
+                </DetailRow>
+              ))}
+            </div>
+          </>
+        )}
+
+        {d.image_pull_secrets.length > 0 && (
+          <>
+            <Section t={t} title="Image Pull Secrets" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Pull Secrets">
+                <ChipWrap>
+                  {d.image_pull_secrets.map((name) => (
+                    <LinkValue
+                      key={name}
+                      t={t}
+                      onClick={() => props.onNavigate?.("Secret", ns, name)}
+                      copyText={name}
+                      enabled={!!props.onNavigate}
+                    >
+                      {name}
+                    </LinkValue>
+                  ))}
+                </ChipWrap>
+              </DetailRow>
+            </div>
+          </>
+        )}
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -543,48 +555,58 @@ export function RoleSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <span
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "roles",
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
           style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            color: t.text,
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
           }}
         >
-          {d.rules.length} rule{d.rules.length === 1 ? "" : "s"}
-        </span>
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {ageFromIso(d.meta.created_at)} old
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: t.text,
+            }}
+          >
+            {d.rules.length} rule{d.rules.length === 1 ? "" : "s"}
           </span>
-        )}
-      </div>
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
 
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "roles",
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "roles",
+            namespace: ns,
+            name: props.name,
+          }}
+        />
 
-      <RulesSection t={t} rules={d.rules} />
-    </Frame>
+        <RulesSection t={t} rules={d.rules} />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -614,84 +636,94 @@ export function ClusterRoleSummary(props: {
   const d = state.detail;
   const aggregated = !!d.aggregation_rule;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <span
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "clusterroles",
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
           style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            color: t.text,
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
           }}
         >
-          {d.rules.length} rule{d.rules.length === 1 ? "" : "s"}
-        </span>
-        {aggregated && (
           <span
             style={{
-              fontSize: FS_SM,
-              fontWeight: 600,
-              padding: "1px 7px",
-              borderRadius: R_SM,
-              background: t.chip,
-              color: t.textDim,
               fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: t.text,
             }}
           >
-            aggregated
+            {d.rules.length} rule{d.rules.length === 1 ? "" : "s"}
           </span>
-        )}
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {ageFromIso(d.meta.created_at)} old
-          </span>
-        )}
-      </div>
+          {aggregated && (
+            <span
+              style={{
+                fontSize: FS_SM,
+                fontWeight: 600,
+                padding: "1px 7px",
+                borderRadius: R_SM,
+                background: t.chip,
+                color: t.textDim,
+                fontFamily: FF_MONO,
+              }}
+            >
+              aggregated
+            </span>
+          )}
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
 
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "clusterroles",
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "clusterroles",
+            namespace: null,
+            name: props.name,
+          }}
+        />
 
-      {aggregated && d.aggregation_rule && (
-        <>
-          <Section t={t} title="Aggregation Rule" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Selectors">
-              <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
-                {d.aggregation_rule.selector_count}
-              </span>
-            </DetailRow>
-            {d.aggregation_rule.match_labels.length > 0 && (
-              <DetailRow t={t} label="Match Labels">
-                <KeyValueChips
-                  t={t}
-                  pairs={d.aggregation_rule.match_labels}
-                />
+        {aggregated && d.aggregation_rule && (
+          <>
+            <Section t={t} title="Aggregation Rule" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Selectors">
+                <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
+                  {d.aggregation_rule.selector_count}
+                </span>
               </DetailRow>
-            )}
-          </div>
-        </>
-      )}
+              {d.aggregation_rule.match_labels.length > 0 && (
+                <DetailRow t={t} label="Match Labels">
+                  <KeyValueChips
+                    t={t}
+                    pairs={d.aggregation_rule.match_labels}
+                  />
+                </DetailRow>
+              )}
+            </div>
+          </>
+        )}
 
-      <RulesSection t={t} rules={d.rules} />
-    </Frame>
+        <RulesSection t={t} rules={d.rules} />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -726,66 +758,76 @@ export function RoleBindingSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <span
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "rolebindings",
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
           style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            color: t.text,
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
           }}
         >
-          {d.role_ref.kind} / {d.role_ref.name}
-        </span>
-        <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-          → {d.subjects.length} subject{d.subjects.length === 1 ? "" : "s"}
-        </span>
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {ageFromIso(d.meta.created_at)} old
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: t.text,
+            }}
+          >
+            {d.role_ref.kind} / {d.role_ref.name}
           </span>
-        )}
-      </div>
+          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+            → {d.subjects.length} subject{d.subjects.length === 1 ? "" : "s"}
+          </span>
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
 
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "rolebindings",
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
-
-      <Section t={t} title="Role Reference" />
-      <div style={{ marginBottom: 22 }}>
-        <RoleRefRow
+        <MetaSection
           t={t}
-          roleRef={d.role_ref}
-          namespace={ns}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "rolebindings",
+            namespace: ns,
+            name: props.name,
+          }}
+        />
+
+        <Section t={t} title="Role Reference" />
+        <div style={{ marginBottom: 22 }}>
+          <RoleRefRow
+            t={t}
+            roleRef={d.role_ref}
+            namespace={ns}
+            onNavigate={props.onNavigate}
+          />
+        </div>
+
+        <SubjectsSection
+          t={t}
+          subjects={d.subjects}
+          bindingNamespace={ns}
           onNavigate={props.onNavigate}
         />
-      </div>
-
-      <SubjectsSection
-        t={t}
-        subjects={d.subjects}
-        bindingNamespace={ns}
-        onNavigate={props.onNavigate}
-      />
-    </Frame>
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -814,65 +856,75 @@ export function ClusterRoleBindingSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <span
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "clusterrolebindings",
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
           style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            color: t.text,
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
           }}
         >
-          {d.role_ref.kind} / {d.role_ref.name}
-        </span>
-        <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-          → {d.subjects.length} subject{d.subjects.length === 1 ? "" : "s"}
-        </span>
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {ageFromIso(d.meta.created_at)} old
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: t.text,
+            }}
+          >
+            {d.role_ref.kind} / {d.role_ref.name}
           </span>
-        )}
-      </div>
+          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+            → {d.subjects.length} subject{d.subjects.length === 1 ? "" : "s"}
+          </span>
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
 
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "clusterrolebindings",
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
-
-      <Section t={t} title="Role Reference" />
-      <div style={{ marginBottom: 22 }}>
-        <RoleRefRow
+        <MetaSection
           t={t}
-          roleRef={d.role_ref}
-          namespace={null}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "clusterrolebindings",
+            namespace: null,
+            name: props.name,
+          }}
+        />
+
+        <Section t={t} title="Role Reference" />
+        <div style={{ marginBottom: 22 }}>
+          <RoleRefRow
+            t={t}
+            roleRef={d.role_ref}
+            namespace={null}
+            onNavigate={props.onNavigate}
+          />
+        </div>
+
+        <SubjectsSection
+          t={t}
+          subjects={d.subjects}
+          bindingNamespace={null}
           onNavigate={props.onNavigate}
         />
-      </div>
-
-      <SubjectsSection
-        t={t}
-        subjects={d.subjects}
-        bindingNamespace={null}
-        onNavigate={props.onNavigate}
-      />
-    </Frame>
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }

--- a/ui/src/components/detail/storage/index.tsx
+++ b/ui/src/components/detail/storage/index.tsx
@@ -7,17 +7,19 @@
 import { useEffect, useRef, useState } from "react";
 import { useResolvedTheme } from "../../../store";
 import { api } from "../../../api";
-import { FF_MONO, type ThemeMode, type Tokens, FS_MD, FS_SM, FS_XS } from "../../../theme";
-import {  } from "../../../theme";
+import { FF_MONO, type ThemeMode, type Tokens, FS_MD, FS_SM, FS_XS, R_SM } from "../../../theme";
 import { Chip, ErrorBlock, LoadingLine, Section, StatusPill } from "../../ui";
 import {
   ChipWrap,
   Copyable,
   DetailRow,
+  EditSessionProvider,
+  GlobalSaveBar,
   KeyValueChips,
   LinkValue,
   Mute,
   ageFromIso,
+  useEditField,
   type DetailNavigate,
 } from "..";
 import { ConditionsSection, MetaSection } from "../workload/shared";
@@ -114,6 +116,134 @@ function StringChips({ t, items }: { t: Tokens; items: string[] }) {
   );
 }
 
+function PvcRequestedStorageEditor({
+  t,
+  requestedStorage,
+}: {
+  t: Tokens;
+  pvcName: string;
+  namespace: string;
+  clusterId: string;
+  requestedStorage: string | null;
+}) {
+  const [hovered, setHovered] = useState(false);
+
+  const validateQuantity = (val: string) => {
+    const v = val.trim();
+    if (v === "") return "storage quantity cannot be empty";
+    const valid = /^\d+(\.\d+)?(?:[KMGTPeE]i?|m)?$/.test(v);
+    if (!valid) {
+      return "invalid storage quantity format (e.g. 10Gi, 500Mi)";
+    }
+    return null;
+  };
+
+  const edit = useEditField<{ value: string }>({
+    id: "pvc:requested_storage",
+    initial: () => ({ value: requestedStorage ?? "" }),
+    serialize: (b) => {
+      return {
+        spec: {
+          resources: {
+            requests: {
+              storage: b.value.trim(),
+            },
+          },
+        },
+      };
+    },
+    dirtyCount: (b) => (b.value.trim() !== (requestedStorage ?? "") ? 1 : 0),
+    validate: (b) => validateQuantity(b.value),
+  });
+
+  const isDirty = edit.dirty > 0;
+  const invalid = edit.editing && validateQuantity(edit.buffer.value) !== null;
+
+  const handleStartEdit = () => {
+    edit.enter();
+  };
+
+  const handleCancel = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    edit.cancel();
+  };
+
+  if (edit.editing) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <input
+          value={edit.buffer.value}
+          onChange={(e) => edit.setBuffer({ value: e.target.value })}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              e.currentTarget.blur();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              edit.cancel();
+            }
+          }}
+          autoFocus
+          style={{
+            background: t.bg,
+            border: `1px solid ${invalid ? t.bad : isDirty ? t.warn : t.border}`,
+            borderRadius: R_SM,
+            color: t.text,
+            padding: "2px 6px",
+            fontSize: FS_MD,
+            fontFamily: FF_MONO,
+            outline: "none",
+            width: "120px",
+          }}
+        />
+        <button
+          onClick={handleCancel}
+          style={{
+            background: "none",
+            border: "none",
+            color: t.textMuted,
+            cursor: "pointer",
+            fontSize: FS_SM,
+            padding: "2px 4px",
+            display: "flex",
+            alignItems: "center",
+          }}
+          title="Revert"
+        >
+          ↺
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={handleStartEdit}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        cursor: "pointer",
+        gap: 6,
+        padding: "2px 6px",
+        borderRadius: R_SM,
+        background: hovered ? t.surfaceAlt : "transparent",
+        transition: "background 0.2s ease",
+      }}
+    >
+      <span style={{ fontFamily: FF_MONO, fontSize: FS_MD, color: isDirty ? t.warn : t.text }}>
+        {isDirty ? edit.buffer.value : (requestedStorage ?? "—")}
+      </span>
+      {(hovered || isDirty) && (
+        <span style={{ fontSize: 10, color: isDirty ? t.warn : t.accent }}>
+          {isDirty ? "●" : "✎"}
+        </span>
+      )}
+    </div>
+  );
+}
+
 // ── PersistentVolumeClaim ──────────────────────────────────────────────────
 
 export function PersistentVolumeClaimSummary(props: {
@@ -147,186 +277,202 @@ export function PersistentVolumeClaimSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <StatusPill status={d.phase} t={t} mode={props.mode} />
-        {d.capacity && (
-          <span
-            style={{
-              fontFamily: FF_MONO,
-              fontSize: FS_MD,
-              fontWeight: 600,
-              color: t.text,
-            }}
-          >
-            {d.capacity}
-          </span>
-        )}
-        {d.requested_storage && d.requested_storage !== d.capacity && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            requested {d.requested_storage}
-          </span>
-        )}
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {ageFromIso(d.meta.created_at)} old
-          </span>
-        )}
-      </div>
-
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "persistentvolumeclaims",
-          namespace: ns,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
-
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Storage Class">
-          {d.storage_class ? (
-            <LinkValue
-              t={t}
-              onClick={() =>
-                props.onNavigate?.("StorageClass", null, d.storage_class!)
-              }
-              copyText={d.storage_class}
-              enabled={!!props.onNavigate}
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "persistentvolumeclaims",
+        namespace: ns,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
+          }}
+        >
+          <StatusPill status={d.phase} t={t} mode={props.mode} />
+          {d.capacity && (
+            <span
+              style={{
+                fontFamily: FF_MONO,
+                fontSize: FS_MD,
+                fontWeight: 600,
+                color: t.text,
+              }}
             >
-              {d.storage_class}
-            </LinkValue>
-          ) : (
-            <Mute t={t}>(default)</Mute>
+              {d.capacity}
+            </span>
           )}
-        </DetailRow>
-        <DetailRow t={t} label="Volume">
-          {d.volume_name ? (
-            <LinkValue
-              t={t}
-              onClick={() =>
-                props.onNavigate?.("PersistentVolume", null, d.volume_name!)
-              }
-              copyText={d.volume_name}
-              enabled={!!props.onNavigate}
-            >
-              {d.volume_name}
-            </LinkValue>
-          ) : (
-            <Mute t={t}>(unbound)</Mute>
+          {d.requested_storage && d.requested_storage !== d.capacity && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              requested {d.requested_storage}
+            </span>
           )}
-        </DetailRow>
-        <DetailRow t={t} label="Access Modes">
-          <StringChips t={t} items={d.access_modes} />
-        </DetailRow>
-        {d.volume_mode && (
-          <DetailRow t={t} label="Volume Mode">
-            <Scalar t={t} value={d.volume_mode} />
-          </DetailRow>
-        )}
-        <DetailRow t={t} label="Requested">
-          <Scalar t={t} value={d.requested_storage} />
-        </DetailRow>
-        <DetailRow t={t} label="Capacity">
-          <Scalar t={t} value={d.capacity} />
-        </DetailRow>
-        {d.allocated_resources.length > 0 && (
-          <DetailRow t={t} label="Allocated">
-            <KeyValueChips t={t} pairs={d.allocated_resources} />
-          </DetailRow>
-        )}
-        {(d.selector.match_labels.length > 0 ||
-          d.selector.match_expressions > 0) && (
-          <DetailRow t={t} label="Selector">
-            {d.selector.match_labels.length > 0 && (
-              <KeyValueChips t={t} pairs={d.selector.match_labels} />
-            )}
-            {d.selector.match_expressions > 0 && (
-              <span style={{ fontSize: FS_SM, color: t.textDim, marginLeft: 6 }}>
-                + {d.selector.match_expressions} matchExpression
-                {d.selector.match_expressions === 1 ? "" : "s"}
-              </span>
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
+
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "persistentvolumeclaims",
+            namespace: ns,
+            name: props.name,
+          }}
+        />
+
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Storage Class">
+            {d.storage_class ? (
+              <LinkValue
+                t={t}
+                onClick={() =>
+                  props.onNavigate?.("StorageClass", null, d.storage_class!)
+                }
+                copyText={d.storage_class}
+                enabled={!!props.onNavigate}
+              >
+                {d.storage_class}
+              </LinkValue>
+            ) : (
+              <Mute t={t}>(default)</Mute>
             )}
           </DetailRow>
-        )}
-      </div>
-
-      {(d.data_source || d.data_source_ref) && (
-        <>
-          <Section t={t} title="Data Source" />
-          <div style={{ marginBottom: 22 }}>
-            {d.data_source && d.data_source.kind && d.data_source.name && (
-              <DetailRow t={t} label="From">
-                <span style={{ fontSize: FS_MD, color: t.textDim }}>
-                  {d.data_source.kind}
+          <DetailRow t={t} label="Volume">
+            {d.volume_name ? (
+              <LinkValue
+                t={t}
+                onClick={() =>
+                  props.onNavigate?.("PersistentVolume", null, d.volume_name!)
+                }
+                copyText={d.volume_name}
+                enabled={!!props.onNavigate}
+              >
+                {d.volume_name}
+              </LinkValue>
+            ) : (
+              <Mute t={t}>(unbound)</Mute>
+            )}
+          </DetailRow>
+          <DetailRow t={t} label="Access Modes">
+            <StringChips t={t} items={d.access_modes} />
+          </DetailRow>
+          {d.volume_mode && (
+            <DetailRow t={t} label="Volume Mode">
+              <Scalar t={t} value={d.volume_mode} />
+            </DetailRow>
+          )}
+          <DetailRow t={t} label="Requested">
+            <PvcRequestedStorageEditor
+              t={t}
+              pvcName={props.name}
+              namespace={ns}
+              clusterId={props.clusterId}
+              requestedStorage={d.requested_storage}
+            />
+          </DetailRow>
+          <DetailRow t={t} label="Capacity">
+            <Scalar t={t} value={d.capacity} />
+          </DetailRow>
+          {d.allocated_resources.length > 0 && (
+            <DetailRow t={t} label="Allocated">
+              <KeyValueChips t={t} pairs={d.allocated_resources} />
+            </DetailRow>
+          )}
+          {(d.selector.match_labels.length > 0 ||
+            d.selector.match_expressions > 0) && (
+            <DetailRow t={t} label="Selector">
+              {d.selector.match_labels.length > 0 && (
+                <KeyValueChips t={t} pairs={d.selector.match_labels} />
+              )}
+              {d.selector.match_expressions > 0 && (
+                <span style={{ fontSize: FS_SM, color: t.textDim, marginLeft: 6 }}>
+                  + {d.selector.match_expressions} matchExpression
+                  {d.selector.match_expressions === 1 ? "" : "s"}
                 </span>
-                <LinkValue
-                  t={t}
-                  onClick={() =>
-                    props.onNavigate?.(
-                      d.data_source!.kind!,
-                      ns,
-                      d.data_source!.name!,
-                    )
-                  }
-                  copyText={d.data_source.name}
-                  enabled={!!props.onNavigate}
-                >
-                  {d.data_source.name}
-                </LinkValue>
-                {d.data_source.api_group && (
-                  <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-                    {d.data_source.api_group}
-                  </span>
-                )}
-              </DetailRow>
-            )}
-            {d.data_source_ref && d.data_source_ref.kind &&
-              d.data_source_ref.name && (
-                <DetailRow t={t} label="From Ref">
+              )}
+            </DetailRow>
+          )}
+        </div>
+
+        {(d.data_source || d.data_source_ref) && (
+          <>
+            <Section t={t} title="Data Source" />
+            <div style={{ marginBottom: 22 }}>
+              {d.data_source && d.data_source.kind && d.data_source.name && (
+                <DetailRow t={t} label="From">
                   <span style={{ fontSize: FS_MD, color: t.textDim }}>
-                    {d.data_source_ref.kind}
+                    {d.data_source.kind}
                   </span>
                   <LinkValue
                     t={t}
                     onClick={() =>
                       props.onNavigate?.(
-                        d.data_source_ref!.kind!,
-                        d.data_source_ref!.namespace ?? ns,
-                        d.data_source_ref!.name!,
+                        d.data_source!.kind!,
+                        ns,
+                        d.data_source!.name!,
                       )
                     }
-                    copyText={d.data_source_ref.name}
+                    copyText={d.data_source.name}
                     enabled={!!props.onNavigate}
                   >
-                    {d.data_source_ref.name}
+                    {d.data_source.name}
                   </LinkValue>
-                  {d.data_source_ref.namespace && (
+                  {d.data_source.api_group && (
                     <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-                      ns {d.data_source_ref.namespace}
+                      {d.data_source.api_group}
                     </span>
                   )}
                 </DetailRow>
               )}
-          </div>
-        </>
-      )}
+              {d.data_source_ref && d.data_source_ref.kind &&
+                d.data_source_ref.name && (
+                  <DetailRow t={t} label="From Ref">
+                    <span style={{ fontSize: FS_MD, color: t.textDim }}>
+                      {d.data_source_ref.kind}
+                    </span>
+                    <LinkValue
+                      t={t}
+                      onClick={() =>
+                        props.onNavigate?.(
+                          d.data_source_ref!.kind!,
+                          d.data_source_ref!.namespace ?? ns,
+                          d.data_source_ref!.name!,
+                        )
+                      }
+                      copyText={d.data_source_ref.name}
+                      enabled={!!props.onNavigate}
+                    >
+                      {d.data_source_ref.name}
+                    </LinkValue>
+                    {d.data_source_ref.namespace && (
+                      <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+                        ns {d.data_source_ref.namespace}
+                      </span>
+                    )}
+                  </DetailRow>
+                )}
+            </div>
+          </>
+        )}
 
-      <ConditionsSection t={t} conditions={d.conditions} />
-    </Frame>
+        <ConditionsSection t={t} conditions={d.conditions} />
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -357,207 +503,217 @@ export function PersistentVolumeSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <StatusPill status={d.phase} t={t} mode={props.mode} />
-        {d.capacity && (
-          <span
-            style={{
-              fontFamily: FF_MONO,
-              fontSize: FS_MD,
-              fontWeight: 600,
-              color: t.text,
-            }}
-          >
-            {d.capacity}
-          </span>
-        )}
-        {d.source_type && (
-          <StatusPill
-            status={d.source_type}
-            t={t}
-            mode={props.mode}
-            dense
-          />
-        )}
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            · {ageFromIso(d.meta.created_at)} old
-          </span>
-        )}
-      </div>
-
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "persistentvolumes",
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
-
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Capacity">
-          <Scalar t={t} value={d.capacity} />
-        </DetailRow>
-        <DetailRow t={t} label="Access Modes">
-          <StringChips t={t} items={d.access_modes} />
-        </DetailRow>
-        <DetailRow t={t} label="Reclaim Policy">
-          <Scalar t={t} value={d.reclaim_policy} mono={false} />
-        </DetailRow>
-        <DetailRow t={t} label="Storage Class">
-          {d.storage_class ? (
-            <LinkValue
-              t={t}
-              onClick={() =>
-                props.onNavigate?.("StorageClass", null, d.storage_class!)
-              }
-              copyText={d.storage_class}
-              enabled={!!props.onNavigate}
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "persistentvolumes",
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
+          }}
+        >
+          <StatusPill status={d.phase} t={t} mode={props.mode} />
+          {d.capacity && (
+            <span
+              style={{
+                fontFamily: FF_MONO,
+                fontSize: FS_MD,
+                fontWeight: 600,
+                color: t.text,
+              }}
             >
-              {d.storage_class}
-            </LinkValue>
-          ) : (
-            <Mute t={t}>—</Mute>
+              {d.capacity}
+            </span>
           )}
-        </DetailRow>
-        {d.volume_mode && (
-          <DetailRow t={t} label="Volume Mode">
-            <Scalar t={t} value={d.volume_mode} />
-          </DetailRow>
-        )}
-        {d.mount_options.length > 0 && (
-          <DetailRow t={t} label="Mount Options">
-            <StringChips t={t} items={d.mount_options} />
-          </DetailRow>
-        )}
-      </div>
+          {d.source_type && (
+            <StatusPill
+              status={d.source_type}
+              t={t}
+              mode={props.mode}
+              dense
+            />
+          )}
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              · {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
 
-      <Section t={t} title="Source" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Type">
-          <Scalar t={t} value={d.source_type} mono={false} />
-        </DetailRow>
-        <DetailRow t={t} label="Summary">
-          <Scalar t={t} value={d.source_summary} />
-        </DetailRow>
-      </div>
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "persistentvolumes",
+            namespace: null,
+            name: props.name,
+          }}
+        />
 
-      {d.claim_ref && (d.claim_ref.name || d.claim_ref.namespace) && (
-        <>
-          <Section t={t} title="Claim" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Bound To">
-              {d.claim_ref.name ? (
-                <LinkValue
-                  t={t}
-                  onClick={() =>
-                    props.onNavigate?.(
-                      d.claim_ref!.kind ?? "PersistentVolumeClaim",
-                      d.claim_ref!.namespace ?? null,
-                      d.claim_ref!.name!,
-                    )
-                  }
-                  copyText={d.claim_ref.name}
-                  enabled={!!props.onNavigate}
-                >
-                  {d.claim_ref.name}
-                </LinkValue>
-              ) : (
-                <Mute t={t}>—</Mute>
-              )}
-              {d.claim_ref.namespace && (
-                <LinkValue
-                  t={t}
-                  onClick={() =>
-                    props.onNavigate?.("Namespace", null, d.claim_ref!.namespace!)
-                  }
-                  copyText={d.claim_ref.namespace}
-                  enabled={!!props.onNavigate}
-                >
-                  {d.claim_ref.namespace}
-                </LinkValue>
-              )}
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Capacity">
+            <Scalar t={t} value={d.capacity} />
+          </DetailRow>
+          <DetailRow t={t} label="Access Modes">
+            <StringChips t={t} items={d.access_modes} />
+          </DetailRow>
+          <DetailRow t={t} label="Reclaim Policy">
+            <Scalar t={t} value={d.reclaim_policy} mono={false} />
+          </DetailRow>
+          <DetailRow t={t} label="Storage Class">
+            {d.storage_class ? (
+              <LinkValue
+                t={t}
+                onClick={() =>
+                  props.onNavigate?.("StorageClass", null, d.storage_class!)
+                }
+                copyText={d.storage_class}
+                enabled={!!props.onNavigate}
+              >
+                {d.storage_class}
+              </LinkValue>
+            ) : (
+              <Mute t={t}>—</Mute>
+            )}
+          </DetailRow>
+          {d.volume_mode && (
+            <DetailRow t={t} label="Volume Mode">
+              <Scalar t={t} value={d.volume_mode} />
             </DetailRow>
-            {d.claim_ref.uid && (
-              <DetailRow t={t} label="Claim UID">
-                <Copyable text={d.claim_ref.uid}>
-                  <span
-                    style={{
-                      fontFamily: FF_MONO,
-                      fontSize: FS_SM,
-                      color: t.textDim,
-                      wordBreak: "break-all",
-                    }}
+          )}
+          {d.mount_options.length > 0 && (
+            <DetailRow t={t} label="Mount Options">
+              <StringChips t={t} items={d.mount_options} />
+            </DetailRow>
+          )}
+        </div>
+
+        <Section t={t} title="Source" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Type">
+            <Scalar t={t} value={d.source_type} mono={false} />
+          </DetailRow>
+          <DetailRow t={t} label="Summary">
+            <Scalar t={t} value={d.source_summary} />
+          </DetailRow>
+        </div>
+
+        {d.claim_ref && (d.claim_ref.name || d.claim_ref.namespace) && (
+          <>
+            <Section t={t} title="Claim" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Bound To">
+                {d.claim_ref.name ? (
+                  <LinkValue
+                    t={t}
+                    onClick={() =>
+                      props.onNavigate?.(
+                        d.claim_ref!.kind ?? "PersistentVolumeClaim",
+                        d.claim_ref!.namespace ?? null,
+                        d.claim_ref!.name!,
+                      )
+                    }
+                    copyText={d.claim_ref.name}
+                    enabled={!!props.onNavigate}
                   >
-                    {d.claim_ref.uid}
-                  </span>
-                </Copyable>
+                    {d.claim_ref.name}
+                  </LinkValue>
+                ) : (
+                  <Mute t={t}>—</Mute>
+                )}
+                {d.claim_ref.namespace && (
+                  <LinkValue
+                    t={t}
+                    onClick={() =>
+                      props.onNavigate?.("Namespace", null, d.claim_ref!.namespace!)
+                    }
+                    copyText={d.claim_ref.namespace}
+                    enabled={!!props.onNavigate}
+                  >
+                    {d.claim_ref.namespace}
+                  </LinkValue>
+                )}
               </DetailRow>
-            )}
-          </div>
-        </>
-      )}
+              {d.claim_ref.uid && (
+                <DetailRow t={t} label="Claim UID">
+                  <Copyable text={d.claim_ref.uid}>
+                    <span
+                      style={{
+                        fontFamily: FF_MONO,
+                        fontSize: FS_SM,
+                        color: t.textDim,
+                        wordBreak: "break-all",
+                      }}
+                    >
+                      {d.claim_ref.uid}
+                    </span>
+                  </Copyable>
+                </DetailRow>
+              )}
+            </div>
+          </>
+        )}
 
-      {d.node_affinity.term_count > 0 && (
-        <>
-          <Section t={t} title="Node Affinity" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Required Terms">
-              <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
-                {d.node_affinity.term_count}
-              </span>
-            </DetailRow>
-            {d.node_affinity.keys.length > 0 && (
-              <DetailRow t={t} label="Keys">
-                <StringChips t={t} items={d.node_affinity.keys} />
-              </DetailRow>
-            )}
-          </div>
-        </>
-      )}
-
-      {(d.phase_message || d.phase_reason) && (
-        <>
-          <Section t={t} title="Status" />
-          <div style={{ marginBottom: 22 }}>
-            {d.phase_reason && (
-              <DetailRow t={t} label="Reason">
-                <Scalar t={t} value={d.phase_reason} mono={false} />
-              </DetailRow>
-            )}
-            {d.phase_message && (
-              <DetailRow t={t} label="Message">
-                <span
-                  style={{
-                    fontSize: FS_SM,
-                    color: t.textMuted,
-                    whiteSpace: "pre-wrap",
-                    wordBreak: "break-word",
-                  }}
-                >
-                  {d.phase_message}
+        {d.node_affinity.term_count > 0 && (
+          <>
+            <Section t={t} title="Node Affinity" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Required Terms">
+                <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
+                  {d.node_affinity.term_count}
                 </span>
               </DetailRow>
-            )}
-          </div>
-        </>
-      )}
-    </Frame>
+              {d.node_affinity.keys.length > 0 && (
+                <DetailRow t={t} label="Keys">
+                  <StringChips t={t} items={d.node_affinity.keys} />
+                </DetailRow>
+              )}
+            </div>
+          </>
+        )}
+
+        {(d.phase_message || d.phase_reason) && (
+          <>
+            <Section t={t} title="Status" />
+            <div style={{ marginBottom: 22 }}>
+              {d.phase_reason && (
+                <DetailRow t={t} label="Reason">
+                  <Scalar t={t} value={d.phase_reason} mono={false} />
+                </DetailRow>
+              )}
+              {d.phase_message && (
+                <DetailRow t={t} label="Message">
+                  <span
+                    style={{
+                      fontSize: FS_SM,
+                      color: t.textMuted,
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                    }}
+                  >
+                    {d.phase_message}
+                  </span>
+                </DetailRow>
+              )}
+            </div>
+          </>
+        )}
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }
 
@@ -588,131 +744,141 @@ export function StorageClassSummary(props: {
 
   const d = state.detail;
   return (
-    <Frame t={t}>
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          alignItems: "center",
-          gap: 10,
-          marginBottom: 18,
-        }}
-      >
-        <span
+    <EditSessionProvider
+      target={{
+        clusterId: props.clusterId,
+        kindId: "storageclasses",
+        namespace: null,
+        name: props.name,
+      }}
+      onSaved={() => setRefetch((r) => r + 1)}
+    >
+      <Frame t={t}>
+        <div
           style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            color: t.text,
-            wordBreak: "break-all",
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 18,
           }}
         >
-          {d.provisioner}
-        </span>
-        {d.is_default && (
-          <StatusPill status="Default" t={t} mode={props.mode} dense />
-        )}
-        {d.allow_volume_expansion && (
-          <StatusPill status="Expandable" t={t} mode={props.mode} dense />
-        )}
-        {d.meta.created_at && (
-          <span style={{ fontSize: FS_SM, color: t.textMuted }}>
-            {ageFromIso(d.meta.created_at)} old
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: t.text,
+              wordBreak: "break-all",
+            }}
+          >
+            {d.provisioner}
           </span>
-        )}
-      </div>
+          {d.is_default && (
+            <StatusPill status="Default" t={t} mode={props.mode} dense />
+          )}
+          {d.allow_volume_expansion && (
+            <StatusPill status="Expandable" t={t} mode={props.mode} dense />
+          )}
+          {d.meta.created_at && (
+            <span style={{ fontSize: FS_SM, color: t.textMuted }}>
+              {ageFromIso(d.meta.created_at)} old
+            </span>
+          )}
+        </div>
 
-      <MetaSection
-        t={t}
-        meta={d.meta}
-        onNavigate={props.onNavigate}
-        editTarget={{
-          clusterId: props.clusterId,
-          kindId: "storageclasses",
-          namespace: null,
-          name: props.name,
-        }}
-        onSaved={() => setRefetch((n) => n + 1)}
-      />
+        <MetaSection
+          t={t}
+          meta={d.meta}
+          onNavigate={props.onNavigate}
+          editTarget={{
+            clusterId: props.clusterId,
+            kindId: "storageclasses",
+            namespace: null,
+            name: props.name,
+          }}
+        />
 
-      <Section t={t} title="Spec" />
-      <div style={{ marginBottom: 22 }}>
-        <DetailRow t={t} label="Provisioner">
-          <Scalar t={t} value={d.provisioner} />
-        </DetailRow>
-        <DetailRow t={t} label="Reclaim Policy">
-          <Scalar t={t} value={d.reclaim_policy} mono={false} />
-        </DetailRow>
-        <DetailRow t={t} label="Binding Mode">
-          <Scalar t={t} value={d.binding_mode} mono={false} />
-        </DetailRow>
-        <DetailRow t={t} label="Allow Expansion">
-          <span style={{ fontSize: FS_MD }}>
-            {d.allow_volume_expansion === true
-              ? "true"
-              : d.allow_volume_expansion === false
-                ? "false"
-                : "—"}
-          </span>
-        </DetailRow>
-        <DetailRow t={t} label="Default">
-          <span style={{ fontSize: FS_MD }}>{d.is_default ? "true" : "false"}</span>
-        </DetailRow>
-      </div>
+        <Section t={t} title="Spec" />
+        <div style={{ marginBottom: 22 }}>
+          <DetailRow t={t} label="Provisioner">
+            <Scalar t={t} value={d.provisioner} />
+          </DetailRow>
+          <DetailRow t={t} label="Reclaim Policy">
+            <Scalar t={t} value={d.reclaim_policy} mono={false} />
+          </DetailRow>
+          <DetailRow t={t} label="Binding Mode">
+            <Scalar t={t} value={d.binding_mode} mono={false} />
+          </DetailRow>
+          <DetailRow t={t} label="Allow Expansion">
+            <span style={{ fontSize: FS_MD }}>
+              {d.allow_volume_expansion === true
+                ? "true"
+                : d.allow_volume_expansion === false
+                  ? "false"
+                  : "—"}
+            </span>
+          </DetailRow>
+          <DetailRow t={t} label="Default">
+            <span style={{ fontSize: FS_MD }}>{d.is_default ? "true" : "false"}</span>
+          </DetailRow>
+        </div>
 
-      {d.parameters.length > 0 && (
-        <>
-          <Section
-            t={t}
-            title="Parameters"
-            right={
-              <span
-                style={{
-                  fontSize: FS_XS,
-                  color: t.textMuted,
-                  fontFamily: FF_MONO,
-                }}
-              >
-                {d.parameters.length} total
-              </span>
-            }
-          />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Parameters">
-              <KeyValueChips t={t} pairs={d.parameters} />
-            </DetailRow>
-          </div>
-        </>
-      )}
-
-      {d.mount_options.length > 0 && (
-        <>
-          <Section t={t} title="Mount Options" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Options">
-              <StringChips t={t} items={d.mount_options} />
-            </DetailRow>
-          </div>
-        </>
-      )}
-
-      {d.allowed_topologies.term_count > 0 && (
-        <>
-          <Section t={t} title="Allowed Topologies" />
-          <div style={{ marginBottom: 22 }}>
-            <DetailRow t={t} label="Terms">
-              <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
-                {d.allowed_topologies.term_count}
-              </span>
-            </DetailRow>
-            {d.allowed_topologies.keys.length > 0 && (
-              <DetailRow t={t} label="Keys">
-                <StringChips t={t} items={d.allowed_topologies.keys} />
+        {d.parameters.length > 0 && (
+          <>
+            <Section
+              t={t}
+              title="Parameters"
+              right={
+                <span
+                  style={{
+                    fontSize: FS_XS,
+                    color: t.textMuted,
+                    fontFamily: FF_MONO,
+                  }}
+                >
+                  {d.parameters.length} total
+                </span>
+              }
+            />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Parameters">
+                <KeyValueChips t={t} pairs={d.parameters} />
               </DetailRow>
-            )}
-          </div>
-        </>
-      )}
-    </Frame>
+            </div>
+          </>
+        )}
+
+        {d.mount_options.length > 0 && (
+          <>
+            <Section t={t} title="Mount Options" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Options">
+                <StringChips t={t} items={d.mount_options} />
+              </DetailRow>
+            </div>
+          </>
+        )}
+
+        {d.allowed_topologies.term_count > 0 && (
+          <>
+            <Section t={t} title="Allowed Topologies" />
+            <div style={{ marginBottom: 22 }}>
+              <DetailRow t={t} label="Terms">
+                <span style={{ fontFamily: FF_MONO, fontSize: FS_MD }}>
+                  {d.allowed_topologies.term_count}
+                </span>
+              </DetailRow>
+              {d.allowed_topologies.keys.length > 0 && (
+                <DetailRow t={t} label="Keys">
+                  <StringChips t={t} items={d.allowed_topologies.keys} />
+                </DetailRow>
+              )}
+            </div>
+          </>
+        )}
+        <GlobalSaveBar t={t} />
+      </Frame>
+    </EditSessionProvider>
   );
 }

--- a/ui/src/components/detail/storage/index.tsx
+++ b/ui/src/components/detail/storage/index.tsx
@@ -7,8 +7,19 @@
 import { useEffect, useRef, useState } from "react";
 import { useResolvedTheme } from "../../../store";
 import { api } from "../../../api";
-import { FF_MONO, type ThemeMode, type Tokens, FS_MD, FS_SM, FS_XS, R_SM } from "../../../theme";
+import {
+  FF_MONO,
+  type ThemeMode,
+  type Tokens,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+} from "../../../theme";
 import { Chip, ErrorBlock, LoadingLine, Section, StatusPill } from "../../ui";
+import {
+  EditModeChrome,
+  EditableTextValue,
+} from "../edit";
 import {
   ChipWrap,
   Copyable,
@@ -19,6 +30,7 @@ import {
   LinkValue,
   Mute,
   ageFromIso,
+  parseQuantity,
   useEditField,
   type DetailNavigate,
 } from "..";
@@ -116,42 +128,40 @@ function StringChips({ t, items }: { t: Tokens; items: string[] }) {
   );
 }
 
-function PvcRequestedStorageEditor({
+// Same shape as MetaSection's labels/annotations editor — read-mode value
+// + an EditModeChrome pencil below, right-aligned. Edit-mode swaps to an
+// EditableTextValue. No bespoke pill / hover state; the global save bar
+// commits the change like every other field on the panel.
+export function PvcRequestedStorageEditor({
   t,
   requestedStorage,
 }: {
   t: Tokens;
-  pvcName: string;
-  namespace: string;
-  clusterId: string;
   requestedStorage: string | null;
 }) {
-  const [hovered, setHovered] = useState(false);
-
-  const validateQuantity = (val: string) => {
+  // K8s ResourceQuantity. `parseQuantity` is the same parser the rest of
+  // the kit uses (ResourceQuota, LimitRange) — keeping a single source of
+  // truth so "what's a valid storage size" answers the same everywhere.
+  const validateQuantity = (val: string): string | null => {
     const v = val.trim();
     if (v === "") return "storage quantity cannot be empty";
-    const valid = /^\d+(\.\d+)?(?:[KMGTPeE]i?|m)?$/.test(v);
-    if (!valid) {
-      return "invalid storage quantity format (e.g. 10Gi, 500Mi)";
-    }
-    return null;
+    return parseQuantity(v) === null
+      ? "invalid storage quantity format (e.g. 10Gi, 500Mi)"
+      : null;
   };
 
   const edit = useEditField<{ value: string }>({
     id: "pvc:requested_storage",
     initial: () => ({ value: requestedStorage ?? "" }),
-    serialize: (b) => {
-      return {
-        spec: {
-          resources: {
-            requests: {
-              storage: b.value.trim(),
-            },
+    serialize: (b) => ({
+      spec: {
+        resources: {
+          requests: {
+            storage: b.value.trim(),
           },
         },
-      };
-    },
+      },
+    }),
     dirtyCount: (b) => (b.value.trim() !== (requestedStorage ?? "") ? 1 : 0),
     validate: (b) => validateQuantity(b.value),
   });
@@ -159,87 +169,46 @@ function PvcRequestedStorageEditor({
   const isDirty = edit.dirty > 0;
   const invalid = edit.editing && validateQuantity(edit.buffer.value) !== null;
 
-  const handleStartEdit = () => {
-    edit.enter();
-  };
-
-  const handleCancel = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    edit.cancel();
-  };
-
-  if (edit.editing) {
-    return (
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <input
-          value={edit.buffer.value}
-          onChange={(e) => edit.setBuffer({ value: e.target.value })}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              e.currentTarget.blur();
-            } else if (e.key === "Escape") {
-              e.preventDefault();
-              edit.cancel();
-            }
-          }}
-          autoFocus
-          style={{
-            background: t.bg,
-            border: `1px solid ${invalid ? t.bad : isDirty ? t.warn : t.border}`,
-            borderRadius: R_SM,
-            color: t.text,
-            padding: "2px 6px",
-            fontSize: FS_MD,
-            fontFamily: FF_MONO,
-            outline: "none",
-            width: "120px",
-          }}
-        />
-        <button
-          onClick={handleCancel}
-          style={{
-            background: "none",
-            border: "none",
-            color: t.textMuted,
-            cursor: "pointer",
-            fontSize: FS_SM,
-            padding: "2px 4px",
-            display: "flex",
-            alignItems: "center",
-          }}
-          title="Revert"
-        >
-          ↺
-        </button>
-      </div>
-    );
-  }
-
   return (
-    <div
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onClick={handleStartEdit}
-      style={{
-        display: "inline-flex",
-        alignItems: "center",
-        cursor: "pointer",
-        gap: 6,
-        padding: "2px 6px",
-        borderRadius: R_SM,
-        background: hovered ? t.surfaceAlt : "transparent",
-        transition: "background 0.2s ease",
-      }}
-    >
-      <span style={{ fontFamily: FF_MONO, fontSize: FS_MD, color: isDirty ? t.warn : t.text }}>
-        {isDirty ? edit.buffer.value : (requestedStorage ?? "—")}
-      </span>
-      {(hovered || isDirty) && (
-        <span style={{ fontSize: 10, color: isDirty ? t.warn : t.accent }}>
-          {isDirty ? "●" : "✎"}
+    <div style={{ width: "100%" }}>
+      {edit.editing ? (
+        <EditableTextValue
+          t={t}
+          value={edit.buffer.value}
+          onChange={(v) => edit.setBuffer({ value: v })}
+          invalid={invalid}
+          placeholder="e.g. 10Gi"
+          ariaLabel="Requested storage"
+        />
+      ) : requestedStorage ? (
+        <span
+          style={{
+            fontFamily: FF_MONO,
+            fontSize: FS_MD,
+            color: isDirty ? t.warn : t.text,
+          }}
+        >
+          {isDirty ? edit.buffer.value : requestedStorage}
         </span>
+      ) : (
+        <Mute t={t}>—</Mute>
       )}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          marginTop: edit.editing ? 6 : 4,
+        }}
+      >
+        <EditModeChrome
+          t={t}
+          editing={edit.editing}
+          dirty={edit.dirty}
+          saving={edit.saving}
+          onEnter={edit.enter}
+          onCancel={edit.cancel}
+        />
+      </div>
     </div>
   );
 }
@@ -378,9 +347,6 @@ export function PersistentVolumeClaimSummary(props: {
           <DetailRow t={t} label="Requested">
             <PvcRequestedStorageEditor
               t={t}
-              pvcName={props.name}
-              namespace={ns}
-              clusterId={props.clusterId}
               requestedStorage={d.requested_storage}
             />
           </DetailRow>

--- a/ui/src/components/detail/storage/pvcStorageEditor.test.tsx
+++ b/ui/src/components/detail/storage/pvcStorageEditor.test.tsx
@@ -1,0 +1,94 @@
+// Behavioural coverage for the PVC requested-storage inline editor.
+// Same pattern as MetaSection labels/annotations: a pencil enters edit
+// mode, an input swaps in, EditModeChrome's Cancel reverts. No pill, no
+// hover-reveal — kept on the standard chrome so every editable field on
+// the panel feels the same.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { PvcRequestedStorageEditor } from "./index";
+import { EditSessionProvider } from "../editSession";
+import { tokens } from "../../../theme";
+import { resetMockInvoke } from "../../../test/tauri-mock";
+
+const t = tokens("dark");
+const TARGET = {
+  clusterId: "ctx",
+  kindId: "persistentvolumeclaims",
+  namespace: "default",
+  name: "data",
+};
+
+beforeEach(() => {
+  resetMockInvoke();
+});
+
+function mount(requestedStorage: string | null) {
+  return render(
+    <EditSessionProvider target={TARGET} onSaved={() => {}}>
+      <PvcRequestedStorageEditor t={t} requestedStorage={requestedStorage} />
+    </EditSessionProvider>,
+  );
+}
+
+function pencil(container: HTMLElement): HTMLButtonElement {
+  // EditModeChrome renders an icon button with title "Edit" in read mode.
+  const btn = container.querySelector("button[title='Edit']");
+  if (!btn) throw new Error("pencil (Edit) button not found");
+  return btn as HTMLButtonElement;
+}
+
+function input(container: HTMLElement): HTMLInputElement {
+  const i = container.querySelector("input");
+  if (!i) throw new Error("edit-mode input not rendered");
+  return i as HTMLInputElement;
+}
+
+describe("PvcRequestedStorageEditor", () => {
+  it("renders the requested storage when set", () => {
+    const { container } = mount("10Gi");
+    expect(container.textContent).toContain("10Gi");
+    expect(container.querySelector("input")).toBeNull();
+  });
+
+  it("renders an em-dash when unset", () => {
+    const { container } = mount(null);
+    expect(container.textContent).toContain("—");
+  });
+
+  it("pencil enters edit mode with the current value", () => {
+    const { container } = mount("10Gi");
+    fireEvent.click(pencil(container));
+    expect(input(container).value).toBe("10Gi");
+  });
+
+  it("Cancel exits edit mode without persisting", () => {
+    const { container } = mount("10Gi");
+    fireEvent.click(pencil(container));
+    fireEvent.change(input(container), { target: { value: "50Gi" } });
+    // Edit-mode chrome carries the Cancel/Revert chip.
+    const cancel = Array.from(container.querySelectorAll("button")).find((b) =>
+      /Cancel|Revert/.test(b.textContent ?? ""),
+    );
+    expect(cancel).toBeTruthy();
+    fireEvent.click(cancel!);
+    expect(container.querySelector("input")).toBeNull();
+    expect(container.textContent).toContain("10Gi");
+  });
+
+  it("typing in edit mode flows through to the buffer", () => {
+    const { container } = mount("10Gi");
+    fireEvent.click(pencil(container));
+    fireEvent.change(input(container), { target: { value: "20Gi" } });
+    expect(input(container).value).toBe("20Gi");
+  });
+
+  it("invalid quantity strings do not block typing", () => {
+    const { container } = mount("10Gi");
+    fireEvent.click(pencil(container));
+    fireEvent.change(input(container), { target: { value: "not a size" } });
+    // The chrome surfaces validation through the global save bar; the
+    // input itself stays usable so the operator can keep editing.
+    expect(input(container).value).toBe("not a size");
+  });
+});

--- a/ui/src/components/detail/workload/index.tsx
+++ b/ui/src/components/detail/workload/index.tsx
@@ -170,12 +170,11 @@ export function DeploymentSummary(props: {
             marginBottom: 18,
           }}
         >
-          <ReplicaCounts
+          <ReplicasEditor
             t={t}
             ready={d.replicas.ready}
             desired={d.replicas.desired}
           />
-          <ReplicasEditor t={t} desired={d.replicas.desired} />
           <span style={{ fontSize: FS_SM, color: t.textMuted }}>
             {d.replicas.updated} up-to-date · {d.replicas.available} available
             {d.replicas.unavailable > 0
@@ -318,12 +317,11 @@ export function ReplicaSetSummary(props: {
             marginBottom: 18,
           }}
         >
-          <ReplicaCounts
+          <ReplicasEditor
             t={t}
             ready={d.replicas.ready}
             desired={d.replicas.desired}
           />
-          <ReplicasEditor t={t} desired={d.replicas.desired} />
           <span style={{ fontSize: FS_SM, color: t.textMuted }}>
             {d.replicas.current} current · {d.replicas.available} available
             {d.meta.created_at ? ` · ${ageFromIso(d.meta.created_at)} old` : ""}
@@ -444,12 +442,11 @@ export function StatefulSetSummary(props: {
             marginBottom: 18,
           }}
         >
-          <ReplicaCounts
+          <ReplicasEditor
             t={t}
             ready={d.replicas.ready}
             desired={d.replicas.desired}
           />
-          <ReplicasEditor t={t} desired={d.replicas.desired} />
           <span style={{ fontSize: FS_SM, color: t.textMuted }}>
             {d.replicas.current} current · {d.replicas.updated} updated ·{" "}
             {d.replicas.available} available

--- a/ui/src/components/detail/workload/replicasEditor.test.tsx
+++ b/ui/src/components/detail/workload/replicasEditor.test.tsx
@@ -1,0 +1,139 @@
+// Behavioural coverage for the ReplicasEditor pill. Asserts the pieces a
+// user-visible change would break — the read-mode display, the stepper
+// math, validate→session-dirty plumbing, and the revert path. Style
+// internals (radius, alpha shadow, etc.) are intentionally not pinned so
+// designers can iterate without breaking these tests.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { ReplicasEditor } from "./shared";
+import { EditSessionProvider } from "../editSession";
+import { tokens } from "../../../theme";
+import { resetMockInvoke } from "../../../test/tauri-mock";
+
+const t = tokens("dark");
+const TARGET = {
+  clusterId: "ctx",
+  kindId: "deployments",
+  namespace: "default",
+  name: "app",
+};
+
+beforeEach(() => {
+  resetMockInvoke();
+});
+
+function mount(opts: { desired: number; ready?: number }) {
+  return render(
+    <EditSessionProvider target={TARGET} onSaved={() => {}}>
+      <ReplicasEditor t={t} desired={opts.desired} ready={opts.ready} />
+    </EditSessionProvider>,
+  );
+}
+
+// The pill renders as a single inline-flex container — find it by the
+// "replicas" label so the test isn't coupled to internal structure.
+function pill(container: HTMLElement): HTMLElement {
+  const label = Array.from(container.querySelectorAll("span")).find(
+    (s) => s.textContent === "replicas",
+  );
+  if (!label) throw new Error("read-mode pill not rendered");
+  return label.parentElement as HTMLElement;
+}
+
+function input(container: HTMLElement): HTMLInputElement {
+  const i = container.querySelector("input[type='text']");
+  if (!i) throw new Error("edit-mode input not rendered");
+  return i as HTMLInputElement;
+}
+
+function buttonByTitle(container: HTMLElement, title: string): HTMLButtonElement {
+  const btn = container.querySelector(`button[title="${title}"]`);
+  if (!btn) throw new Error(`button[title="${title}"] not found`);
+  return btn as HTMLButtonElement;
+}
+
+describe("ReplicasEditor", () => {
+  it("renders ready/desired in read mode when ready is provided", () => {
+    const { container } = mount({ desired: 3, ready: 2 });
+    expect(container.textContent).toContain("2 / 3");
+    expect(container.textContent).toContain("replicas");
+    // Input is hidden until the operator clicks in.
+    expect(container.querySelector("input")).toBeNull();
+  });
+
+  it("renders just the desired count when ready is omitted", () => {
+    const { container } = mount({ desired: 5 });
+    expect(container.textContent).toContain("5");
+    expect(container.textContent).not.toContain(" / ");
+  });
+
+  it("clicking the pill enters edit mode and shows the stepper", () => {
+    const { container } = mount({ desired: 3, ready: 3 });
+    fireEvent.click(pill(container));
+    expect(input(container).value).toBe("3");
+    expect(buttonByTitle(container, "Decrement replicas")).toBeTruthy();
+    expect(buttonByTitle(container, "Increment replicas")).toBeTruthy();
+  });
+
+  it("increment / decrement step the buffer; decrement clamps at 0", () => {
+    const { container } = mount({ desired: 1, ready: 1 });
+    fireEvent.click(pill(container));
+    fireEvent.click(buttonByTitle(container, "Increment replicas"));
+    expect(input(container).value).toBe("2");
+    fireEvent.click(buttonByTitle(container, "Decrement replicas"));
+    fireEvent.click(buttonByTitle(container, "Decrement replicas"));
+    expect(input(container).value).toBe("0");
+    // Decrement disabled at 0 — clicking it again must not go negative.
+    expect(buttonByTitle(container, "Decrement replicas").disabled).toBe(true);
+    fireEvent.click(buttonByTitle(container, "Decrement replicas"));
+    expect(input(container).value).toBe("0");
+  });
+
+  it("typing a non-numeric value is rejected; numeric typing flows through", () => {
+    const { container } = mount({ desired: 2 });
+    fireEvent.click(pill(container));
+    fireEvent.change(input(container), { target: { value: "abc" } });
+    expect(input(container).value).toBe("2"); // unchanged
+    fireEvent.change(input(container), { target: { value: "42" } });
+    expect(input(container).value).toBe("42");
+  });
+
+  it("Escape exits edit mode without persisting buffer changes", () => {
+    const { container } = mount({ desired: 4, ready: 4 });
+    fireEvent.click(pill(container));
+    fireEvent.change(input(container), { target: { value: "9" } });
+    fireEvent.keyDown(input(container), { key: "Escape" });
+    // Back to read mode showing the original count.
+    expect(container.querySelector("input")).toBeNull();
+    expect(container.textContent).toContain("4 / 4");
+  });
+
+  it("dirty edit reveals the revert button and ↺ returns to the original", () => {
+    const { container } = mount({ desired: 3, ready: 3 });
+    fireEvent.click(pill(container));
+    fireEvent.click(buttonByTitle(container, "Increment replicas"));
+    const revert = buttonByTitle(container, "Revert to original count");
+    expect(revert).toBeTruthy();
+    fireEvent.click(revert);
+    expect(input(container).value).toBe("3");
+    // No longer dirty → revert button disappears.
+    expect(container.querySelector("button[title='Revert to original count']")).toBeNull();
+  });
+
+  it("dirty state surfaces a pending dot when collapsed back to read mode", () => {
+    // The read-mode pencil dot is rendered when dirty>0. Trigger dirty by
+    // entering edit, typing, then pressing Enter to collapse.
+    const { container } = mount({ desired: 3, ready: 3 });
+    fireEvent.click(pill(container));
+    fireEvent.change(input(container), { target: { value: "5" } });
+    // Enter blurs the input — we simulate the same end-state by firing the
+    // session's view: the pending change should still be flagged. Since
+    // the widget keeps editing=true until cancel/save, just assert that
+    // the input keeps the typed value and the stepper marks it dirty.
+    expect(input(container).value).toBe("5");
+    // The revert button only appears when dirty>0, so its presence proves
+    // dirty propagated through useEditField.
+    expect(buttonByTitle(container, "Revert to original count")).toBeTruthy();
+  });
+});

--- a/ui/src/components/detail/workload/shared.tsx
+++ b/ui/src/components/detail/workload/shared.tsx
@@ -4,7 +4,20 @@
 // metadata + selector + pod-template chrome consistent across the family.
 
 import { useMemo, useState } from "react";
-import { FF_MONO, type Tokens, R_LG, R_SM, FS_MD, FS_SM, FS_XS } from "../../../theme";
+import {
+  FF_MONO,
+  type Tokens,
+  R_LG,
+  R_SM,
+  R_PILL,
+  CONTROL_H,
+  FS_LG,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  hexWithAlpha,
+  readyDesiredColor,
+} from "../../../theme";
 import { Btn, Checkbox, Chip, Section, Select, Icons } from "../../ui";
 import { ForwardChip } from "../forwardChip";
 import {
@@ -1117,7 +1130,6 @@ export function ReplicaCounts({
   ready: number;
   desired: number;
 }) {
-  const ok = ready === desired && desired > 0;
   return (
     <span
       style={{
@@ -1125,12 +1137,34 @@ export function ReplicaCounts({
         fontSize: FS_MD,
         fontWeight: 600,
         fontVariantNumeric: "tabular-nums",
-        color: ok ? t.good : ready === 0 ? t.bad : t.warn,
+        color: readyDesiredColor(ready, desired, t),
       }}
     >
       {ready} / {desired}
     </span>
   );
+}
+
+// Common chrome for ReplicasEditor's `-` / `+` steppers. Kept module-level
+// so the style object isn't reallocated on every render.
+function stepperBtnStyle(t: Tokens, disabled: boolean): React.CSSProperties {
+  return {
+    background: "transparent",
+    color: disabled ? t.textDim : t.text,
+    border: "none",
+    width: 20,
+    height: 20,
+    borderRadius: R_PILL,
+    cursor: disabled ? "not-allowed" : "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontFamily: FF_MONO,
+    fontSize: FS_LG,
+    fontWeight: 700,
+    padding: 0,
+    outline: "none",
+  };
 }
 
 // ── ReplicasEditor ─────────────────────────────────────────────────────────
@@ -1181,8 +1215,7 @@ export function ReplicasEditor({
       String(parsed) !== edit.buffer.value.trim());
 
   const hasReady = ready !== undefined;
-  const ok = hasReady ? ready === desired && desired > 0 : true;
-  const statusColor = hasReady ? (ok ? t.good : ready === 0 ? t.bad : t.warn) : t.good;
+  const statusColor = readyDesiredColor(ready, desired, t);
 
   const handleDecrement = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1207,12 +1240,16 @@ export function ReplicasEditor({
         alignItems: "center",
         background: edit.editing ? t.bg : t.surfaceAlt,
         border: `1px solid ${invalid ? t.bad : isDirty ? t.warn : edit.editing ? t.border : t.borderSoft}`,
-        borderRadius: "20px",
+        borderRadius: R_PILL,
         padding: "3px 10px",
         gap: 8,
-        boxShadow: isDirty ? `0 0 8px ${t.warn}33` : edit.editing ? `0 0 6px ${t.borderSoft}` : "none",
-        transition: "all 0.2s ease-in-out",
-        height: 28,
+        boxShadow: isDirty
+          ? `0 0 8px ${hexWithAlpha(t.warn, 0.2)}`
+          : edit.editing
+            ? `0 0 6px ${t.borderSoft}`
+            : "none",
+        transition: "background .15s, border-color .15s, box-shadow .15s",
+        height: CONTROL_H,
         boxSizing: "border-box",
       }}
     >
@@ -1222,22 +1259,7 @@ export function ReplicasEditor({
             type="button"
             onClick={handleDecrement}
             disabled={edit.saving || parsed <= 0}
-            style={{
-              background: "transparent",
-              color: parsed <= 0 ? t.textDim : t.text,
-              border: "none",
-              width: 20,
-              height: 20,
-              borderRadius: "50%",
-              cursor: parsed <= 0 ? "not-allowed" : "pointer",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: "14px",
-              fontWeight: "bold",
-              padding: 0,
-              outline: "none",
-            }}
+            style={stepperBtnStyle(t, parsed <= 0)}
             title="Decrement replicas"
           >
             -
@@ -1269,6 +1291,7 @@ export function ReplicasEditor({
               fontFamily: FF_MONO,
               fontSize: FS_MD,
               fontWeight: 600,
+              fontVariantNumeric: "tabular-nums",
               background: "transparent",
               color: invalid ? t.bad : isDirty ? t.warn : t.text,
               border: "none",
@@ -1281,22 +1304,7 @@ export function ReplicasEditor({
             type="button"
             onClick={handleIncrement}
             disabled={edit.saving}
-            style={{
-              background: "transparent",
-              color: t.text,
-              border: "none",
-              width: 20,
-              height: 20,
-              borderRadius: "50%",
-              cursor: "pointer",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: "14px",
-              fontWeight: "bold",
-              padding: 0,
-              outline: "none",
-            }}
+            style={stepperBtnStyle(t, false)}
             title="Increment replicas"
           >
             +
@@ -1318,11 +1326,11 @@ export function ReplicasEditor({
                   cursor: "pointer",
                   display: "flex",
                   alignItems: "center",
-                  fontSize: 12,
+                  fontSize: FS_MD,
                   padding: 2,
                 }}
               >
-                ↺
+                {Icons.refresh}
               </button>
             )}
           </div>
@@ -1344,6 +1352,7 @@ export function ReplicasEditor({
               fontFamily: FF_MONO,
               fontSize: FS_MD,
               fontWeight: 600,
+              fontVariantNumeric: "tabular-nums",
               color: statusColor,
             }}
           >
@@ -1359,7 +1368,7 @@ export function ReplicasEditor({
               alignItems: "center",
               opacity: hovered ? 1 : 0,
               transform: hovered ? "translateX(0)" : "translateX(-2px)",
-              transition: "all 0.15s ease-in-out",
+              transition: "opacity .15s, transform .15s",
               color: t.textDim,
               marginLeft: 2,
             }}
@@ -1373,7 +1382,7 @@ export function ReplicasEditor({
               style={{
                 width: 6,
                 height: 6,
-                borderRadius: "50%",
+                borderRadius: R_PILL,
                 background: t.warn,
                 marginLeft: 2,
               }}
@@ -2469,15 +2478,17 @@ export function ImageEditor({
                 background: t.bg,
                 color: t.text,
                 border: `1px solid ${
-                  imageFocused ? (t.accent || "#10b981") : imageHovered ? t.border : t.borderSoft
+                  imageFocused ? t.accent : imageHovered ? t.border : t.borderSoft
                 }`,
                 borderRadius: R_SM,
                 fontFamily: FF_MONO,
                 fontSize: FS_MD,
                 outline: "none",
                 boxSizing: "border-box",
-                boxShadow: imageFocused ? `0 0 0 3px ${(t.accent || "#10b981")}33` : "none",
-                transition: "all 0.15s ease-in-out",
+                boxShadow: imageFocused
+                  ? `0 0 0 3px ${hexWithAlpha(t.accent, 0.2)}`
+                  : "none",
+                transition: "border-color .15s, box-shadow .15s, background .15s",
               }}
             />
           ) : image ? (
@@ -2524,7 +2535,7 @@ export function ImageEditor({
               style={{
                 fontFamily: FF_MONO,
                 fontSize: FS_MD,
-                height: 30,
+                height: CONTROL_H,
                 padding: "4px 28px 4px 8px",
                 width: "100%",
               }}

--- a/ui/src/components/detail/workload/shared.tsx
+++ b/ui/src/components/detail/workload/shared.tsx
@@ -5,7 +5,7 @@
 
 import { useMemo, useState } from "react";
 import { FF_MONO, type Tokens, R_LG, R_SM, FS_MD, FS_SM, FS_XS } from "../../../theme";
-import { Btn, Checkbox, Chip, Section, Select } from "../../ui";
+import { Btn, Checkbox, Chip, Section, Select, Icons } from "../../ui";
 import { ForwardChip } from "../forwardChip";
 import {
   KeyRefPicker,
@@ -1145,11 +1145,14 @@ export function ReplicaCounts({
 // Use it next to `ReplicaCounts` in each kind's header row.
 export function ReplicasEditor({
   t,
+  ready,
   desired,
 }: {
   t: Tokens;
+  ready?: number;
   desired: number;
 }) {
+  const [hovered, setHovered] = useState(false);
   const edit = useEditField<{ value: string }>({
     id: "replicas",
     initial: () => ({ value: String(desired) }),
@@ -1168,6 +1171,7 @@ export function ReplicasEditor({
         : null;
     },
   });
+
   const parsed = Number.parseInt(edit.buffer.value, 10);
   const invalid =
     edit.editing &&
@@ -1176,43 +1180,208 @@ export function ReplicasEditor({
       parsed < 0 ||
       String(parsed) !== edit.buffer.value.trim());
 
+  const hasReady = ready !== undefined;
+  const ok = hasReady ? ready === desired && desired > 0 : true;
+  const statusColor = hasReady ? (ok ? t.good : ready === 0 ? t.bad : t.warn) : t.good;
+
+  const handleDecrement = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const current = Number.isFinite(parsed) ? parsed : desired;
+    edit.setBuffer({ value: String(Math.max(0, current - 1)) });
+  };
+
+  const handleIncrement = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const current = Number.isFinite(parsed) ? parsed : desired;
+    edit.setBuffer({ value: String(current + 1) });
+  };
+
+  const isDirty = edit.dirty > 0;
+
   return (
-    <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
-      {edit.editing && (
-        <input
-          type="number"
-          min={0}
-          value={edit.buffer.value}
-          onChange={(e) => edit.setBuffer({ value: e.target.value })}
-          autoFocus
-          onKeyDown={(e) => {
-            if (e.key === "Escape") {
-              e.preventDefault();
-              edit.cancel();
-            }
-          }}
+    <div
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        background: edit.editing ? t.bg : t.surfaceAlt,
+        border: `1px solid ${invalid ? t.bad : isDirty ? t.warn : edit.editing ? t.border : t.borderSoft}`,
+        borderRadius: "20px",
+        padding: "3px 10px",
+        gap: 8,
+        boxShadow: isDirty ? `0 0 8px ${t.warn}33` : edit.editing ? `0 0 6px ${t.borderSoft}` : "none",
+        transition: "all 0.2s ease-in-out",
+        height: 28,
+        boxSizing: "border-box",
+      }}
+    >
+      {edit.editing ? (
+        <>
+          <button
+            type="button"
+            onClick={handleDecrement}
+            disabled={edit.saving || parsed <= 0}
+            style={{
+              background: "transparent",
+              color: parsed <= 0 ? t.textDim : t.text,
+              border: "none",
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              cursor: parsed <= 0 ? "not-allowed" : "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "14px",
+              fontWeight: "bold",
+              padding: 0,
+              outline: "none",
+            }}
+            title="Decrement replicas"
+          >
+            -
+          </button>
+
+          <input
+            type="text"
+            pattern="[0-9]*"
+            value={edit.buffer.value}
+            onChange={(e) => {
+              if (/^\d*$/.test(e.target.value)) {
+                edit.setBuffer({ value: e.target.value });
+              }
+            }}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                e.preventDefault();
+                edit.cancel();
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                e.currentTarget.blur();
+              }
+            }}
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              width: 32,
+              textAlign: "center",
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              background: "transparent",
+              color: invalid ? t.bad : isDirty ? t.warn : t.text,
+              border: "none",
+              outline: "none",
+              padding: 0,
+            }}
+          />
+
+          <button
+            type="button"
+            onClick={handleIncrement}
+            disabled={edit.saving}
+            style={{
+              background: "transparent",
+              color: t.text,
+              border: "none",
+              width: 20,
+              height: 20,
+              borderRadius: "50%",
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: "14px",
+              fontWeight: "bold",
+              padding: 0,
+              outline: "none",
+            }}
+            title="Increment replicas"
+          >
+            +
+          </button>
+
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{ display: "flex", alignItems: "center", gap: 4, marginLeft: 4 }}
+          >
+            {isDirty && (
+              <button
+                type="button"
+                onClick={() => edit.setBuffer({ value: String(desired) })}
+                title="Revert to original count"
+                style={{
+                  background: "transparent",
+                  color: t.warn,
+                  border: "none",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  fontSize: 12,
+                  padding: 2,
+                }}
+              >
+                ↺
+              </button>
+            )}
+          </div>
+        </>
+      ) : (
+        <div
+          onClick={() => edit.enter()}
           style={{
-            width: 56,
-            padding: "3px 6px",
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            background: t.bg,
-            color: t.text,
-            border: `1px solid ${invalid ? t.bad : t.borderSoft}`,
-            borderRadius: R_SM,
-            outline: "none",
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            cursor: "pointer",
+            userSelect: "none",
+            width: "100%",
           }}
-        />
+        >
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              color: statusColor,
+            }}
+          >
+            {hasReady ? `${ready} / ${desired}` : desired}
+          </span>
+          <span style={{ fontSize: FS_XS, color: t.textMuted }}>
+            replicas
+          </span>
+
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              opacity: hovered ? 1 : 0,
+              transform: hovered ? "translateX(0)" : "translateX(-2px)",
+              transition: "all 0.15s ease-in-out",
+              color: t.textDim,
+              marginLeft: 2,
+            }}
+          >
+            {Icons.pencil}
+          </span>
+
+          {isDirty && (
+            <span
+              title="Pending unsaved replicas change"
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: "50%",
+                background: t.warn,
+                marginLeft: 2,
+              }}
+            />
+          )}
+        </div>
       )}
-      <EditModeChrome
-        t={t}
-        editing={edit.editing}
-        dirty={edit.dirty}
-        saving={edit.saving}
-        onEnter={edit.enter}
-        onCancel={edit.cancel}
-      />
-    </span>
+    </div>
   );
 }
 
@@ -2192,36 +2361,13 @@ function ResourcesSide({
 // policy is bundled because the two read together. Pod's apiserver allows
 // image mutation on running Pods (the kubelet picks it up on the next
 // restart); other containers fields stay immutable on Pod.
-//
-// The two fields render in one DetailRow each in read mode (preserving the
-// existing layout) and share a single edit-mode chrome so the operator
-// commits both in one save.
+// The two fields render in one DetailRow each in read mode.
 
-type ImageFields = { image: string; image_pull_policy: string };
-
-const PULL_POLICY_OPTIONS = [
-  { value: "", label: "(default)" },
+export const PULL_POLICY_OPTIONS = [
   { value: "Always", label: "Always" },
   { value: "IfNotPresent", label: "IfNotPresent" },
   { value: "Never", label: "Never" },
-] as const;
-
-function imageBufferFrom(c: {
-  image: string | null;
-  image_pull_policy: string | null;
-}): ImageFields {
-  return {
-    image: c.image ?? "",
-    image_pull_policy: c.image_pull_policy ?? "",
-  };
-}
-
-function imageDirtyCount(b: ImageFields, orig: ImageFields): number {
-  let n = 0;
-  if (b.image !== orig.image) n += 1;
-  if (b.image_pull_policy !== orig.image_pull_policy) n += 1;
-  return n;
-}
+];
 
 export function ImageEditor({
   t,
@@ -2243,77 +2389,134 @@ export function ImageEditor({
     isInit: boolean;
   }) => Record<string, unknown>;
 }) {
-  const original = useMemo<ImageFields>(
-    () => imageBufferFrom({ image, image_pull_policy: imagePullPolicy }),
-    [image, imagePullPolicy],
-  );
-  const edit = useEditField<ImageFields>({
+  const session = useEditSession();
+
+  const originalImage = image ?? "";
+  const editImage = useEditField<{ value: string }>({
     id: `image:${containerName}`,
-    initial: () => original,
+    initial: () => ({ value: originalImage }),
     serialize: (b) => {
-      const co: {
-        name: string;
-        image?: string;
-        imagePullPolicy?: string;
-        isInit: boolean;
-      } = { name: containerName, isInit: containerKind === "init" || containerKind === "sidecar" };
-      // Only include fields the operator actually changed — keeps SSA
-      // ownership minimal.
-      if (b.image !== original.image) co.image = b.image;
-      if (b.image_pull_policy !== original.image_pull_policy) {
-        if (b.image_pull_policy !== "") co.imagePullPolicy = b.image_pull_policy;
-      }
+      const co = {
+        name: containerName,
+        image: b.value,
+        isInit: containerKind === "init" || containerKind === "sidecar",
+      };
       return serializeFor(co);
     },
-    dirtyCount: (b) => imageDirtyCount(b, original),
+    dirtyCount: (b) => (b.value !== originalImage ? 1 : 0),
   });
+
+  const originalPolicy = imagePullPolicy ?? "";
+  const editPolicy = useEditField<{ value: string }>({
+    id: `pull-policy:${containerName}`,
+    initial: () => ({ value: originalPolicy }),
+    serialize: (b) => {
+      const co = {
+        name: containerName,
+        imagePullPolicy: b.value,
+        isInit: containerKind === "init" || containerKind === "sidecar",
+      };
+      return serializeFor(co);
+    },
+    dirtyCount: (b) => (b.value !== originalPolicy ? 1 : 0),
+  });
+
+  const [imageHovered, setImageHovered] = useState(false);
+  const [imageFocused, setImageFocused] = useState(false);
+
+  const isImageEditable = !!session;
+  const isPolicyEditable = !!session;
+
+  const imageRight = isImageEditable ? (
+    <EditModeChrome
+      t={t}
+      editing={editImage.editing}
+      dirty={editImage.dirty}
+      saving={editImage.saving}
+      onEnter={editImage.enter}
+      onCancel={editImage.cancel}
+    />
+  ) : null;
+
+  const policyRight = isPolicyEditable ? (
+    <EditModeChrome
+      t={t}
+      editing={editPolicy.editing}
+      dirty={editPolicy.dirty}
+      saving={editPolicy.saving}
+      onEnter={editPolicy.enter}
+      onCancel={editPolicy.cancel}
+    />
+  ) : null;
 
   return (
     <>
       <DetailRow t={t} label="Image">
-        {edit.editing ? (
-          <div style={{ width: "100%" }}>
-            <EditableTextValue
-              t={t}
-              value={edit.buffer.image}
-              onChange={(v) => edit.setBuffer({ ...edit.buffer, image: v })}
-              placeholder="repo/image:tag"
-            />
-          </div>
-        ) : image ? (
-          <Copyable text={image}>
-            <span
+        <div style={{ width: "100%" }}>
+          {editImage.editing ? (
+            <input
+              type="text"
+              value={editImage.buffer.value}
+              onChange={(e) => editImage.setBuffer({ value: e.target.value })}
+              placeholder="e.g. nginx:latest"
+              onFocus={() => setImageFocused(true)}
+              onBlur={() => setImageFocused(false)}
+              onMouseEnter={() => setImageHovered(true)}
+              onMouseLeave={() => setImageHovered(false)}
               style={{
+                width: "100%",
+                padding: "5px 10px",
+                background: t.bg,
+                color: t.text,
+                border: `1px solid ${
+                  imageFocused ? (t.accent || "#10b981") : imageHovered ? t.border : t.borderSoft
+                }`,
+                borderRadius: R_SM,
                 fontFamily: FF_MONO,
-                fontSize: FS_SM,
-                wordBreak: "break-all",
+                fontSize: FS_MD,
+                outline: "none",
+                boxSizing: "border-box",
+                boxShadow: imageFocused ? `0 0 0 3px ${(t.accent || "#10b981")}33` : "none",
+                transition: "all 0.15s ease-in-out",
+              }}
+            />
+          ) : image ? (
+            <Copyable text={editImage.buffer.value}>
+              <span
+                style={{
+                  fontFamily: FF_MONO,
+                  fontSize: FS_SM,
+                  wordBreak: "break-all",
+                  color: editImage.dirty > 0 ? t.warn : t.text,
+                }}
+              >
+                {editImage.buffer.value}
+              </span>
+            </Copyable>
+          ) : (
+            <Mute t={t}>—</Mute>
+          )}
+          {imageRight && (
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                marginTop: editImage.editing ? 6 : 4,
               }}
             >
-              {image}
-            </span>
-          </Copyable>
-        ) : (
-          <Mute t={t}>—</Mute>
-        )}
+              {imageRight}
+            </div>
+          )}
+        </div>
       </DetailRow>
+
       <DetailRow t={t} label="ImagePullPolicy">
-        {edit.editing ? (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 8,
-              width: "100%",
-            }}
-          >
+        <div style={{ width: "100%" }}>
+          {editPolicy.editing ? (
             <Select<string>
               t={t}
-              fullWidth={false}
-              value={edit.buffer.image_pull_policy}
-              onChange={(v) =>
-                edit.setBuffer({ ...edit.buffer, image_pull_policy: v })
-              }
+              value={editPolicy.buffer.value}
+              onChange={(v) => editPolicy.setBuffer({ value: v })}
               options={PULL_POLICY_OPTIONS.map((o) => ({
                 value: o.value,
                 label: o.label,
@@ -2321,42 +2524,33 @@ export function ImageEditor({
               style={{
                 fontFamily: FF_MONO,
                 fontSize: FS_MD,
-                height: 28,
+                height: 30,
                 padding: "4px 28px 4px 8px",
+                width: "100%",
               }}
             />
-            <EditModeChrome
-              t={t}
-              editing={edit.editing}
-              dirty={edit.dirty}
-              saving={edit.saving}
-              onEnter={edit.enter}
-              onCancel={edit.cancel}
-              />
-          </div>
-        ) : (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 8,
-              width: "100%",
-            }}
-          >
-            <span style={{ fontSize: FS_MD }}>
-              {imagePullPolicy ?? <Mute t={t}>(default)</Mute>}
+          ) : (
+            <span
+              style={{
+                fontSize: FS_MD,
+                color: editPolicy.dirty > 0 ? t.warn : t.text,
+              }}
+            >
+              {editPolicy.buffer.value || <Mute t={t}>(default)</Mute>}
             </span>
-            <EditModeChrome
-              t={t}
-              editing={edit.editing}
-              dirty={edit.dirty}
-              saving={edit.saving}
-              onEnter={edit.enter}
-              onCancel={edit.cancel}
-              />
-          </div>
-        )}
+          )}
+          {policyRight && (
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                marginTop: editPolicy.editing ? 6 : 4,
+              }}
+            >
+              {policyRight}
+            </div>
+          )}
+        </div>
       </DetailRow>
     </>
   );

--- a/ui/src/components/settings/AiSection.tsx
+++ b/ui/src/components/settings/AiSection.tsx
@@ -12,7 +12,18 @@ import type {
   ProviderStatusWire,
   ReasoningEffort,
 } from "../../types";
-import { tokens, FF_MONO, type ThemeMode, type Tokens, R_LG, R_MD, FS_MD, FS_SM, FS_XS } from "../../theme";
+import {
+  tokens,
+  FF_MONO,
+  type ThemeMode,
+  type Tokens,
+  R_LG,
+  R_MD,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  hexWithAlpha,
+} from "../../theme";
 import { Btn, ErrorBlock, Field, SectionHeader, Select, Toggle } from "../ui";
 
 // AiSection — settings page tab for the cluster-aware AI agent. The
@@ -413,8 +424,8 @@ export function AiSection({}: { mode: ThemeMode }) {
           style={{
             marginTop: 12,
             padding: "8px 10px",
-            background: t.bad + "1f",
-            border: `1px solid ${t.bad}66`,
+            background: hexWithAlpha(t.bad, 0.12),
+            border: `1px solid ${hexWithAlpha(t.bad, 0.4)}`,
             borderRadius: R_MD,
           }}
         >
@@ -493,7 +504,7 @@ function ProviderRow({
         fontSize: FS_XS,
         fontFamily: FF_MONO,
         color: t.good,
-        background: t.good + "1a",
+        background: hexWithAlpha(t.good, 0.1),
         padding: "1px 6px",
         borderRadius: R_LG,
       }}
@@ -1331,8 +1342,8 @@ function McpTestResultChip({
         style={{
           marginLeft: 24,
           padding: "4px 8px",
-          background: t.good + "1f",
-          border: `1px solid ${t.good}66`,
+          background: hexWithAlpha(t.good, 0.12),
+          border: `1px solid ${hexWithAlpha(t.good, 0.4)}`,
           borderRadius: R_MD,
           color: t.good,
           fontFamily: FF_MONO,
@@ -1362,8 +1373,8 @@ function McpTestResultChip({
       style={{
         marginLeft: 24,
         padding: "4px 8px",
-        background: t.bad + "1f",
-        border: `1px solid ${t.bad}66`,
+        background: hexWithAlpha(t.bad, 0.12),
+        border: `1px solid ${hexWithAlpha(t.bad, 0.4)}`,
         borderRadius: R_MD,
         color: t.bad,
         fontFamily: FF_MONO,

--- a/ui/src/components/ui/atoms.test.tsx
+++ b/ui/src/components/ui/atoms.test.tsx
@@ -265,6 +265,119 @@ describe("ContainerDots", () => {
     );
     expect(dotColor).toHaveBeenCalled();
   });
+
+  it("Running + ready=false recolors the dot to warn (not good)", () => {
+    // We assert on background — the main shape is a solid disc, so the
+    // status colour shows up there. t.good vs t.warn are distinct hex.
+    const { container, rerender } = render(
+      <ContainerDots
+        t={t}
+        containers={[{ name: "m", status: "Running", kind: "main", ready: true }]}
+      />,
+    );
+    const goodDot = container.querySelector(
+      "span[style*='border-radius: 50%']",
+    ) as HTMLElement;
+    const goodBg = goodDot.style.background;
+
+    rerender(
+      <ContainerDots
+        t={t}
+        containers={[
+          { name: "m", status: "Running", kind: "main", ready: false },
+        ]}
+      />,
+    );
+    const warnDot = container.querySelector(
+      "span[style*='border-radius: 50%']",
+    ) as HTMLElement;
+    expect(warnDot.style.background).not.toBe(goodBg);
+    // Warn bucket pins to t.warn — jsdom normalises hex to rgb() so we
+    // convert the token before comparing.
+    const hex = t.warn.replace("#", "");
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    expect(warnDot.style.background).toBe(`rgb(${r}, ${g}, ${b})`);
+  });
+
+  it("layout order is init → sidecar → main with separators between groups", () => {
+    const { container } = render(
+      <ContainerDots
+        t={t}
+        containers={[
+          { name: "i", status: "Completed", kind: "init" },
+          { name: "s", status: "Running", kind: "sidecar" },
+          { name: "m", status: "Running", kind: "main" },
+        ]}
+      />,
+    );
+    // Children of the outer wrapper in order: init dot, sep, sidecar dot,
+    // sep, main dot. Tooltips wrap each dot in a span; separators are bare
+    // spans. We assert positional ordering via getBoundingClientRect's left.
+    const root = container.firstElementChild as HTMLElement;
+    const children = Array.from(root.children) as HTMLElement[];
+    // 3 dots + 2 separators = 5 immediate children. Tooltip wraps a Slot
+    // around the dot so the dot becomes the immediate child either way.
+    expect(children.length).toBe(5);
+    // The two 1-px separators have width:1px on their style attribute.
+    expect(children[1]!.style.width).toBe("1px");
+    expect(children[3]!.style.width).toBe("1px");
+  });
+
+  it("completed init dot is dimmed (opacity ~0.45)", () => {
+    const { container } = render(
+      <ContainerDots
+        t={t}
+        containers={[
+          { name: "i1", status: "Completed", kind: "init" },
+          { name: "i2", status: "Running", kind: "init" },
+        ]}
+      />,
+    );
+    // Init shape uses borderRadius: 2 — find both, the Completed one carries
+    // opacity 0.45, the Running one does not.
+    const initDots = Array.from(
+      container.querySelectorAll("span[style*='border-radius: 2px']"),
+    ) as HTMLElement[];
+    expect(initDots.length).toBe(2);
+    const opacities = initDots.map((el) => el.style.opacity);
+    expect(opacities).toContain("0.45");
+    expect(opacities).toContain("");
+  });
+
+  it("init and sidecar share thin geometry; radius separates them", () => {
+    const { container } = render(
+      <ContainerDots
+        t={t}
+        // size defaults to 8 → init and sidecar are both 6×10; main is 10×10.
+        containers={[
+          { name: "i", status: "Running", kind: "init" },
+          { name: "s", status: "Running", kind: "sidecar" },
+          { name: "m", status: "Running", kind: "main" },
+        ]}
+      />,
+    );
+    const dots = (
+      Array.from(
+        container.querySelectorAll("span[style*='display: inline-block']"),
+      ) as HTMLElement[]
+    ).filter((el) => el.style.width && el.style.width !== "1px"); // drop separators
+    expect(dots.length).toBe(3);
+    const [initDot, sidecarDot, mainDot] = dots;
+    // Init: 6×10, 2 px radius (square corners).
+    expect(initDot!.style.width).toBe("6px");
+    expect(initDot!.style.height).toBe("10px");
+    expect(initDot!.style.borderRadius).toBe("2px");
+    // Sidecar: 6×10, 6 px radius (full capsule).
+    expect(sidecarDot!.style.width).toBe("6px");
+    expect(sidecarDot!.style.height).toBe("10px");
+    expect(sidecarDot!.style.borderRadius).toBe("6px");
+    // Main: 10×10, 50% radius (disc).
+    expect(mainDot!.style.width).toBe("10px");
+    expect(mainDot!.style.height).toBe("10px");
+    expect(mainDot!.style.borderRadius).toBe("50%");
+  });
 });
 
 describe("LoadingLine", () => {

--- a/ui/src/components/ui/atoms.tsx
+++ b/ui/src/components/ui/atoms.tsx
@@ -1020,14 +1020,27 @@ export function SectionHeader({
 }
 
 // ── ContainerDots ──────────────────────────────────────────────────────────
-// Renders init/main/sidecar containers as a row of small shapes — square caps
-// for init, solid disc for main, ring for sidecar. Transient states pulse
-// (fs-pulse-dot) so the operator can see something is in motion. Mirrors
-// design/shared.jsx ContainerDots.
+// Renders init/sidecar/main containers as a row of small shapes — narrow
+// rounded-rectangle for init, narrow capsule for sidecar, solid disc for
+// main. Init and sidecar share footprint (thin + tall) but corners separate
+// them: init's small 2 px radius reads as "stepwise / discrete" while
+// sidecar's fully-round capsule reads as "persistent". The disc anchors the
+// row as the actual workload. Layout reads left→right in lifecycle order:
+// inits run first, sidecars start with them and persist, mains come last.
+// Separators flank the sidecar group when present so the persistent
+// (sidecar + main) and stepwise (init) regions are visually distinct.
+//
+// `ready` lets us catch the "Running but readiness-probe failing" case — a
+// solid green dot for a pod that isn't actually serving traffic is a known
+// footgun, so we downgrade those to the warn bucket. Completed init dots are
+// dimmed (they're chronological gutter, not active state).
+//
+// Transient states pulse (fs-pulse-dot) so the operator can see motion.
 export type ContainerLite = {
   name: string;
   status: string;
   kind?: "init" | "main" | "sidecar";
+  ready?: boolean;
 };
 
 export function ContainerDots({
@@ -1057,31 +1070,54 @@ export function ContainerDots({
     mains = containers.slice();
   }
 
-  const colorOf = (c: ContainerLite): string =>
-    dotColor ? dotColor(c) : statusDot(c.status, t);
+  const colorOf = (c: ContainerLite): string => {
+    if (dotColor) return dotColor(c);
+    // Running + readiness probe failing → warn, not good. A green dot for a
+    // pod the service has already cut out of the endpoint slice is the bug
+    // that prompted this whole pass.
+    if (c.status === "Running" && c.ready === false) return t.warn;
+    return statusDot(c.status, t);
+  };
 
   const dotFor = (c: ContainerLite, kind: "init" | "main" | "sidecar") => {
     const col = colorOf(c);
-    const w = kind === "main" ? size + 2 : size;
-    const h = w;
+    // Init + sidecar share a thin-and-tall footprint (size-2 × size+2); main
+    // is the largest (size+2 × size+2). Init and sidecar are distinguished
+    // by corner radius: init uses a literal 2 px (stepwise), sidecar uses a
+    // full capsule (persistent). At size=7 (table) → 5×9; at size=8 → 6×10;
+    // at size=9 (detail) → 7×11.
+    let w: number;
+    let h: number;
+    if (kind === "main") {
+      w = size + 2;
+      h = size + 2;
+    } else {
+      w = Math.max(4, size - 2);
+      h = size + 2;
+    }
     const base: CSSProperties = {
       width: w,
       height: h,
       flexShrink: 0,
       display: "inline-block",
     };
+    // Completed init dots are gutter, not active state — dim them so the
+    // currently-running init / sidecar / main stays the eye's anchor.
+    if (kind === "init" && c.status === "Completed") base.opacity = 0.45;
     if (kind === "init")
-      // Init container is intentionally a near-square "cap" to read as
-      // distinct from the round main / ringed sidecar shapes. Keep a
-      // literal small radius — theme radius scales would turn the 8×8
-      // square into a circle under Readable's 6 px radius.
+      // Literal 2 px radius (not theme radius) — theme radius scales would
+      // round Readable's 6 px radius into a near-capsule and erase the
+      // shape distinction from sidecar.
       return { ...base, borderRadius: 2, background: col };
     if (kind === "sidecar")
       return {
         ...base,
-        borderRadius: "50%",
-        background: "transparent",
-        boxShadow: `inset 0 0 0 1.5px ${col}`,
+        // borderRadius = w (≥ h/2) gives a pure capsule at any (w, h).
+        borderRadius: w,
+        background: col,
+        // Match the main dot's subtle inset ring so the capsule reads as
+        // part of the same shape family, not a flat sticker.
+        boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.18)",
       };
     return {
       ...base,
@@ -1101,6 +1137,32 @@ export function ContainerDots({
   const tip = (kind: "init" | "main" | "sidecar", c: ContainerLite) =>
     `${kind}: ${c.name} — ${c.status}`;
 
+  const sep = (key: string) => (
+    <span
+      key={key}
+      style={{
+        display: "inline-block",
+        width: 1,
+        height: size + 2,
+        background: t.border,
+        margin: `0 ${gap + 1}px`,
+        verticalAlign: "middle",
+      }}
+    />
+  );
+
+  // Layout: [init squares] | [sidecar rings] | [main discs]. Sidecars are
+  // declared in spec.initContainers (restartPolicy=Always) and start with the
+  // init group, so they belong adjacent to it — but they persist alongside
+  // main, so they sit between. Separators bracket the sidecar group when both
+  // its neighbours are present.
+  const sidecarLeftSep = showSeparator && inits.length > 0 && sidecars.length > 0;
+  const sidecarRightSep =
+    showSeparator && sidecars.length > 0 && mains.length > 0;
+  // Edge case: inits + mains but no sidecars — one separator between them.
+  const initMainSep =
+    showSeparator && inits.length > 0 && sidecars.length === 0 && mains.length > 0;
+
   return (
     <span
       style={{
@@ -1116,49 +1178,19 @@ export function ContainerDots({
           <span className={className(c)} style={dotFor(c, "init")} />
         </Tooltip>
       ))}
-      {showSeparator && inits.length > 0 && (
-        <span
-          style={{
-            display: "inline-block",
-            width: 1,
-            height: size + 2,
-            background: t.border,
-            margin: `0 ${gap + 1}px`,
-            verticalAlign: "middle",
-          }}
-        />
-      )}
-      {mains.length > 0 && (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap,
-          }}
-        >
-          {mains.map((c, i) => (
-            <Tooltip key={`m${i}`} label={tip("main", c)}>
-              <span className={className(c)} style={dotFor(c, "main")} />
-            </Tooltip>
-          ))}
-        </span>
-      )}
-      {sidecars.length > 0 && (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap,
-            marginLeft: 1,
-          }}
-        >
-          {sidecars.map((c, i) => (
-            <Tooltip key={`s${i}`} label={tip("sidecar", c)}>
-              <span className={className(c)} style={dotFor(c, "sidecar")} />
-            </Tooltip>
-          ))}
-        </span>
-      )}
+      {sidecarLeftSep && sep("sep-i-s")}
+      {initMainSep && sep("sep-i-m")}
+      {sidecars.map((c, i) => (
+        <Tooltip key={`s${i}`} label={tip("sidecar", c)}>
+          <span className={className(c)} style={dotFor(c, "sidecar")} />
+        </Tooltip>
+      ))}
+      {sidecarRightSep && sep("sep-s-m")}
+      {mains.map((c, i) => (
+        <Tooltip key={`m${i}`} label={tip("main", c)}>
+          <span className={className(c)} style={dotFor(c, "main")} />
+        </Tooltip>
+      ))}
     </span>
   );
 }

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -46,6 +46,15 @@ export const FS_XL = "var(--fs-fs-xl, 16px)";
 export const R_SM = "var(--fs-radius-sm, 4px)";
 export const R_MD = "var(--fs-radius-md, 6px)";
 export const R_LG = "var(--fs-radius-lg, 10px)";
+// Sentinel for pill / circle silhouettes — the value is intentionally
+// theme-independent (sharp-corner themes like VS Code still want their
+// inline-stepper pill rounded), so it isn't published as a CSS var.
+export const R_PILL = "999px";
+
+// Control height comes from the active theme's `sizing.controlHeight` —
+// App.tsx publishes it as `--fs-control-h`. The literal fallback matches
+// the Default theme so renders before App-mount stay sane.
+export const CONTROL_H = "var(--fs-control-h, 28px)";
 
 export type ThemeMode = "light" | "dark";
 
@@ -983,6 +992,35 @@ export function statusDot(status: string, t: Tokens): string {
   }
 }
 
+// Bucket for a `ready / desired` ratio (replicas, partition progress, …).
+// Kept here so every surface that renders "x / y" uses the same rules:
+// all-ready+non-zero → good, none-ready → bad, partial → warn, no signal
+// (desired === 0, ready unknown) → good (nothing to do).
+export type ReadyDesiredBucket = "good" | "warn" | "bad";
+export function readyDesiredBucket(
+  ready: number | undefined,
+  desired: number,
+): ReadyDesiredBucket {
+  if (ready === undefined) return "good";
+  if (ready === 0 && desired > 0) return "bad";
+  if (ready === desired && desired > 0) return "good";
+  return "warn";
+}
+export function readyDesiredColor(
+  ready: number | undefined,
+  desired: number,
+  t: Tokens,
+): string {
+  switch (readyDesiredBucket(ready, desired)) {
+    case "good":
+      return t.good;
+    case "warn":
+      return t.warn;
+    case "bad":
+      return t.bad;
+  }
+}
+
 // Pill background + foreground for a status — softer than the dot.
 //
 // Both `bg` and `fg` derive from the active palette's bucket color, so a
@@ -1022,8 +1060,10 @@ export function statusFill(
 /// Append an alpha channel to a hex / rgb-ish color. Tolerates `#rrggbb`,
 /// `#rgb`, and `rgb(...)` / `rgba(...)` inputs. Falls back to the input
 /// itself if the shape is unfamiliar (palette authors can paste anything
-/// reasonable and the pill stays usable).
-function hexWithAlpha(color: string, alpha: number): string {
+/// reasonable and the pill stays usable). Exported so per-component
+/// glows / shadows can ride the active palette instead of hardcoding an
+/// `${t.warn}33` string-concat that breaks for non-hex palettes.
+export function hexWithAlpha(color: string, alpha: number): string {
   const a = Math.max(0, Math.min(1, alpha));
   const rgb = toRgb(color);
   if (!rgb) return color;


### PR DESCRIPTION
… decouple container image editor

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
