### PR TITLE
fix(ui): position fixed portals correctly under UI scale

### DIFF
--- a/ui/src/components/ContextMenu.tsx
+++ b/ui/src/components/ContextMenu.tsx
@@ -6,6 +6,7 @@ import {
   type CSSProperties,
 } from "react";
 import { tokens, FF_MONO, type ThemeMode, R_LG, FS_MD, FS_XS } from "../theme";
+import { placeMenuAtCursor, rootZoom } from "../lib/zoom";
 
 import { useResolvedTheme } from "../store";
 export type MenuItem =
@@ -39,11 +40,16 @@ export function ContextMenu({ mode, position, items, onClose, rowName }: Props) 
     const el = ref.current;
     if (!el) return;
     const r = el.getBoundingClientRect();
-    let { x, y } = position;
-    if (x + r.width > window.innerWidth - 4) x = window.innerWidth - r.width - 4;
-    if (y + r.height > window.innerHeight - 4)
-      y = window.innerHeight - r.height - 4;
-    setAdjusted({ x: Math.max(4, x), y: Math.max(4, y) });
+    // cursor, menu rect and viewport are all visual px; placeMenuAtCursor
+    // clamps in that space and divides the result by zoom for the fixed style.
+    setAdjusted(
+      placeMenuAtCursor(
+        position,
+        { width: r.width, height: r.height },
+        { width: window.innerWidth, height: window.innerHeight },
+        rootZoom(),
+      ),
+    );
   }, [position]);
 
   useEffect(() => {

--- a/ui/src/components/ui/Tooltip.tsx
+++ b/ui/src/components/ui/Tooltip.tsx
@@ -13,8 +13,7 @@ import {
 import { createPortal } from "react-dom";
 import { FF_MONO, type ThemeMode, R_MD, R_SM, FS_SM, FS_XS } from "../../theme";
 import { useAppStore, useResolvedTheme } from "../../store";
-
-type Side = "top" | "bottom" | "left" | "right";
+import { placeTooltip, fixedRectScale, type Side } from "../../lib/zoom";
 
 type TooltipProps = {
   label: ReactNode;
@@ -66,39 +65,19 @@ export function Tooltip({
     if (!trig || !tip) return;
     const tr = trig.getBoundingClientRect();
     const r = tip.getBoundingClientRect();
-    const gap = 8;
-    const margin = 6;
-
-    const placements: Record<Side, { x: number; y: number }> = {
-      top: { x: tr.left + tr.width / 2 - r.width / 2, y: tr.top - r.height - gap },
-      bottom: {
-        x: tr.left + tr.width / 2 - r.width / 2,
-        y: tr.bottom + gap,
-      },
-      left: { x: tr.left - r.width - gap, y: tr.top + tr.height / 2 - r.height / 2 },
-      right: { x: tr.right + gap, y: tr.top + tr.height / 2 - r.height / 2 },
-    };
-
-    const fits = (s: Side) => {
-      const p = placements[s];
-      return (
-        p.x >= margin &&
-        p.y >= margin &&
-        p.x + r.width <= window.innerWidth - margin &&
-        p.y + r.height <= window.innerHeight - margin
-      );
-    };
-    const flipMap: Record<Side, Side> = {
-      top: "bottom",
-      bottom: "top",
-      left: "right",
-      right: "left",
-    };
-    const chosen: Side = fits(side) ? side : fits(flipMap[side]) ? flipMap[side] : side;
-    let { x, y } = placements[chosen];
-    x = Math.max(margin, Math.min(x, window.innerWidth - r.width - margin));
-    y = Math.max(margin, Math.min(y, window.innerHeight - r.height - margin));
-    setPos({ x, y, placedSide: chosen });
+    // tr/r/innerWidth and the fixed tip share whatever space the engine reports
+    // rects in; fixedRectScale() measures the rect→fixed conversion so the tip
+    // lands on the trigger after the root repaints it × zoom — correct whether
+    // the engine reports rects in visual or unzoomed px.
+    setPos(
+      placeTooltip(
+        tr,
+        { width: r.width, height: r.height },
+        side,
+        { width: window.innerWidth, height: window.innerHeight },
+        fixedRectScale(),
+      ),
+    );
   }, [side]);
 
   useLayoutEffect(() => {

--- a/ui/src/components/ui/atoms.tsx
+++ b/ui/src/components/ui/atoms.tsx
@@ -23,6 +23,7 @@ import {
   type Tokens,
 } from "../../theme";
 import { useAppStore } from "../../store";
+import { placeSelectPopover, fixedRectScale } from "../../lib/zoom";
 import { Tooltip } from "./Tooltip";
 
 // ── Eyebrow ────────────────────────────────────────────────────────────────
@@ -558,26 +559,18 @@ export function Select<V extends string | number>({
     const trig = triggerRef.current;
     if (!trig) return;
     const r = trig.getBoundingClientRect();
-    const margin = 8;
-    const gap = 4;
-    const below = window.innerHeight - r.bottom - margin;
-    const above = r.top - margin;
-    const flipUp = below < 200 && above > below;
-    const maxH = Math.max(120, Math.min(360, flipUp ? above - gap : below - gap));
-    const desiredW = Math.max(r.width, popoverMinWidth ?? 0);
-    const maxW = window.innerWidth - margin * 2;
-    const w = Math.min(desiredW, maxW);
-    let x = r.left;
-    if (x + w > window.innerWidth - margin) {
-      x = Math.max(margin, window.innerWidth - margin - w);
-    }
-    // Up: anchor by viewport-from-bottom so the popover bottom hugs the
-    // trigger top no matter how tall it actually renders. Down: top-anchor
-    // just below the trigger.
-    const y = flipUp
-      ? window.innerHeight - r.top + gap
-      : r.bottom + gap;
-    setPop({ x, y, w, maxH, flipUp });
+    // r/innerWidth and the fixed popover share whatever space the engine
+    // reports rects in; fixedRectScale() measures the rect→fixed conversion so
+    // the popover lands on the trigger after the root repaints it × zoom —
+    // correct whether the engine reports rects in visual or unzoomed px.
+    setPop(
+      placeSelectPopover(
+        r,
+        { width: window.innerWidth, height: window.innerHeight },
+        { popoverMinWidth },
+        fixedRectScale(),
+      ),
+    );
   }, [popoverMinWidth]);
 
   useLayoutEffect(() => {

--- a/ui/src/lib/zoom.test.ts
+++ b/ui/src/lib/zoom.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  rootZoom,
+  fixedRectScale,
+  resetFixedRectScaleCache,
+  placeMenuAtCursor,
+  placeSelectPopover,
+  placeTooltip,
+  type Rect,
+} from "./zoom";
+
+// A fixed portal under `documentElement.style.zoom` is repainted × zoom, while
+// the inputs (getBoundingClientRect / clientX / innerWidth) are visual px. Each
+// helper does its math in visual px, then divides emitted coordinates by zoom
+// so the painted portal lands back at the intended visual geometry.
+
+afterEach(() => {
+  document.documentElement.style.zoom = "";
+  resetFixedRectScaleCache();
+  vi.restoreAllMocks();
+});
+
+describe("rootZoom", () => {
+  it("returns 1 when zoom is unset", () => {
+    expect(rootZoom()).toBe(1);
+  });
+  it("parses the applied zoom", () => {
+    document.documentElement.style.zoom = "1.1";
+    expect(rootZoom()).toBeCloseTo(1.1, 5);
+  });
+  it("falls back to 1 for non-positive / unparseable values", () => {
+    document.documentElement.style.zoom = "0";
+    expect(rootZoom()).toBe(1);
+    document.documentElement.style.zoom = "nonsense";
+    expect(rootZoom()).toBe(1);
+  });
+});
+
+describe("fixedRectScale", () => {
+  // Stub how the engine reports a fixed element's width. The probe sets
+  // width:1000px; the ratio is reportedWidth / 1000.
+  function stubProbeWidth(reported: number) {
+    vi.spyOn(HTMLDivElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: reported,
+      height: 0,
+      top: 0,
+      left: 0,
+      right: reported,
+      bottom: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+  }
+
+  it("falls back to rootZoom when the probe can't be measured (jsdom → 0)", () => {
+    document.documentElement.style.zoom = "1.1";
+    // jsdom reports 0-size rects; ratio is unmeasurable → fall back to zoom.
+    expect(fixedRectScale()).toBeCloseTo(1.1, 5);
+  });
+
+  it("returns the paint zoom on engines that report rects in visual px", () => {
+    document.documentElement.style.zoom = "1.1";
+    stubProbeWidth(1000 * 1.1); // visual: 1000css × 1.1 paint, reported as visual
+    expect(fixedRectScale()).toBeCloseTo(1.1, 5);
+  });
+
+  it("returns 1 on engines that report rects unzoomed", () => {
+    document.documentElement.style.zoom = "1.1";
+    stubProbeWidth(1000); // unzoomed: reported as the css px we set
+    expect(fixedRectScale()).toBeCloseTo(1, 5);
+  });
+
+  it("caches per zoom value", () => {
+    document.documentElement.style.zoom = "1.2";
+    const spy = vi
+      .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({ width: 1200, height: 0 } as DOMRect);
+    expect(fixedRectScale()).toBeCloseTo(1.2, 5); // 1200 / 1000
+    expect(fixedRectScale()).toBeCloseTo(1.2, 5);
+    expect(spy).toHaveBeenCalledTimes(1); // second call served from cache
+  });
+});
+
+describe("placeMenuAtCursor", () => {
+  const menu = { width: 210, height: 120 };
+  const viewport = { width: 1000, height: 800 };
+
+  it("passes the cursor through unchanged at zoom 1", () => {
+    expect(placeMenuAtCursor({ x: 300, y: 200 }, menu, viewport, 1)).toEqual({
+      x: 300,
+      y: 200,
+    });
+  });
+
+  it("divides the visual cursor by zoom so the repaint lands on it", () => {
+    // Visual cursor (330, 220) under zoom 1.1 → fixed (300, 200); the root
+    // repaints × 1.1 → back to (330, 220) visual.
+    const p = placeMenuAtCursor({ x: 330, y: 220 }, menu, viewport, 1.1);
+    expect(p.x).toBeCloseTo(300, 5);
+    expect(p.y).toBeCloseTo(200, 5);
+  });
+
+  it("clamps to the right/bottom edge in visual space before dividing", () => {
+    // Visual: x 980 + 210 > 996 → 786; y 780 + 120 > 796 → 676. Then / 1.1.
+    const p = placeMenuAtCursor({ x: 980, y: 780 }, menu, viewport, 1.1);
+    expect(p.x).toBeCloseTo(786 / 1.1, 5);
+    expect(p.y).toBeCloseTo(676 / 1.1, 5);
+  });
+
+  it("keeps a 4px visual margin at the top-left", () => {
+    const p = placeMenuAtCursor({ x: 0, y: 0 }, menu, viewport, 1.1);
+    expect(p.x).toBeCloseTo(4 / 1.1, 5);
+    expect(p.y).toBeCloseTo(4 / 1.1, 5);
+  });
+});
+
+describe("placeSelectPopover", () => {
+  const viewport = { width: 1000, height: 800 };
+  const trigger: Rect = {
+    left: 200,
+    right: 360,
+    top: 100,
+    bottom: 124,
+    width: 160,
+    height: 24,
+  };
+
+  it("anchors below the trigger and matches its width at zoom 1", () => {
+    const p = placeSelectPopover(trigger, viewport, {}, 1);
+    expect(p.flipUp).toBe(false);
+    expect(p.x).toBe(200);
+    expect(p.y).toBe(124 + 4); // bottom + gap
+    expect(p.w).toBe(160);
+  });
+
+  it("divides x/y/w/maxH by zoom so the fixed popover lands on the trigger", () => {
+    const p = placeSelectPopover(trigger, viewport, {}, 1.1);
+    expect(p.x).toBeCloseTo(200 / 1.1, 5);
+    expect(p.y).toBeCloseTo(128 / 1.1, 5);
+    expect(p.w).toBeCloseTo(160 / 1.1, 5);
+    // maxH = clamp(800 - 124 - 8 - 4, 120, 360) = 360, then / zoom.
+    expect(p.maxH).toBeCloseTo(360 / 1.1, 5);
+  });
+
+  it("flips up when there is little room below, anchoring from the bottom", () => {
+    const low: Rect = { ...trigger, top: 720, bottom: 744 };
+    const p = placeSelectPopover(low, viewport, {}, 1);
+    expect(p.flipUp).toBe(true);
+    // y = innerHeight - top + gap = 800 - 720 + 4 (distance from viewport bottom)
+    expect(p.y).toBe(84);
+  });
+
+  it("honours popoverMinWidth and clamps x within the viewport", () => {
+    const nearRight: Rect = { ...trigger, left: 900, right: 960, width: 60 };
+    const p = placeSelectPopover(nearRight, viewport, { popoverMinWidth: 300 }, 1);
+    expect(p.w).toBe(300);
+    // 900 + 300 > 992 → x = 1000 - 8 - 300 = 692
+    expect(p.x).toBe(692);
+  });
+});
+
+describe("placeTooltip", () => {
+  const viewport = { width: 1000, height: 800 };
+  const trigger: Rect = {
+    left: 400,
+    right: 440,
+    top: 300,
+    bottom: 320,
+    width: 40,
+    height: 20,
+  };
+  const tip = { width: 100, height: 30 };
+
+  it("centers below the trigger for side=bottom at zoom 1", () => {
+    const p = placeTooltip(trigger, tip, "bottom", viewport, 1);
+    expect(p.placedSide).toBe("bottom");
+    expect(p.x).toBe(400 + 20 - 50); // center - tip/2
+    expect(p.y).toBe(320 + 8); // bottom + gap
+  });
+
+  it("divides the result by zoom", () => {
+    const p = placeTooltip(trigger, tip, "bottom", viewport, 1.1);
+    expect(p.x).toBeCloseTo(370 / 1.1, 5);
+    expect(p.y).toBeCloseTo(328 / 1.1, 5);
+  });
+
+  it("flips to bottom when top does not fit", () => {
+    const high: Rect = { ...trigger, top: 10, bottom: 30 };
+    const p = placeTooltip(high, tip, "top", viewport, 1);
+    expect(p.placedSide).toBe("bottom");
+  });
+});

--- a/ui/src/lib/zoom.ts
+++ b/ui/src/lib/zoom.ts
@@ -1,0 +1,200 @@
+// Positioning helpers for `position: fixed` portals under the global UI scale.
+//
+// App.tsx applies the UI scale as `document.documentElement.style.zoom`
+// (= uiScale * UI_SCALE_BASELINE; baseline 1.1, so the default is already
+// >1.0). A `position: fixed` portal is a descendant of that zoomed root, so the
+// browser repaints its `top/left/width/height` coordinates × zoom (the "paint
+// scale", which is exactly the numeric `style.zoom`).
+//
+// The inputs we measure from are reported differently per engine:
+//   - `clientX/clientY` (the mouse) are *visual* (post-zoom) px on every engine.
+//   - `getBoundingClientRect()` / `innerWidth` are visual on WebKitGTK (Linux)
+//     and modern Blink/WebView2, but the MetricsTab notes that macOS WebKit can
+//     report them *unzoomed*. So we can't assume rect == visual everywhere.
+//
+// The rule these helpers enforce: do all placement math in the same space the
+// inputs come in, then divide every coordinate written to the fixed portal by
+// the appropriate scale so the portal lands where intended once the root
+// repaints it × zoom:
+//   - cursor-anchored menus divide by the *paint scale* (`rootZoom()`), because
+//     the cursor is visual on all engines.
+//   - trigger-anchored menus divide by the *measured rect scale*
+//     (`fixedRectScale()`), which self-calibrates: it equals the paint scale on
+//     engines that report rects in visual px, and 1 where rects are unzoomed.
+//
+// Pure placement fns take the scale as a parameter so they stay testable; the
+// React call sites pass `rootZoom()` or `fixedRectScale()` as appropriate.
+
+export type Point = { x: number; y: number };
+export type Size = { width: number; height: number };
+export type Side = "top" | "bottom" | "left" | "right";
+
+export type Rect = {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+};
+
+// Active root zoom (paint scale). Falls back to 1 when unset / unparseable
+// (jsdom in tests, first paint before App.tsx writes it).
+export function rootZoom(): number {
+  const z = Number.parseFloat(document.documentElement.style.zoom || "");
+  return Number.isFinite(z) && z > 0 ? z : 1;
+}
+
+// Measured ratio between what `getBoundingClientRect()` reports for a
+// `position: fixed` element and the CSS px we set on it. This is the divisor
+// trigger-anchored portals need, and it works regardless of whether the engine
+// reports rects in visual px (ratio == paint zoom) or unzoomed px (ratio == 1)
+// — because the probe is measured the exact same way the real triggers are.
+//
+// Cached per zoom value (the ratio only changes when the scale changes); call
+// `resetFixedRectScaleCache()` in tests. Falls back to `rootZoom()` when the
+// probe can't be measured (jsdom reports 0-size rects).
+const PROBE_PX = 1000;
+let probeCache: { key: string; value: number } | null = null;
+
+export function resetFixedRectScaleCache(): void {
+  probeCache = null;
+}
+
+export function fixedRectScale(): number {
+  const key = document.documentElement.style.zoom || "";
+  if (probeCache && probeCache.key === key) return probeCache.value;
+  let value = rootZoom();
+  const body = document.body;
+  if (body) {
+    const probe = document.createElement("div");
+    probe.style.position = "fixed";
+    probe.style.left = "0";
+    probe.style.top = "0";
+    probe.style.width = `${PROBE_PX}px`;
+    probe.style.height = "0";
+    probe.style.visibility = "hidden";
+    probe.style.pointerEvents = "none";
+    body.appendChild(probe);
+    const measured = probe.getBoundingClientRect().width;
+    body.removeChild(probe);
+    if (Number.isFinite(measured) && measured > 0) value = measured / PROBE_PX;
+  }
+  probeCache = { key, value };
+  return value;
+}
+
+// Cursor-anchored menu (right-click ContextMenu). `cursor` is the visual-px
+// clientX/clientY; `menu` and `viewport` are visual px. Returns the fixed-layer
+// top/left in pre-zoom px, clamped 4px inside the viewport.
+export function placeMenuAtCursor(
+  cursor: Point,
+  menu: Size,
+  viewport: Size,
+  scale: number,
+): Point {
+  const m = 4;
+  let x = cursor.x;
+  let y = cursor.y;
+  if (x + menu.width > viewport.width - m) x = viewport.width - menu.width - m;
+  if (y + menu.height > viewport.height - m) y = viewport.height - menu.height - m;
+  x = Math.max(m, x);
+  y = Math.max(m, y);
+  return { x: x / scale, y: y / scale };
+}
+
+export type SelectPlacement = {
+  x: number;
+  y: number;
+  w: number;
+  maxH: number;
+  flipUp: boolean;
+};
+
+// Trigger-anchored dropdown (Select). `trigger` and `viewport` are visual px.
+// `flipUp` anchors the popover bottom to the trigger top (style `bottom`),
+// otherwise the popover top hangs below the trigger (style `top`). All emitted
+// pixel values (x, y, w, maxH) are pre-zoom px ready for the fixed style.
+export function placeSelectPopover(
+  trigger: Rect,
+  viewport: Size,
+  opts: { popoverMinWidth?: number },
+  scale: number,
+): SelectPlacement {
+  const margin = 8;
+  const gap = 4;
+  const below = viewport.height - trigger.bottom - margin;
+  const above = trigger.top - margin;
+  const flipUp = below < 200 && above > below;
+  const maxH = Math.max(120, Math.min(360, flipUp ? above - gap : below - gap));
+  const desiredW = Math.max(trigger.width, opts.popoverMinWidth ?? 0);
+  const maxW = viewport.width - margin * 2;
+  const w = Math.min(desiredW, maxW);
+  let x = trigger.left;
+  if (x + w > viewport.width - margin) {
+    x = Math.max(margin, viewport.width - margin - w);
+  }
+  // Up: distance from the viewport bottom to the popover bottom edge. Down:
+  // popover top edge just under the trigger.
+  const y = flipUp ? viewport.height - trigger.top + gap : trigger.bottom + gap;
+  return {
+    x: x / scale,
+    y: y / scale,
+    w: w / scale,
+    maxH: maxH / scale,
+    flipUp,
+  };
+}
+
+// Trigger-anchored tooltip. `trigger`, `tip` and `viewport` are visual px.
+// Picks the requested `side`, flips to the opposite side if it doesn't fit,
+// then clamps. Returns the fixed-layer top/left in pre-zoom px plus the side
+// actually used (for the caller's arrow / styling).
+export function placeTooltip(
+  trigger: Rect,
+  tip: Size,
+  side: Side,
+  viewport: Size,
+  scale: number,
+): { x: number; y: number; placedSide: Side } {
+  const gap = 8;
+  const margin = 6;
+  const placements: Record<Side, Point> = {
+    top: {
+      x: trigger.left + trigger.width / 2 - tip.width / 2,
+      y: trigger.top - tip.height - gap,
+    },
+    bottom: {
+      x: trigger.left + trigger.width / 2 - tip.width / 2,
+      y: trigger.bottom + gap,
+    },
+    left: {
+      x: trigger.left - tip.width - gap,
+      y: trigger.top + trigger.height / 2 - tip.height / 2,
+    },
+    right: {
+      x: trigger.right + gap,
+      y: trigger.top + trigger.height / 2 - tip.height / 2,
+    },
+  };
+  const fits = (s: Side) => {
+    const p = placements[s];
+    return (
+      p.x >= margin &&
+      p.y >= margin &&
+      p.x + tip.width <= viewport.width - margin &&
+      p.y + tip.height <= viewport.height - margin
+    );
+  };
+  const flipMap: Record<Side, Side> = {
+    top: "bottom",
+    bottom: "top",
+    left: "right",
+    right: "left",
+  };
+  const chosen: Side = fits(side) ? side : fits(flipMap[side]) ? flipMap[side] : side;
+  let { x, y } = placements[chosen];
+  x = Math.max(margin, Math.min(x, viewport.width - tip.width - margin));
+  y = Math.max(margin, Math.min(y, viewport.height - tip.height - margin));
+  return { x: x / scale, y: y / scale, placedSide: chosen };
+}


### PR DESCRIPTION
The global UI scale is applied as `documentElement.style.zoom`, so a `position: fixed` portal (a descendant of the zoomed root) gets repainted × zoom. The cursor menu, Select dropdown and Tooltip fed visual-px coordinates straight into their fixed styles, which the root then scaled a second time — landing them drifted down/right by `coord × (zoom - 1)`, visible because the baseline scale is already 1.1×.

Centralise the placement math in `lib/zoom.ts` (pure, tested helpers) and divide every coordinate written to a fixed portal by the right scale:
- cursor-anchored ContextMenu divides by the paint zoom (`rootZoom()`), since clientX/clientY are visual on every engine.
- trigger-anchored Select/Tooltip divide by `fixedRectScale()`, a runtime probe that measures the rect→fixed conversion. It self-calibrates to the paint zoom where getBoundingClientRect reports visual px (WebKitGTK, Blink) and to 1 where it reports unzoomed px (macOS WebKit) — correct across platforms without per-engine assumptions.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
