### PR TITLE
Feat/mcp transports and tool output spool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1709,6 +1709,7 @@ dependencies = [
  "futures",
  "pretty_assertions",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -13,6 +13,10 @@ workspace = true
 [dev-dependencies]
 tokio-test.workspace = true
 pretty_assertions.workspace = true
+# Transport tests build a reqwest client, which needs a process-global rustls
+# crypto provider installed (the binary does this in main.rs). Tests install
+# `ring` themselves via this dev-dep.
+rustls.workspace = true
 
 [dependencies]
 tokio.workspace = true

--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -173,10 +173,40 @@ impl ReasoningSettings {
     }
 }
 
+/// How FerrisScope connects to an MCP server. Mirrors the `type` field in
+/// Claude Desktop / Cursor configs so JSON copy-pastes between tools.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpTransport {
+    /// Spawn `command` as a subprocess and talk JSON-RPC over its
+    /// stdin/stdout. The default and the only transport that uses
+    /// `command` / `args` / `env`.
+    #[default]
+    Stdio,
+    /// Legacy HTTP+SSE transport (MCP 2024-11-05): GET `url` for a
+    /// Server-Sent Events stream, POST requests to the `endpoint` URL the
+    /// server advertises on that stream.
+    Sse,
+    /// Streamable HTTP transport (MCP 2025-03-26): POST JSON-RPC to `url`;
+    /// each response is either a JSON body or an SSE stream. Session is
+    /// carried in the `Mcp-Session-Id` header.
+    Http,
+}
+
+impl McpTransport {
+    /// `true` for the network transports (`sse` / `http`) that connect to a
+    /// `url` rather than spawning a local `command`.
+    #[must_use]
+    pub fn is_remote(self) -> bool {
+        matches!(self, Self::Sse | Self::Http)
+    }
+}
+
 /// One operator-configured external MCP-protocol server. Each entry produces
-/// a separate child process per chat; their tool catalogues are merged with
-/// the native toolkit. The shape mirrors `mcpServers` in Claude Desktop /
-/// Cursor / similar tools so the JSON copy-pastes between them.
+/// a separate connection per chat (a subprocess for `stdio`, an HTTP client
+/// for `sse` / `http`); their tool catalogues are merged with the native
+/// toolkit. The shape mirrors `mcpServers` in Claude Desktop / Cursor /
+/// similar tools so the JSON copy-pastes between them.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct McpServerConfig {
     /// Stable id used to address this entry from the UI / events. Generated
@@ -185,19 +215,36 @@ pub struct McpServerConfig {
     /// Operator-friendly label ("filesystem", "github", "my-server"). Shown
     /// in the chat-tools popover and per-server status messages.
     pub name: String,
-    /// Path to the executable. Absolute paths are recommended (no PATH
-    /// lookup is performed by FerrisScope itself, but the OS may resolve
-    /// relative names).
+    /// How to reach the server. Defaults to `stdio` (subprocess). When set to
+    /// `sse` / `http`, `url` is used instead of `command` / `args` / `env`.
+    #[serde(default)]
+    pub transport: McpTransport,
+    /// Path to the executable. Used only by the `stdio` transport. Absolute
+    /// paths are recommended (no PATH lookup is performed by FerrisScope
+    /// itself, but the OS may resolve relative names).
+    #[serde(default)]
     pub command: String,
-    /// CLI args appended after the command. Most MCP servers want a `stdio`
-    /// flag here (e.g. `--stdio`, `--transport stdio`).
+    /// Endpoint URL. Used only by the `sse` / `http` transports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// CLI args appended after the command (`stdio` only). Most MCP servers
+    /// want a `stdio` flag here (e.g. `--stdio`, `--transport stdio`).
     #[serde(default)]
     pub args: Vec<String>,
     /// Extra env vars merged on top of the inherited environment + the
-    /// `KUBECONFIG` we set to pin the chat's bound context. Operator-supplied
-    /// vars win on key collision.
+    /// `KUBECONFIG` we set to pin the chat's bound context (`stdio` only).
+    /// Operator-supplied vars win on key collision.
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Extra HTTP headers sent on every request (`sse` / `http` only) —
+    /// typically `Authorization` for a remote server's bearer token.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    /// Treat every tool from this server as a read (auto-run, no approval
+    /// prompt). Operator opt-in trust decision per server — off by default.
+    /// Overrides the name heuristic; native tools are unaffected.
+    #[serde(default)]
+    pub trust_as_read: bool,
     /// Disabled servers are persisted but not spawned. Lets operators keep
     /// configurations around without paying the spawn cost.
     #[serde(default = "default_enabled")]
@@ -251,4 +298,69 @@ pub struct AgentSettings {
     /// `provider_options` still wins.
     #[serde(default)]
     pub reasoning: ReasoningSettings,
+}
+
+#[cfg(test)]
+mod mcp_config_tests {
+    use super::{McpServerConfig, McpTransport};
+
+    #[test]
+    fn legacy_config_deserializes_with_transport_and_trust_defaults() {
+        // A pre-transport persisted entry omits the new fields entirely.
+        let json = r#"{
+            "id": "s1",
+            "name": "github",
+            "command": "/usr/local/bin/srv",
+            "args": ["--stdio"],
+            "env": { "TOKEN": "x" },
+            "enabled": true
+        }"#;
+        let cfg: McpServerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.transport, McpTransport::Stdio);
+        assert!(!cfg.trust_as_read);
+        assert_eq!(cfg.url, None);
+        assert!(cfg.headers.is_empty());
+        assert!(cfg.transport == McpTransport::default());
+    }
+
+    #[test]
+    fn remote_config_round_trips_transport_url_headers_trust() {
+        let json = r#"{
+            "id": "s2",
+            "name": "remote",
+            "transport": "http",
+            "url": "https://mcp.example.com/rpc",
+            "headers": { "Authorization": "Bearer t" },
+            "trust_as_read": true,
+            "enabled": true
+        }"#;
+        let cfg: McpServerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.transport, McpTransport::Http);
+        assert!(cfg.transport.is_remote());
+        assert_eq!(cfg.url.as_deref(), Some("https://mcp.example.com/rpc"));
+        assert_eq!(
+            cfg.headers.get("Authorization").map(String::as_str),
+            Some("Bearer t")
+        );
+        assert!(cfg.trust_as_read);
+        // Command defaults to empty for a remote entry.
+        assert!(cfg.command.is_empty());
+
+        // Re-serialize → re-parse keeps the snake_case transport tag stable.
+        let s = serde_json::to_string(&cfg).unwrap();
+        assert!(s.contains("\"transport\":\"http\""), "{s}");
+        let back: McpServerConfig = serde_json::from_str(&s).unwrap();
+        assert_eq!(back.transport, McpTransport::Http);
+    }
+
+    #[test]
+    fn transport_tags_are_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&McpTransport::Sse).unwrap(),
+            "\"sse\""
+        );
+        assert!(!McpTransport::Stdio.is_remote());
+        assert!(McpTransport::Sse.is_remote());
+        assert!(McpTransport::Http.is_remote());
+    }
 }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -14,8 +14,8 @@ pub mod session;
 pub mod types;
 
 pub use config::{
-    AgentSettings, ApprovalMode, Credential, ProviderConfig, ProviderKind, ReasoningEffort,
-    ReasoningSettings,
+    AgentSettings, ApprovalMode, Credential, McpServerConfig, McpTransport, ProviderConfig,
+    ProviderKind, ReasoningEffort, ReasoningSettings,
 };
 pub use mcp::{classify as classify_tool, McpClient, McpError, McpTool, ToolCategory};
 pub use native::{NativeRegistry, NativeTool, NativeToolError};

--- a/crates/agent/src/mcp/http.rs
+++ b/crates/agent/src/mcp/http.rs
@@ -1,0 +1,299 @@
+//! Streamable HTTP transport (MCP 2025-03-26).
+//!
+//! Every JSON-RPC message is POSTed to a single `url`. The response is either
+//! an `application/json` body (one response, or a JSON-RPC batch array) or a
+//! `text/event-stream` (SSE) carrying the response plus any interleaved
+//! server messages. Notifications get a `202 Accepted` with no body.
+//!
+//! Session continuity uses the `Mcp-Session-Id` header: the server sets it on
+//! the `initialize` response and we echo it on every later request. After
+//! `initialize` we also send `MCP-Protocol-Version` (the negotiated version).
+//!
+//! Scope note: the optional standalone GET stream (for unsolicited
+//! server→client messages) is intentionally not opened — the agent only makes
+//! request/response tool calls, so the POST response stream is sufficient.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use eventsource_stream::Eventsource;
+use futures::StreamExt;
+use reqwest::header::{HeaderName, HeaderValue, ACCEPT, CONTENT_TYPE};
+use serde_json::Value;
+use tokio::sync::{mpsc, Mutex};
+
+use super::transport::{build_headers, Transport};
+use super::McpError;
+
+/// Lowercase header names — `HeaderName::from_static` requires lowercase.
+const SESSION_HEADER: &str = "mcp-session-id";
+const PROTOCOL_HEADER: &str = "mcp-protocol-version";
+
+pub struct HttpTransport {
+    client: reqwest::Client,
+    url: String,
+    base_headers: reqwest::header::HeaderMap,
+    /// Set from the `initialize` response, echoed on every later request.
+    session_id: Mutex<Option<String>>,
+    /// Negotiated protocol version, captured from the `initialize` result.
+    protocol_version: Mutex<Option<String>>,
+    incoming: mpsc::UnboundedSender<Value>,
+}
+
+impl HttpTransport {
+    pub fn connect(
+        url: &str,
+        headers: &HashMap<String, String>,
+        incoming: mpsc::UnboundedSender<Value>,
+    ) -> Result<Arc<Self>, McpError> {
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| McpError::Transport(format!("build http client: {e}")))?;
+        Ok(Arc::new(Self {
+            client,
+            url: url.to_string(),
+            base_headers: build_headers(headers),
+            session_id: Mutex::new(None),
+            protocol_version: Mutex::new(None),
+            incoming,
+        }))
+    }
+
+    /// Capture the negotiated protocol version from an `initialize` result so
+    /// later requests can advertise it. No-op for every other message.
+    async fn capture_meta(&self, v: &Value) {
+        if let Some(pv) = v
+            .get("result")
+            .and_then(|r| r.get("protocolVersion"))
+            .and_then(Value::as_str)
+        {
+            *self.protocol_version.lock().await = Some(pv.to_string());
+        }
+    }
+
+    async fn deliver(&self, v: Value) -> bool {
+        self.capture_meta(&v).await;
+        self.incoming.send(v).is_ok()
+    }
+}
+
+#[async_trait::async_trait]
+impl Transport for HttpTransport {
+    async fn send(&self, message: Value) -> Result<(), McpError> {
+        let mut headers = self.base_headers.clone();
+        headers.insert(
+            ACCEPT,
+            HeaderValue::from_static("application/json, text/event-stream"),
+        );
+        if let Some(sid) = self.session_id.lock().await.clone() {
+            if let Ok(v) = HeaderValue::from_str(&sid) {
+                headers.insert(HeaderName::from_static(SESSION_HEADER), v);
+            }
+        }
+        if let Some(pv) = self.protocol_version.lock().await.clone() {
+            if let Ok(v) = HeaderValue::from_str(&pv) {
+                headers.insert(HeaderName::from_static(PROTOCOL_HEADER), v);
+            }
+        }
+
+        let resp = self
+            .client
+            .post(&self.url)
+            .headers(headers)
+            .json(&message)
+            .send()
+            .await
+            .map_err(|e| McpError::Transport(e.to_string()))?;
+
+        let status = resp.status();
+        // Capture the session id from any response (the server sets it on
+        // initialize). Done before consuming the body below.
+        if let Some(sid) = resp
+            .headers()
+            .get(SESSION_HEADER)
+            .and_then(|v| v.to_str().ok())
+        {
+            *self.session_id.lock().await = Some(sid.to_string());
+        }
+        let content_type = resp
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(McpError::Transport(format!("{status}: {body}")));
+        }
+
+        if content_type.contains("text/event-stream") {
+            let mut stream = resp.bytes_stream().eventsource();
+            while let Some(ev) = stream.next().await {
+                let ev = ev.map_err(|e| McpError::Transport(e.to_string()))?;
+                if ev.data.trim().is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<Value>(&ev.data) {
+                    Ok(v) => {
+                        if !self.deliver(v).await {
+                            break;
+                        }
+                    }
+                    Err(e) => tracing::warn!(error = %e, "mcp http: bad sse data"),
+                }
+            }
+        } else if content_type.contains("application/json") {
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| McpError::Transport(e.to_string()))?;
+            if body.trim().is_empty() {
+                return Ok(());
+            }
+            match serde_json::from_str::<Value>(&body)? {
+                Value::Array(items) => {
+                    for v in items {
+                        if !self.deliver(v).await {
+                            break;
+                        }
+                    }
+                }
+                other => {
+                    self.deliver(other).await;
+                }
+            }
+        }
+        // else: 202 Accepted (notification) or empty body — nothing to deliver.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::McpClient;
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    // reqwest needs a process-global rustls crypto provider (the binary
+    // installs `ring` in main.rs). Idempotent: only the first call succeeds.
+    fn ensure_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    // Read one HTTP/1.1 request off the socket: headers, then Content-Length
+    // bytes of body. Returns the body string (the JSON-RPC request).
+    async fn read_http_body(stream: &mut tokio::net::TcpStream) -> String {
+        let mut buf = Vec::new();
+        let mut tmp = [0u8; 1024];
+        // Read until headers terminator.
+        let header_end = loop {
+            let n = stream.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                return String::new();
+            }
+            buf.extend_from_slice(&tmp[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..header_end]).to_ascii_lowercase();
+        let len: usize = head
+            .lines()
+            .find_map(|l| l.strip_prefix("content-length:"))
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(0);
+        while buf.len() < header_end + len {
+            let n = stream.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        String::from_utf8_lossy(&buf[header_end..header_end + len]).to_string()
+    }
+
+    fn request_id(body: &str) -> Value {
+        serde_json::from_str::<Value>(body)
+            .ok()
+            .and_then(|v| v.get("id").cloned())
+            .unwrap_or(Value::Null)
+    }
+
+    // Spawn a one-request mock that replies with the given content-type body,
+    // substituting {ID} with the request's JSON-RPC id.
+    async fn spawn_mock(content_type: &'static str, body_template: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let body = read_http_body(&mut stream).await;
+            let id = request_id(&body);
+            let payload = body_template.replace("{ID}", &id.to_string());
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{payload}",
+                payload.len()
+            );
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            stream.flush().await.unwrap();
+            let _ = stream.shutdown().await;
+        });
+        format!("http://{addr}/rpc")
+    }
+
+    #[tokio::test]
+    async fn json_response_resolves_request() {
+        ensure_provider();
+        let url = spawn_mock(
+            "application/json",
+            r#"{"jsonrpc":"2.0","id":{ID},"result":{"ok":true}}"#,
+        )
+        .await;
+        let (tx, rx) = mpsc::unbounded_channel();
+        let transport = HttpTransport::connect(&url, &HashMap::new(), tx).unwrap();
+        let client = McpClient::from_transport(transport, rx);
+        let out = client.call_tool("noop", json!({})).await.unwrap();
+        assert_eq!(out, json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn sse_response_resolves_request() {
+        ensure_provider();
+        // The POST response is an SSE stream carrying the JSON-RPC reply.
+        let url = spawn_mock(
+            "text/event-stream",
+            "data: {\"jsonrpc\":\"2.0\",\"id\":{ID},\"result\":{\"ok\":true}}\n\n",
+        )
+        .await;
+        let (tx, rx) = mpsc::unbounded_channel();
+        let transport = HttpTransport::connect(&url, &HashMap::new(), tx).unwrap();
+        let client = McpClient::from_transport(transport, rx);
+        let out = client.call_tool("noop", json!({})).await.unwrap();
+        assert_eq!(out, json!({ "ok": true }));
+    }
+
+    #[tokio::test]
+    async fn http_error_status_surfaces_as_transport_error() {
+        ensure_provider();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let _ = read_http_body(&mut stream).await;
+            let resp = "HTTP/1.1 401 Unauthorized\r\nContent-Length: 11\r\nConnection: close\r\n\r\nbad api key";
+            stream.write_all(resp.as_bytes()).await.unwrap();
+            let _ = stream.shutdown().await;
+        });
+        let url = format!("http://{addr}/rpc");
+        let (tx, rx) = mpsc::unbounded_channel();
+        let transport = HttpTransport::connect(&url, &HashMap::new(), tx).unwrap();
+        let client = McpClient::from_transport(transport, rx);
+        let err = client.call_tool("noop", json!({})).await.unwrap_err();
+        match err {
+            McpError::Transport(m) => assert!(m.contains("401"), "{m}"),
+            other => panic!("expected Transport error, got {other:?}"),
+        }
+    }
+}

--- a/crates/agent/src/mcp/mod.rs
+++ b/crates/agent/src/mcp/mod.rs
@@ -16,8 +16,16 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
-use tokio::sync::{oneshot, Mutex};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+pub mod http;
+pub mod sse;
+pub mod transport;
+
+pub use http::HttpTransport;
+pub use sse::SseTransport;
+pub use transport::{StdioTransport, Transport};
 
 #[derive(Debug, thiserror::Error)]
 pub enum McpError {
@@ -31,6 +39,10 @@ pub enum McpError {
     Closed,
     #[error("invalid response: {0}")]
     InvalidResponse(String),
+    /// Transport-level failure for the network transports (`sse` / `http`):
+    /// connection refused, non-2xx status, malformed SSE framing, etc.
+    #[error("transport: {0}")]
+    Transport(String),
 }
 
 /// MCP protocol version we advertise during `initialize`. Servers either
@@ -152,67 +164,34 @@ struct JsonRpcErrorObj {
     message: String,
 }
 
-type Pending = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Value, McpError>>>>>;
+pub(crate) type Pending = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Value, McpError>>>>>;
 
-/// One MCP client. Holds the writer; the reader task is detached and
-/// notifies pending requests via the shared `pending` map.
+/// One MCP client over an arbitrary [`Transport`]. The transport owns the
+/// wire (subprocess pipes, HTTP, SSE) and pushes every incoming JSON-RPC
+/// message into a channel; the client correlates responses to outstanding
+/// requests by id through the shared `pending` map.
 pub struct McpClient {
     next_id: AtomicU64,
-    writer: Mutex<Box<dyn AsyncWrite + Unpin + Send>>,
+    transport: Arc<dyn Transport>,
     pending: Pending,
 }
 
 impl McpClient {
-    /// Wraps an already-opened `(reader, writer)` pair. Spawns a detached
-    /// reader task. The caller (typically the app crate's subprocess
-    /// supervisor) owns the underlying child; dropping the writer here
-    /// closes the request side without killing the child by itself.
-    pub fn new<W, R>(writer: W, reader: R) -> Arc<Self>
-    where
-        W: AsyncWrite + Unpin + Send + 'static,
-        R: AsyncRead + Unpin + Send + 'static,
-    {
+    /// Build a client from a ready transport plus the receiver end of the
+    /// transport's incoming-message channel. Spawns a detached task that
+    /// resolves pending requests as messages arrive; when the channel closes
+    /// (transport hung up) every outstanding request fails with
+    /// [`McpError::Closed`] so callers unblock instead of hanging.
+    pub fn from_transport(
+        transport: Arc<dyn Transport>,
+        mut incoming: mpsc::UnboundedReceiver<Value>,
+    ) -> Arc<Self> {
         let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
         let pending_for_reader = pending.clone();
         tokio::spawn(async move {
-            let mut buf = BufReader::new(reader);
-            let mut line = String::new();
-            loop {
-                line.clear();
-                match buf.read_line(&mut line).await {
-                    Ok(0) | Err(_) => break,
-                    Ok(_) => {}
-                }
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                let resp: JsonRpcResponse = match serde_json::from_str(trimmed) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        tracing::warn!(error = %e, line = %trimmed, "mcp: bad json line");
-                        continue;
-                    }
-                };
-                let Some(id) = resp.id.as_ref().and_then(Value::as_u64) else {
-                    // Notifications and malformed ids — ignore.
-                    continue;
-                };
-                let mut g = pending_for_reader.lock().await;
-                if let Some(tx) = g.remove(&id) {
-                    let payload = if let Some(err) = resp.error {
-                        Err(McpError::Server {
-                            code: err.code,
-                            message: err.message,
-                        })
-                    } else {
-                        Ok(resp.result.unwrap_or(Value::Null))
-                    };
-                    let _ = tx.send(payload);
-                }
+            while let Some(value) = incoming.recv().await {
+                Self::dispatch_incoming(&pending_for_reader, value).await;
             }
-            // Reader closed: fail every outstanding request so callers
-            // unblock instead of hanging on a dead child.
             let mut g = pending_for_reader.lock().await;
             for (_, tx) in g.drain() {
                 let _ = tx.send(Err(McpError::Closed));
@@ -220,17 +199,51 @@ impl McpClient {
         });
         Arc::new(Self {
             next_id: AtomicU64::new(1),
-            writer: Mutex::new(Box::new(writer)),
+            transport,
             pending,
         })
     }
 
-    async fn write_line(&self, bytes: &[u8]) -> Result<(), McpError> {
-        let mut w = self.writer.lock().await;
-        w.write_all(bytes).await?;
-        w.write_all(b"\n").await?;
-        w.flush().await?;
-        Ok(())
+    /// Convenience constructor for the `stdio` transport: wraps an
+    /// already-opened `(writer, reader)` pair (subprocess pipes). The caller
+    /// owns the underlying child; dropping the transport closes the request
+    /// side without killing the child by itself.
+    pub fn new<W, R>(writer: W, reader: R) -> Arc<Self>
+    where
+        W: AsyncWrite + Unpin + Send + 'static,
+        R: AsyncRead + Unpin + Send + 'static,
+    {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let transport = StdioTransport::new(writer, reader, tx);
+        Self::from_transport(transport, rx)
+    }
+
+    /// Route one incoming JSON-RPC message to its waiting request. Server
+    /// notifications and server→client requests (no matching pending id) are
+    /// ignored — we don't expose server-initiated calls to the agent.
+    async fn dispatch_incoming(pending: &Pending, value: Value) {
+        let resp: JsonRpcResponse = match serde_json::from_value(value) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(error = %e, "mcp: bad json-rpc message");
+                return;
+            }
+        };
+        let Some(id) = resp.id.as_ref().and_then(Value::as_u64) else {
+            return;
+        };
+        let mut g = pending.lock().await;
+        if let Some(tx) = g.remove(&id) {
+            let payload = if let Some(err) = resp.error {
+                Err(McpError::Server {
+                    code: err.code,
+                    message: err.message,
+                })
+            } else {
+                Ok(resp.result.unwrap_or(Value::Null))
+            };
+            let _ = tx.send(payload);
+        }
     }
 
     async fn request(&self, method: &str, params: Option<Value>) -> Result<Value, McpError> {
@@ -243,9 +256,9 @@ impl McpClient {
             method,
             params,
         };
-        let bytes = serde_json::to_vec(&req)?;
-        if let Err(e) = self.write_line(&bytes).await {
-            // Failed to write — clear the pending slot so we don't leak.
+        let msg = serde_json::to_value(&req)?;
+        if let Err(e) = self.transport.send(msg).await {
+            // Failed to send — clear the pending slot so we don't leak.
             self.pending.lock().await.remove(&id);
             return Err(e);
         }
@@ -261,8 +274,8 @@ impl McpClient {
             method,
             params,
         };
-        let bytes = serde_json::to_vec(&n)?;
-        self.write_line(&bytes).await
+        let msg = serde_json::to_value(&n)?;
+        self.transport.send(msg).await
     }
 
     /// MCP `initialize` handshake. Returns the server's reply verbatim so

--- a/crates/agent/src/mcp/sse.rs
+++ b/crates/agent/src/mcp/sse.rs
@@ -1,0 +1,236 @@
+//! Legacy HTTP+SSE transport (MCP 2024-11-05).
+//!
+//! Two channels: a long-lived `GET <url>` Server-Sent Events stream for
+//! server→client messages, and per-request `POST`s for client→server. On
+//! connect the server's first SSE event is `endpoint`, whose data is the URL
+//! to POST requests to (often relative — resolved against `url`). Every later
+//! `message` event carries a JSON-RPC payload, which we forward to the client.
+//!
+//! Superseded by [`HttpTransport`](super::http::HttpTransport) (Streamable
+//! HTTP) in newer servers, but still widely deployed, so we support both.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use eventsource_stream::Eventsource;
+use futures::StreamExt;
+use reqwest::header::{HeaderValue, ACCEPT, CONTENT_TYPE};
+use serde_json::Value;
+use tokio::sync::{mpsc, watch};
+
+use super::transport::{build_headers, Transport};
+use super::McpError;
+
+pub struct SseTransport {
+    client: reqwest::Client,
+    base_headers: reqwest::header::HeaderMap,
+    /// The POST endpoint advertised by the server's `endpoint` SSE event.
+    /// `None` until that event arrives; `send` waits for it.
+    endpoint: watch::Receiver<Option<String>>,
+}
+
+impl SseTransport {
+    pub async fn connect(
+        url: &str,
+        headers: &HashMap<String, String>,
+        incoming: mpsc::UnboundedSender<Value>,
+    ) -> Result<Arc<Self>, McpError> {
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| McpError::Transport(format!("build http client: {e}")))?;
+        let base_headers = build_headers(headers);
+        let base_url = reqwest::Url::parse(url)
+            .map_err(|e| McpError::Transport(format!("invalid url: {e}")))?;
+
+        let mut get_headers = base_headers.clone();
+        get_headers.insert(ACCEPT, HeaderValue::from_static("text/event-stream"));
+        let resp = client
+            .get(url)
+            .headers(get_headers)
+            .send()
+            .await
+            .map_err(|e| McpError::Transport(e.to_string()))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(McpError::Transport(format!("{status}: {body}")));
+        }
+
+        let (ep_tx, ep_rx) = watch::channel::<Option<String>>(None);
+        tokio::spawn(async move {
+            let mut stream = resp.bytes_stream().eventsource();
+            while let Some(ev) = stream.next().await {
+                let ev = match ev {
+                    Ok(e) => e,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "mcp sse: stream error");
+                        break;
+                    }
+                };
+                if ev.event == "endpoint" {
+                    let raw = ev.data.trim();
+                    match base_url.join(raw) {
+                        Ok(u) => {
+                            let _ = ep_tx.send(Some(u.to_string()));
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, endpoint = %raw, "mcp sse: bad endpoint");
+                        }
+                    }
+                } else {
+                    // "message" (or any data-bearing event) → JSON-RPC payload.
+                    if ev.data.trim().is_empty() {
+                        continue;
+                    }
+                    match serde_json::from_str::<Value>(&ev.data) {
+                        Ok(v) => {
+                            if incoming.send(v).is_err() {
+                                break;
+                            }
+                        }
+                        Err(e) => tracing::warn!(error = %e, "mcp sse: bad data"),
+                    }
+                }
+            }
+            // Stream ended: dropping `incoming` + `ep_tx` here unblocks both
+            // the client (pending requests fail) and any `send` awaiting the
+            // endpoint (the watch sender closes).
+        });
+
+        Ok(Arc::new(Self {
+            client,
+            base_headers,
+            endpoint: ep_rx,
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl Transport for SseTransport {
+    async fn send(&self, message: Value) -> Result<(), McpError> {
+        // The endpoint URL arrives asynchronously on the SSE stream; wait for
+        // it (the watch sender closing means the stream died before sending
+        // one — surface that rather than hang).
+        let mut rx = self.endpoint.clone();
+        let endpoint = match rx.wait_for(Option::is_some).await {
+            Ok(r) => match r.as_ref().cloned() {
+                Some(ep) => ep,
+                None => return Err(McpError::Transport("sse endpoint missing".into())),
+            },
+            Err(_) => {
+                return Err(McpError::Transport(
+                    "sse endpoint never arrived (stream closed)".into(),
+                ))
+            }
+        };
+
+        let mut headers = self.base_headers.clone();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let resp = self
+            .client
+            .post(&endpoint)
+            .headers(headers)
+            .json(&message)
+            .send()
+            .await
+            .map_err(|e| McpError::Transport(e.to_string()))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(McpError::Transport(format!("{status}: {body}")));
+        }
+        // The JSON-RPC response (if any) comes back over the SSE stream, not
+        // this POST's body.
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::McpClient;
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn ensure_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    async fn read_http_body(stream: &mut tokio::net::TcpStream) -> String {
+        let mut buf = Vec::new();
+        let mut tmp = [0u8; 1024];
+        let header_end = loop {
+            let n = stream.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                return String::new();
+            }
+            buf.extend_from_slice(&tmp[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..header_end]).to_ascii_lowercase();
+        let len: usize = head
+            .lines()
+            .find_map(|l| l.strip_prefix("content-length:"))
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(0);
+        while buf.len() < header_end + len {
+            let n = stream.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        String::from_utf8_lossy(&buf[header_end..header_end + len]).to_string()
+    }
+
+    #[tokio::test]
+    async fn endpoint_then_post_round_trips_over_sse() {
+        ensure_provider();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            // Connection 1: GET → SSE headers + endpoint event (relative).
+            let (mut s1, _) = listener.accept().await.unwrap();
+            let _ = read_http_body(&mut s1).await; // consume GET headers
+            s1.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: keep-alive\r\n\r\n",
+            )
+            .await
+            .unwrap();
+            s1.write_all(b"event: endpoint\r\ndata: /messages\r\n\r\n")
+                .await
+                .unwrap();
+            s1.flush().await.unwrap();
+
+            // Connection 2: POST /messages → 202; reply pushed over SSE.
+            let (mut s2, _) = listener.accept().await.unwrap();
+            let body = read_http_body(&mut s2).await;
+            let id = serde_json::from_str::<Value>(&body)
+                .ok()
+                .and_then(|v| v.get("id").cloned())
+                .unwrap_or(Value::Null);
+            s2.write_all(b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .unwrap();
+            s2.flush().await.unwrap();
+
+            let event =
+                format!("data: {{\"jsonrpc\":\"2.0\",\"id\":{id},\"result\":{{\"ok\":true}}}}\n\n");
+            s1.write_all(event.as_bytes()).await.unwrap();
+            s1.flush().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        });
+
+        let url = format!("http://{addr}/sse");
+        let (tx, rx) = mpsc::unbounded_channel();
+        let transport = SseTransport::connect(&url, &HashMap::new(), tx)
+            .await
+            .unwrap();
+        let client = McpClient::from_transport(transport, rx);
+        let out = client.call_tool("noop", json!({})).await.unwrap();
+        assert_eq!(out, json!({ "ok": true }));
+    }
+}

--- a/crates/agent/src/mcp/transport.rs
+++ b/crates/agent/src/mcp/transport.rs
@@ -1,0 +1,171 @@
+//! Transport abstraction for the MCP client.
+//!
+//! [`McpClient`](super::McpClient) is wire-agnostic: it serializes JSON-RPC
+//! messages and hands them to a [`Transport`], and consumes incoming messages
+//! from a channel the transport fills. Three transports ship:
+//!
+//! - [`StdioTransport`] — subprocess pipes (this file). The default.
+//! - [`HttpTransport`](super::http::HttpTransport) — Streamable HTTP.
+//! - [`SseTransport`](super::sse::SseTransport) — legacy HTTP+SSE.
+//!
+//! Every transport delivers incoming messages (responses + server
+//! notifications) by `send`-ing serde_json [`Value`]s into the
+//! `mpsc::UnboundedSender` it was constructed with. Closing that sender (drop)
+//! signals the client that the connection is gone.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::sync::{mpsc, Mutex};
+
+use super::McpError;
+
+/// Sends one already-serialized JSON-RPC message (request or notification) to
+/// the server. Implementations are responsible for routing any resulting
+/// incoming messages into the channel handed to them at construction.
+#[async_trait::async_trait]
+pub trait Transport: Send + Sync {
+    async fn send(&self, message: Value) -> Result<(), McpError>;
+}
+
+/// Build a reqwest [`HeaderMap`] from operator-supplied `name: value` pairs.
+/// Invalid header names / values are dropped with a warning rather than
+/// failing the whole connection — a single bad header shouldn't sink a server.
+pub(crate) fn build_headers(headers: &HashMap<String, String>) -> HeaderMap {
+    let mut h = HeaderMap::new();
+    for (k, v) in headers {
+        match (
+            HeaderName::from_bytes(k.as_bytes()),
+            HeaderValue::from_str(v),
+        ) {
+            (Ok(name), Ok(value)) => {
+                h.insert(name, value);
+            }
+            _ => tracing::warn!(header = %k, "mcp: dropping invalid HTTP header"),
+        }
+    }
+    h
+}
+
+/// JSON-RPC over a subprocess's stdin (writer) + stdout (reader), one message
+/// per line. The reader runs as a detached task that parses each line into a
+/// [`Value`] and forwards it to the client; dropping the child's stdout (EOF)
+/// ends the task and closes the channel.
+pub struct StdioTransport {
+    writer: Mutex<Box<dyn AsyncWrite + Unpin + Send>>,
+}
+
+impl StdioTransport {
+    pub fn new<W, R>(writer: W, reader: R, incoming: mpsc::UnboundedSender<Value>) -> Arc<Self>
+    where
+        W: AsyncWrite + Unpin + Send + 'static,
+        R: AsyncRead + Unpin + Send + 'static,
+    {
+        tokio::spawn(async move {
+            let mut buf = BufReader::new(reader);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match buf.read_line(&mut line).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<Value>(trimmed) {
+                    Ok(v) => {
+                        // Receiver dropped (client gone) → stop reading.
+                        if incoming.send(v).is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, line = %trimmed, "mcp: bad json line");
+                    }
+                }
+            }
+            // Dropping `incoming` here closes the channel, which the client's
+            // drain loop turns into `McpError::Closed` for pending requests.
+        });
+        Arc::new(Self {
+            writer: Mutex::new(Box::new(writer)),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Transport for StdioTransport {
+    async fn send(&self, message: Value) -> Result<(), McpError> {
+        let bytes = serde_json::to_vec(&message)?;
+        let mut w = self.writer.lock().await;
+        w.write_all(&bytes).await?;
+        w.write_all(b"\n").await?;
+        w.flush().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::McpClient;
+    use serde_json::json;
+    use tokio::io::duplex;
+
+    // A stdio transport over an in-memory duplex pipe: we play "server" on the
+    // far end, reading the client's request line and writing a canned reply.
+    #[tokio::test]
+    async fn stdio_round_trips_a_request() {
+        // client writes to `c_wr`, reads from `c_rd`; server uses the mirror.
+        let (client_io, mut server_io) = duplex(8192);
+        let (c_rd, c_wr) = tokio::io::split(client_io);
+        let client = McpClient::new(c_wr, c_rd);
+
+        // Server: read one line (the initialize request), reply with a result.
+        let server = tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+            let (rd, mut wr) = tokio::io::split(&mut server_io);
+            let mut lines = BufReader::new(rd).lines();
+            let line = lines.next_line().await.unwrap().unwrap();
+            let req: serde_json::Value = serde_json::from_str(&line).unwrap();
+            let id = req.get("id").cloned().unwrap();
+            let reply = json!({ "jsonrpc": "2.0", "id": id, "result": { "ok": true } });
+            wr.write_all(serde_json::to_string(&reply).unwrap().as_bytes())
+                .await
+                .unwrap();
+            wr.write_all(b"\n").await.unwrap();
+            wr.flush().await.unwrap();
+            // Keep server_io alive until the client has read the reply.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        });
+
+        let result = client.call_tool("noop", json!({})).await.unwrap();
+        assert_eq!(result, json!({ "ok": true }));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn closed_transport_fails_pending_requests() {
+        let (client_io, mut server_io) = duplex(8192);
+        let (c_rd, c_wr) = tokio::io::split(client_io);
+        let client = McpClient::new(c_wr, c_rd);
+        // Server reads the request (so the write succeeds), then drops its end
+        // without replying → client reader hits EOF → the drain loop fails the
+        // outstanding request with `Closed` rather than letting it hang.
+        let server = tokio::spawn(async move {
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let (rd, _wr) = tokio::io::split(&mut server_io);
+            let mut lines = BufReader::new(rd).lines();
+            let _ = lines.next_line().await;
+            // drop server_io on return
+        });
+        let err = client.call_tool("noop", json!({})).await.unwrap_err();
+        assert!(matches!(err, McpError::Closed), "{err:?}");
+        server.await.unwrap();
+    }
+}

--- a/crates/app/src/agent.rs
+++ b/crates/app/src/agent.rs
@@ -54,6 +54,20 @@ const MAX_TOOL_ROUNDS: u32 = 500;
 /// we still surface `is_error: true` so the model can recover.
 const TOOL_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(5);
 
+/// Hard ceiling, in bytes, on a single tool result before it enters the
+/// transcript. Oversized output — a Prometheus query that returns every
+/// `up` series, `kubectl get … -o json` across a busy namespace — otherwise
+/// (a) bloats *every* subsequent request because the result rides along on
+/// each following round, and (b) can tip the request past the model's
+/// context window or, worse, make some OpenAI models return an *empty*
+/// completion. The loop then retries that empty turn against the same
+/// oversized transcript until it gives up ("no output after N attempts"),
+/// and because the giant result is now pinned in the transcript the chat
+/// stays wedged. Capping at the source keeps the transcript bounded and the
+/// chat recoverable. ~30k bytes ≈ 7-8k tokens — enough for the model to see
+/// the shape of a large result and decide to narrow its query.
+const MAX_TOOL_RESULT_BYTES: usize = 30_000;
+
 const SYSTEM_PROMPT_BASELINE: &str = "\
 You are FerrisScope's Kubernetes operator assistant. You help the user \
 understand and operate their Kubernetes cluster. Prefer Server-Side Apply \
@@ -784,6 +798,11 @@ struct McpServerHandle {
     /// schema enumeration and the dispatch lookup (we walk this list to
     /// route a tool name back to the owning client).
     tools: Vec<McpTool>,
+    /// Operator opted to treat every tool from this server as a read
+    /// (auto-run, no approval). Carried from `McpServerConfig::trust_as_read`
+    /// so the approval gate and the tools inspector can override the name
+    /// heuristic without re-reading settings.
+    trust_as_read: bool,
     /// Failure message. `None` on success.
     message: Option<String>,
 }
@@ -859,6 +878,11 @@ struct ChatRuntime {
     /// Held here so the per-turn system prompt can describe the *active* cluster
     /// (not just the origin) without going through tool-call round trips.
     cluster: agent_native::ChatClusterRef,
+    /// Per-chat disk spool for oversized tool output. The agent loop writes the
+    /// full payload here when a result exceeds `MAX_TOOL_RESULT_BYTES`; the
+    /// `fs_tool_output_read` / `fs_tool_output_grep` tools (built over the same
+    /// directory) read it back. Cloned into each tool-call future. Cheap clone.
+    tool_spool: agent_native::tool_output::ToolSpool,
     /// In-flight approval requests, keyed by tool call id. The agent loop
     /// awaits each receiver while the UI surfaces the approval card; the
     /// `chat_approve_tool_call` command sends the operator's decision.
@@ -1018,15 +1042,20 @@ pub(crate) async fn ai_set_settings(
         p.settings.mcp_binary_path = if path.is_empty() { None } else { Some(path) };
     }
     if let Some(servers) = patch.mcp_servers {
-        // Normalise: drop entries with empty name + empty command (operator
-        // added a row and abandoned it). Trim names so leading/trailing
-        // whitespace doesn't sneak into status messages.
+        // Normalise: drop entries the operator added then abandoned — empty
+        // name *and* no endpoint (no command for stdio, no url for remote).
+        // Trim names / urls so whitespace doesn't sneak into status messages.
         p.settings.mcp_servers = servers
             .into_iter()
             .filter_map(|mut s| {
                 s.name = s.name.trim().to_string();
                 s.command = s.command.trim().to_string();
-                if s.name.is_empty() && s.command.is_empty() {
+                s.url = s
+                    .url
+                    .map(|u| u.trim().to_string())
+                    .filter(|u| !u.is_empty());
+                let no_endpoint = s.command.is_empty() && s.url.is_none();
+                if s.name.is_empty() && no_endpoint {
                     None
                 } else {
                     Some(s)
@@ -1147,6 +1176,12 @@ pub(crate) async fn mcp_test_server(
     use tokio::io::{AsyncBufReadExt, BufReader};
     use tokio::process::Command;
     use tokio::sync::Mutex as AsyncMutex;
+
+    // Remote transports (sse / http) have no subprocess and no stderr to
+    // capture — connect over the network and run the same handshake.
+    if config.transport.is_remote() {
+        return Ok(mcp_test_remote(&config).await);
+    }
 
     let bin = config.command.trim();
     if bin.is_empty() {
@@ -1300,6 +1335,80 @@ pub(crate) async fn mcp_test_server(
             error: Some(format!("{e}{stderr_tail}")),
         },
     })
+}
+
+/// Test a remote (`sse` / `http`) MCP server: connect, run `initialize` +
+/// `tools/list`, and report the tool count. No subprocess / stderr (those are
+/// stdio-only), so failures surface as the transport / handshake error text.
+async fn mcp_test_remote(config: &McpServerConfig) -> McpTestResult {
+    use ferrisscope_agent::mcp::{HttpTransport, SseTransport};
+
+    let err = |msg: String| McpTestResult {
+        ok: false,
+        tool_count: 0,
+        tool_names: Vec::new(),
+        error: Some(msg),
+    };
+
+    let url = config.url.as_deref().map(str::trim).unwrap_or("");
+    if url.is_empty() {
+        return err("url is empty".to_string());
+    }
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let client = match config.transport {
+        ferrisscope_agent::McpTransport::Http => {
+            match HttpTransport::connect(url, &config.headers, tx) {
+                Ok(t) => ferrisscope_agent::McpClient::from_transport(t, rx),
+                Err(e) => return err(format!("connect failed: {e}")),
+            }
+        }
+        ferrisscope_agent::McpTransport::Sse => {
+            match SseTransport::connect(url, &config.headers, tx).await {
+                Ok(t) => ferrisscope_agent::McpClient::from_transport(t, rx),
+                Err(e) => return err(format!("connect failed: {e}")),
+            }
+        }
+        ferrisscope_agent::McpTransport::Stdio => {
+            return err("internal: stdio routed to remote test".to_string());
+        }
+    };
+
+    let outcome: Result<Vec<ferrisscope_agent::mcp::McpTool>, String> =
+        tokio::time::timeout(MCP_TEST_OVERALL, async {
+            tokio::time::timeout(
+                MCP_TEST_INITIALIZE,
+                client.initialize("ferrisscope", env!("CARGO_PKG_VERSION")),
+            )
+            .await
+            .map_err(|_| "MCP `initialize` timed out".to_string())?
+            .map_err(|e| format!("MCP `initialize` failed: {e}"))?;
+
+            tokio::time::timeout(MCP_TEST_LIST_TOOLS, client.list_tools())
+                .await
+                .map_err(|_| "MCP `tools/list` timed out".to_string())?
+                .map_err(|e| format!("MCP `tools/list` failed: {e}"))
+        })
+        .await
+        .unwrap_or_else(|_| Err("test timed out after 90s overall".to_string()));
+
+    match outcome {
+        Ok(tools) => {
+            #[allow(clippy::cast_possible_truncation)]
+            let tool_count = tools.len() as u32;
+            McpTestResult {
+                ok: true,
+                tool_count,
+                tool_names: tools
+                    .iter()
+                    .take(MCP_TEST_NAME_PREVIEW)
+                    .map(|t| t.name.clone())
+                    .collect(),
+                error: None,
+            }
+        }
+        Err(e) => err(e),
+    }
 }
 
 /// List models for a provider. Defaults to `active_provider` when
@@ -1590,9 +1699,13 @@ pub(crate) async fn chat_open(
         vec![McpServerConfig {
             id: "legacy".to_string(),
             name: "MCP server".to_string(),
+            transport: ferrisscope_agent::config::McpTransport::Stdio,
             command: legacy.clone(),
+            url: None,
             args: Vec::new(),
             env: HashMap::new(),
+            headers: HashMap::new(),
+            trust_as_read: false,
             enabled: true,
         }]
     } else {
@@ -1651,7 +1764,13 @@ pub(crate) async fn chat_open(
         session_id.clone(),
         restored_active,
     );
-    let native = agent_native::build_registry(app.clone(), cluster_ctx.clone());
+    // Per-chat disk spool for oversized tool output. Built from the stable
+    // (cluster, session) pair so a reopened chat resolves the same handles its
+    // rehydrated transcript references. Reap stale spills opportunistically on
+    // open (best-effort, off the open path).
+    let tool_spool = agent_native::tool_output::ToolSpool::new(&data.meta.cluster_id, &session_id);
+    tauri::async_runtime::spawn(agent_native::tool_output::sweep_expired());
+    let native = agent_native::build_registry(app.clone(), cluster_ctx.clone(), tool_spool.clone());
 
     let chat_id = format!("chat-{}", uuid::Uuid::new_v4());
     let on_event_for_replay = on_event.clone();
@@ -1666,6 +1785,7 @@ pub(crate) async fn chat_open(
             name: s.name.clone(),
             process: None,
             tools: Vec::new(),
+            trust_as_read: s.trust_as_read,
             message: None,
         })
         .collect();
@@ -1688,6 +1808,7 @@ pub(crate) async fn chat_open(
         external_scratch: external_scratch.clone(),
         native,
         cluster: cluster_ctx,
+        tool_spool,
         pending_approvals: HashMap::new(),
         approved_always: HashSet::new(),
         // Reset every chat-open. The persisted `meta.title` is the
@@ -2437,10 +2558,12 @@ pub(crate) async fn chat_list_tools(
     let mut out: Vec<ChatToolWire> = Vec::new();
     for server in &g.mcp_servers {
         for tool in &server.tools {
+            // A trusted server ("treat all as read") reports every tool as
+            // read so the inspector matches what the approval gate will do.
             out.push(ChatToolWire {
                 name: tool.name.clone(),
                 description: tool.description.clone(),
-                category: category_label(classify_tool(&tool.name)),
+                category: category_label(mcp_category(server.trust_as_read, &tool.name)),
                 input_schema: tool.input_schema.clone(),
                 source: server.name.clone(),
             });
@@ -2472,6 +2595,18 @@ fn category_label(c: ToolCategory) -> &'static str {
         ToolCategory::Read => "read",
         ToolCategory::Write => "write",
         ToolCategory::Unknown => "unknown",
+    }
+}
+
+/// Resolve an MCP tool's category. A server the operator marked
+/// `trust_as_read` forces [`ToolCategory::Read`] (auto-run, no approval);
+/// otherwise fall back to the name heuristic. Native tools never go through
+/// here — they declare their own category.
+fn mcp_category(trust_as_read: bool, name: &str) -> ToolCategory {
+    if trust_as_read {
+        ToolCategory::Read
+    } else {
+        classify_tool(name)
     }
 }
 
@@ -3324,12 +3459,14 @@ async fn run_turn_loop(
         // before any of the already-approved cards get a ToolResult and
         // disappear, which feels like the UI is stuck.
         let mut futures = Vec::with_capacity(tool_calls.len());
+        let spool = { runtime.lock().await.tool_spool.clone() };
         for tc in &tool_calls {
             let runtime = runtime.clone();
             let store = store.clone();
             let cluster_id = cluster_id.clone();
             let session_id = session_id.clone();
             let tc = tc.clone();
+            let spool = spool.clone();
             let category = classify_tool(&tc.name);
             futures.push(async move {
                 let (content, is_error) = execute_tool_call(
@@ -3342,6 +3479,13 @@ async fn run_turn_loop(
                     approval_mode,
                 )
                 .await;
+                // Clamp before anything sees it — the wire ToolResult, the
+                // model-facing transcript, and the persisted log all derive
+                // from this one string, so capping here keeps them in sync
+                // and stops an oversized result from wedging the loop. The
+                // full payload is spilled to disk first so the model can
+                // recover it via fs_tool_output_read / _grep.
+                let content = maybe_spill(&spool, &tc.id, content).await;
                 let _ = runtime.lock().await.channel.send(ChatEvent::ToolResult {
                     tool_call_id: tc.id.clone(),
                     name: tc.name.clone(),
@@ -3949,6 +4093,93 @@ async fn run_provider_round(
 /// Native tools take precedence: if a name resolves to a native tool, its
 /// `category()` overrides the heuristic and dispatch goes in-process. Falls
 /// through to MCP otherwise.
+/// Largest byte index `<= max` that falls on a UTF-8 char boundary of `s`.
+/// Slicing `&s[..n]` at the returned `n` never panics mid-codepoint.
+/// Returns `s.len()` when the string already fits within `max`.
+pub(crate) fn char_boundary_floor(s: &str, max: usize) -> usize {
+    if s.len() <= max {
+        return s.len();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    end
+}
+
+/// Clamp a tool result to [`MAX_TOOL_RESULT_BYTES`], keeping the head and
+/// appending a marker that tells the model the output was clipped. Splits on a
+/// char boundary — never panics. Short results pass through untouched. Applied
+/// at the single tool-call chokepoint so the cap is uniform across the wire
+/// event, the model-facing transcript, and the on-disk log.
+///
+/// `handle: Some(id)` means the full output was spilled to disk and can be
+/// recovered with `fs_tool_output_read` / `fs_tool_output_grep` — the marker
+/// points the model at those tools. `None` means spilling was unavailable (no
+/// cache dir / write failed), so the dropped bytes are gone and the marker
+/// tells the model to narrow the request and retry instead.
+fn cap_tool_result(content: String, handle: Option<&str>) -> String {
+    if content.len() <= MAX_TOOL_RESULT_BYTES {
+        return content;
+    }
+    let end = char_boundary_floor(&content, MAX_TOOL_RESULT_BYTES);
+    let total = content.len();
+    let dropped = total - end;
+    let mut out = content;
+    out.truncate(end);
+    use std::fmt::Write as _;
+    match handle {
+        Some(h) => {
+            let _ = write!(
+                out,
+                "\n\n…[tool output truncated: showing the first {end} of {total} bytes. \
+                 Full output saved as handle \"{h}\" — call `fs_tool_output_read` \
+                 (offset/limit) to page through it or `fs_tool_output_grep` (pattern) to \
+                 search it. Or narrow the original request and call again.]"
+            );
+        }
+        None => {
+            let _ = write!(
+                out,
+                "\n\n…[tool output truncated: {dropped} of {total} bytes omitted. \
+                 Narrow the request (label/field selector, a more specific name, \
+                 namespace, time range, or limit) and call again to see the rest.]"
+            );
+        }
+    }
+    out
+}
+
+/// Spill an oversized tool result to the per-chat disk spool and return the
+/// capped, handle-bearing preview. Results within budget pass through
+/// untouched. If the spool write fails (no cache dir, IO error) we still cap —
+/// just lossily, without a handle — so an oversized result can never wedge the
+/// loop regardless of disk state.
+async fn maybe_spill(
+    spool: &agent_native::tool_output::ToolSpool,
+    handle: &str,
+    content: String,
+) -> String {
+    if content.len() <= MAX_TOOL_RESULT_BYTES {
+        return content;
+    }
+    if spool.put(handle, &content).await {
+        cap_tool_result(content, Some(handle))
+    } else {
+        cap_tool_result(content, None)
+    }
+}
+
+/// `true` when the MCP tool `name` is served by a server the operator marked
+/// `trust_as_read`. Walks the same per-server catalogues the dispatch lookup
+/// uses, so a name is trusted iff its owning server is trusted.
+async fn mcp_tool_is_trusted(runtime: &Arc<Mutex<ChatRuntime>>, name: &str) -> bool {
+    let g = runtime.lock().await;
+    g.mcp_servers
+        .iter()
+        .any(|s| s.trust_as_read && s.tools.iter().any(|t| t.name == name))
+}
+
 async fn execute_tool_call(
     runtime: &Arc<Mutex<ChatRuntime>>,
     store: &SessionStore,
@@ -3971,6 +4202,11 @@ async fn execute_tool_call(
     let native_tool = { runtime.lock().await.native.find(&tc.name) };
     let category = match &native_tool {
         Some(t) => t.category(),
+        // MCP tool: an operator-trusted server ("treat all as read") forces
+        // Read so the call auto-runs; otherwise keep the passed-in name
+        // heuristic. Mirrors `mcp_category`, but reuses the already-computed
+        // `category` instead of re-classifying.
+        None if mcp_tool_is_trusted(runtime, &tc.name).await => ToolCategory::Read,
         None => category,
     };
 
@@ -4829,8 +5065,12 @@ fn render_head_for_summary(messages: &[ChatMessage]) -> String {
             // past the model's context.
             const PER_MSG_CAP: usize = 8000;
             if m.content.len() > PER_MSG_CAP {
-                out.push_str(&m.content[..PER_MSG_CAP]);
-                let _ = writeln!(out, "\n…(truncated, {} chars)", m.content.len());
+                // Split on a char boundary — a raw `&m.content[..8000]`
+                // panics when byte 8000 lands mid-codepoint (UTF-8 in a
+                // tool result is enough to trip it).
+                let end = char_boundary_floor(&m.content, PER_MSG_CAP);
+                out.push_str(&m.content[..end]);
+                let _ = writeln!(out, "\n…(truncated, {} bytes)", m.content.len());
             } else {
                 out.push_str(&m.content);
                 out.push('\n');
@@ -4902,6 +5142,80 @@ mod tests {
     fn context_overflow_classifier_negative_auth() {
         let e = ProviderError::Auth("invalid token".into());
         assert!(!is_context_overflow_error(&e));
+    }
+
+    #[test]
+    fn mcp_category_trusted_forces_read_even_for_write_names() {
+        // A write-classified name from a trusted server still resolves Read.
+        assert_eq!(mcp_category(true, "pods_delete"), ToolCategory::Read);
+        assert_eq!(mcp_category(true, "frobnicate"), ToolCategory::Read);
+    }
+
+    #[test]
+    fn mcp_category_untrusted_keeps_name_heuristic() {
+        assert_eq!(mcp_category(false, "pods_delete"), ToolCategory::Write);
+        assert_eq!(mcp_category(false, "pods_list"), ToolCategory::Read);
+        assert_eq!(mcp_category(false, "frobnicate"), ToolCategory::Unknown);
+    }
+
+    #[test]
+    fn cap_tool_result_passes_short_through() {
+        let s = "small tool output".to_string();
+        assert_eq!(cap_tool_result(s.clone(), None), s);
+    }
+
+    #[test]
+    fn cap_tool_result_passes_exact_cap_through() {
+        let s = "x".repeat(MAX_TOOL_RESULT_BYTES);
+        // A result sitting exactly on the cap is left untouched — no marker.
+        assert_eq!(cap_tool_result(s.clone(), None), s);
+    }
+
+    #[test]
+    fn cap_tool_result_truncates_oversized_with_marker() {
+        let s = "y".repeat(MAX_TOOL_RESULT_BYTES + 5_000);
+        // No handle (spool unavailable) → lossy marker tells the model to narrow.
+        let out = cap_tool_result(s, None);
+        assert!(out.starts_with(&"y".repeat(MAX_TOOL_RESULT_BYTES)));
+        assert!(out.contains("tool output truncated"));
+        assert!(out.contains("5000 of"));
+        assert!(out.contains("Narrow the request"));
+    }
+
+    #[test]
+    fn cap_tool_result_with_handle_points_at_recovery_tools() {
+        let s = "z".repeat(MAX_TOOL_RESULT_BYTES + 1_000);
+        let out = cap_tool_result(s, Some("call_abc123"));
+        assert!(out.starts_with(&"z".repeat(MAX_TOOL_RESULT_BYTES)));
+        assert!(out.contains("tool output truncated"));
+        assert!(out.contains("call_abc123"));
+        assert!(out.contains("fs_tool_output_read"));
+        assert!(out.contains("fs_tool_output_grep"));
+    }
+
+    #[test]
+    fn cap_tool_result_never_splits_codepoint() {
+        // A 3-byte char straddling the cap so a naive `&s[..MAX]` would
+        // panic mid-codepoint. The whole char is dropped, not split.
+        let mut s = "a".repeat(MAX_TOOL_RESULT_BYTES - 1);
+        s.push('€'); // occupies bytes MAX-1..=MAX+1; byte MAX is not a boundary
+        s.push_str(&"b".repeat(100));
+        let out = cap_tool_result(s, None); // must not panic
+        assert!(out.starts_with(&"a".repeat(MAX_TOOL_RESULT_BYTES - 1)));
+        assert!(!out.contains('€'));
+        assert!(out.contains("tool output truncated"));
+    }
+
+    #[test]
+    fn char_boundary_floor_walks_back_to_boundary() {
+        // "a€" → bytes [a][€ € €], valid boundaries at 0, 1, 4.
+        let s = "a€";
+        assert_eq!(s.len(), 4);
+        assert_eq!(char_boundary_floor(s, 5), 4, "already fits → full len");
+        assert_eq!(char_boundary_floor(s, 4), 4, "exact boundary kept");
+        assert_eq!(char_boundary_floor(s, 3), 1, "mid-€ floors to 1");
+        assert_eq!(char_boundary_floor(s, 2), 1, "mid-€ floors to 1");
+        assert_eq!(char_boundary_floor(s, 1), 1, "ascii boundary kept");
     }
 
     #[test]

--- a/crates/app/src/agent_mcp.rs
+++ b/crates/app/src/agent_mcp.rs
@@ -24,15 +24,19 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
-use ferrisscope_agent::config::McpServerConfig;
+use ferrisscope_agent::config::{McpServerConfig, McpTransport};
+use ferrisscope_agent::mcp::{HttpTransport, SseTransport};
 use ferrisscope_agent::McpClient;
 use tokio::process::{Child, Command};
 
 #[derive(Debug)]
 pub(crate) enum McpProcessError {
     BinaryNotConfigured,
+    UrlNotConfigured,
     Spawn(std::io::Error),
     NoPipes,
+    /// Failed to establish a network transport (`sse` / `http`).
+    Connect(ferrisscope_agent::McpError),
     Initialize(ferrisscope_agent::McpError),
     ScratchKubeconfig(String),
 }
@@ -43,8 +47,12 @@ impl std::fmt::Display for McpProcessError {
             Self::BinaryNotConfigured => {
                 f.write_str("MCP server binary not configured (no `command` set on this entry)")
             }
+            Self::UrlNotConfigured => {
+                f.write_str("MCP server URL not configured (no `url` set on this entry)")
+            }
             Self::Spawn(e) => write!(f, "failed to spawn MCP server: {e}"),
             Self::NoPipes => f.write_str("MCP server stdin/stdout not piped"),
+            Self::Connect(e) => write!(f, "MCP connect failed: {e}"),
             Self::Initialize(e) => write!(f, "MCP initialize failed: {e}"),
             Self::ScratchKubeconfig(s) => write!(f, "scratch kubeconfig: {s}"),
         }
@@ -55,7 +63,7 @@ impl std::error::Error for McpProcessError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Spawn(e) => Some(e),
-            Self::Initialize(e) => Some(e),
+            Self::Connect(e) | Self::Initialize(e) => Some(e),
             _ => None,
         }
     }
@@ -74,6 +82,71 @@ pub(crate) struct McpProcess {
 }
 
 impl McpProcess {
+    /// Connect to the configured server (by `transport`) and run the MCP
+    /// `initialize` handshake, returning a ready client. `stdio` spawns the
+    /// `command` subprocess; `sse` / `http` connect to `url`. The kubeconfig /
+    /// context / scratch args pin the context for `stdio` children only —
+    /// remote servers run elsewhere and aren't ours to point at a context.
+    pub(crate) async fn spawn(
+        config: &McpServerConfig,
+        kubeconfig_path: Option<&PathBuf>,
+        context_name: Option<&str>,
+        external_scratch: Option<&Path>,
+    ) -> Result<Self, McpProcessError> {
+        match config.transport {
+            McpTransport::Stdio => {
+                Self::spawn_stdio(config, kubeconfig_path, context_name, external_scratch).await
+            }
+            McpTransport::Sse | McpTransport::Http => Self::connect_remote(config).await,
+        }
+    }
+
+    /// Connect to a remote MCP server over `sse` / `http`. No child process and
+    /// no kubeconfig pinning — the server runs wherever the operator hosts it.
+    /// Operator `headers` (e.g. `Authorization`) are sent on every request.
+    async fn connect_remote(config: &McpServerConfig) -> Result<Self, McpProcessError> {
+        let url = config
+            .url
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+            .ok_or(McpProcessError::UrlNotConfigured)?;
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let client = match config.transport {
+            McpTransport::Http => {
+                let t = HttpTransport::connect(url, &config.headers, tx)
+                    .map_err(McpProcessError::Connect)?;
+                McpClient::from_transport(t, rx)
+            }
+            McpTransport::Sse => {
+                let t = SseTransport::connect(url, &config.headers, tx)
+                    .await
+                    .map_err(McpProcessError::Connect)?;
+                McpClient::from_transport(t, rx)
+            }
+            // Dispatcher only routes remote transports here.
+            McpTransport::Stdio => return Err(McpProcessError::UrlNotConfigured),
+        };
+
+        match tokio::time::timeout(
+            Duration::from_secs(20),
+            client.initialize("ferrisscope", env!("CARGO_PKG_VERSION")),
+        )
+        .await
+        {
+            Ok(Ok(_)) => Ok(Self {
+                client,
+                child: None,
+                scratch_kubeconfig: None,
+            }),
+            Ok(Err(e)) => Err(McpProcessError::Initialize(e)),
+            Err(_) => Err(McpProcessError::Initialize(
+                ferrisscope_agent::McpError::InvalidResponse("MCP initialize timed out".into()),
+            )),
+        }
+    }
+
     /// Spawn the configured binary, do the MCP `initialize` handshake, and
     /// return a ready client.
     ///
@@ -98,7 +171,7 @@ impl McpProcess {
     /// is the sole `KUBECONFIG` value. The scratch is borrowed; the caller
     /// (`ChatRuntime`) owns its lifetime so multiple MCP servers in the same
     /// chat can share it without racing on cleanup.
-    pub(crate) async fn spawn(
+    async fn spawn_stdio(
         config: &McpServerConfig,
         kubeconfig_path: Option<&PathBuf>,
         context_name: Option<&str>,

--- a/crates/app/src/agent_native/logs.rs
+++ b/crates/app/src/agent_native/logs.rs
@@ -27,12 +27,14 @@ const MAX_TAIL_LINES: i64 = 5_000;
 /// `MAX_TOTAL_BYTES_HARD` via the `byte_cap` arg when it actually needs
 /// a deep read.
 const DEFAULT_TOTAL_BYTES: usize = 256 * 1024;
-/// Hard ceiling on how high `byte_cap` can go. 4 MiB is enough for a
-/// thorough investigation across a fleet of pods without letting one
-/// tool call swamp a chat's context window — at ~4 chars/token that's
-/// roughly 1M tokens, which exceeds the input budget on most models
-/// and would force compaction immediately. Keep below that.
-const MAX_TOTAL_BYTES_HARD: usize = 4 * 1024 * 1024;
+/// Hard ceiling on how high `byte_cap` can go. The transcript is protected
+/// independently now — an oversized result is spilled to disk and clipped to
+/// `MAX_TOOL_RESULT_BYTES` before it reaches the model — so this cap bounds
+/// transient memory + apiserver load, not the context window (the old 4 MiB
+/// limit was sized for the latter, which no longer applies). 16 MiB across a
+/// fleet of pods is plenty for a deep investigation, and the full captured
+/// logs stay searchable via `fs_tool_output_grep` / `fs_tool_output_read`.
+const MAX_TOTAL_BYTES_HARD: usize = 16 * 1024 * 1024;
 const MAX_PODS_PER_SELECTOR: usize = 10;
 
 #[derive(Debug, Deserialize)]
@@ -78,10 +80,13 @@ impl NativeTool for LogsTail {
             description: "One-shot pod log tail (no follow). Pass `pod` for a single pod, or \
                 `label_selector` to fan out across matching pods (capped at 10). Returns the most \
                 recent lines bounded by `tail_lines` (default 200, max 5000) AND a total-bytes \
-                cap (default 256 KiB, max 4 MiB via `byte_cap`). Set `previous: true` to read \
+                cap (default 256 KiB, max 16 MiB via `byte_cap`). Set `previous: true` to read \
                 logs from the previously-terminated container instance (useful right after a \
-                crash). When the response comes back with `truncated: true` and you need the \
-                fuller picture, retry with a larger `byte_cap` (e.g. 1048576 for 1 MiB)."
+                crash). When the response comes back with `truncated: true`, output beyond \
+                `byte_cap` was dropped — retry with a larger `byte_cap` (e.g. 4194304 for 4 MiB). \
+                Large results are saved automatically: search the full captured logs with \
+                `fs_tool_output_grep` / `fs_tool_output_read` using the handle shown in the \
+                truncation notice rather than re-fetching."
                 .to_string(),
             parameters: json!({
                 "type": "object",
@@ -99,8 +104,8 @@ impl NativeTool for LogsTail {
                     "byte_cap": {
                         "type": "integer",
                         "minimum": 1024,
-                        "maximum": 4_194_304,
-                        "description": "Total-bytes cap across all pods. Default 262144 (256 KiB), max 4194304 (4 MiB). Bump higher when investigating verbose / repeated-error logs."
+                        "maximum": MAX_TOTAL_BYTES_HARD,
+                        "description": "Total-bytes cap across all pods. Default 262144 (256 KiB), max 16777216 (16 MiB). Bump higher when investigating verbose / repeated-error logs; the full captured result stays searchable via fs_tool_output_grep."
                     }
                 },
                 "required": ["namespace"],

--- a/crates/app/src/agent_native/mod.rs
+++ b/crates/app/src/agent_native/mod.rs
@@ -36,6 +36,7 @@ pub(crate) mod portforward;
 pub(crate) mod prom;
 pub(crate) mod resources;
 pub(crate) mod rollout;
+pub(crate) mod tool_output;
 pub(crate) mod workload;
 
 /// Per-chat cluster context shared across every native tool.
@@ -161,7 +162,11 @@ where
 /// clone, internally ref-counted) and a shared `ChatClusterRef`; AppState is
 /// fetched per-call via `app.state::<AppState>()` so we don't need to thread
 /// an `Arc<AppState>` through the system.
-pub(crate) fn build_registry(app: AppHandle, cluster: ChatClusterRef) -> NativeRegistry {
+pub(crate) fn build_registry(
+    app: AppHandle,
+    cluster: ChatClusterRef,
+    spool: tool_output::ToolSpool,
+) -> NativeRegistry {
     let mut reg = NativeRegistry::new();
 
     // Node shell family — privileged, three-tool session lifecycle.
@@ -332,6 +337,12 @@ pub(crate) fn build_registry(app: AppHandle, cluster: ChatClusterRef) -> NativeR
 
     // Pod exec — kubectl-exec equivalent against an existing pod.
     reg.register(Arc::new(pod_exec::PodExec::new(app, cluster)));
+
+    // Tool-output recovery — read/grep the full payload of a result that was
+    // truncated before it entered the transcript. Read-only; serve from the
+    // per-chat spool directory.
+    reg.register(Arc::new(tool_output::ToolOutputRead::new(spool.clone())));
+    reg.register(Arc::new(tool_output::ToolOutputGrep::new(spool)));
 
     reg
 }

--- a/crates/app/src/agent_native/node_shell.rs
+++ b/crates/app/src/agent_native/node_shell.rs
@@ -49,10 +49,13 @@ const DEFAULT_DEBUG_IMAGE: &str = "alpine:3.20";
 /// call via the `namespace` arg.
 const DEFAULT_DEBUG_NAMESPACE: &str = "default";
 
-/// Cap on captured stdout/stderr. Keeps the LLM transcript bounded when the
-/// model asks for `cat /var/log/foo` against a 50MB file. Caller can chunk
-/// with `head` / `tail` if they want more.
-const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+/// Cap on captured stdout/stderr. Bounds memory when the model runs
+/// `cat /var/log/foo` against a 50MB file. Raised from 64 KiB now that the
+/// transcript is protected separately by the spill (oversized results are
+/// saved to disk and clipped to `MAX_TOOL_RESULT_BYTES`): the full captured
+/// output stays searchable via `fs_tool_output_grep` / `fs_tool_output_read`,
+/// and the caller can still chunk with `head` / `tail` for more than 1 MiB.
+const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
 /// Per-call exec timeout. The shell session itself lives until close; this
 /// just bounds one command. Long-running probes should be wrapped in
@@ -318,7 +321,9 @@ impl NativeTool for NodeShellExec {
         ToolSchema {
             name: "fs_node_shell_exec".into(),
             description: "Run a command in an open node-shell session (`chroot /host sh -c \
-                '<cmd>'` — paths are host-side). Output capped at 64KiB."
+                '<cmd>'` — paths are host-side). Output capped at 1 MiB; large output is saved \
+                automatically — search it with `fs_tool_output_grep` / `fs_tool_output_read` \
+                using the handle in the truncation notice."
                 .into(),
             parameters: json!({
                 "type": "object",

--- a/crates/app/src/agent_native/node_ssh.rs
+++ b/crates/app/src/agent_native/node_ssh.rs
@@ -57,11 +57,13 @@ use crate::state::AppState;
 const DEFAULT_SSH_PORT: u16 = 22;
 
 /// Cap on captured stdout/stderr per `_exec` call. Mirrors the node-shell
-/// 64 KiB budget so the agent's tool-result accounting stays consistent
-/// across the two fallback paths. The underlying `SshSession::exec` already
-/// caps each stream at 8 MiB to defend the heap; this is the further
-/// LLM-transcript cap on top.
-const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+/// Output budget, consistent with `fs_pod_exec` / `fs_node_shell_exec`. Raised
+/// from 64 KiB now that the transcript is protected by the spill (oversized
+/// results are saved to disk and clipped to `MAX_TOOL_RESULT_BYTES`); the full
+/// captured output stays searchable via `fs_tool_output_grep` / `_read`. The
+/// underlying `SshSession::exec` still caps each stream at 8 MiB to defend the
+/// heap, so this 1 MiB cap sits comfortably under that.
+const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
 /// Fallback per-call exec timeout. The operator can pass `timeout_seconds`
 /// to bound a specific command tighter; SSH itself has its own 10s exec
@@ -317,7 +319,9 @@ impl NativeTool for NodeSshExec {
         ToolSchema {
             name: "fs_node_ssh_exec".into(),
             description: "Run a command over an open node-SSH session (like `ssh user@host \
-                '<cmd>'`). No /host chroot. Output capped at 64KiB."
+                '<cmd>'`). No /host chroot. Output capped at 1 MiB; large output is saved \
+                automatically — search it with `fs_tool_output_grep` / `fs_tool_output_read` \
+                using the handle in the truncation notice."
                 .into(),
             parameters: json!({
                 "type": "object",

--- a/crates/app/src/agent_native/nodes_kubelet.rs
+++ b/crates/app/src/agent_native/nodes_kubelet.rs
@@ -27,9 +27,12 @@ use crate::state::AppState;
 /// `fs_logs_tail::DEFAULT_TOTAL_BYTES` so the model gets predictable
 /// budget across the two log paths.
 const DEFAULT_LOG_BYTES: usize = 256 * 1024;
-/// Hard ceiling — same 4 MiB as `fs_logs_tail`, kept consistent so the
-/// model only has to remember one number when bumping `byte_cap`.
-const MAX_LOG_BYTES_HARD: usize = 4 * 1024 * 1024;
+/// Hard ceiling — same 16 MiB as `fs_logs_tail`, kept consistent so the model
+/// only has to remember one number when bumping `byte_cap`. The transcript is
+/// protected by the spill (oversized results are saved to disk and clipped to
+/// `MAX_TOOL_RESULT_BYTES`), so this bounds memory / apiserver load only; the
+/// full captured log stays searchable via `fs_tool_output_grep` / `_read`.
+const MAX_LOG_BYTES_HARD: usize = 16 * 1024 * 1024;
 
 #[derive(Debug, Deserialize)]
 struct LogArgs {
@@ -82,8 +85,11 @@ impl NativeTool for NodesLog {
                 (alpha in 1.27, GA in 1.30). On older clusters the kubelet ignores `?query=` \
                 and returns the directory index; we surface that with a `note` so you can pick \
                 a file path from `entries` and retry, or fall back to a node shell.\n\n\
-                File output is capped at `byte_cap` (default 256 KiB, max 4 MiB); tighten with \
-                `tail_lines` or bump `byte_cap` if you hit the cap. Requires `nodes/proxy` RBAC."
+                File output is capped at `byte_cap` (default 256 KiB, max 16 MiB); tighten with \
+                `tail_lines` or bump `byte_cap` if you hit the cap. Large results are saved \
+                automatically — search the full captured log with `fs_tool_output_grep` / \
+                `fs_tool_output_read` using the handle in the truncation notice. Requires \
+                `nodes/proxy` RBAC."
                 .to_string(),
             parameters: json!({
                 "type": "object",
@@ -97,8 +103,8 @@ impl NativeTool for NodesLog {
                     "byte_cap": {
                         "type": "integer",
                         "minimum": 1024,
-                        "maximum": 4_194_304,
-                        "description": "Total-bytes cap. Default 262144 (256 KiB), max 4194304 (4 MiB)."
+                        "maximum": MAX_LOG_BYTES_HARD,
+                        "description": "Total-bytes cap. Default 262144 (256 KiB), max 16777216 (16 MiB). The full captured result stays searchable via fs_tool_output_grep."
                     }
                 },
                 "required": ["name", "query"],

--- a/crates/app/src/agent_native/pod_exec.rs
+++ b/crates/app/src/agent_native/pod_exec.rs
@@ -28,9 +28,13 @@ use tauri::{AppHandle, Manager};
 use crate::agent_native::{read_capped, ChatClusterRef};
 use crate::state::AppState;
 
-/// Output cap matches `fs_node_shell_exec` so the agent gets a consistent
-/// budget regardless of which exec path it picked.
-const MAX_OUTPUT_BYTES: usize = 64 * 1024;
+/// Output cap matches `fs_node_shell_exec` / `fs_node_ssh_exec` so the agent
+/// gets a consistent budget regardless of which exec path it picked. Raised
+/// from 64 KiB now that the transcript is protected by the spill (oversized
+/// results are saved to disk and clipped to `MAX_TOOL_RESULT_BYTES`): this cap
+/// bounds captured memory only, and the full output stays searchable via
+/// `fs_tool_output_grep` / `fs_tool_output_read`.
+const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
 /// Per-call timeout default. Overridable via `timeout_seconds`. Sized to
 /// fit comfortably under the agent loop's 300s ceiling so a tool-level
@@ -83,7 +87,9 @@ impl NativeTool for PodExec {
             description: "Run a command in an existing pod's container (kubectl exec). \
                 argv-only — pass `[\"sh\",\"-c\",\"...\"]` for shell (won't work in \
                 distroless / scratch images). Container defaults to the first in \
-                the pod spec. Output capped at 64KiB."
+                the pod spec. Output capped at 1 MiB; large output is saved \
+                automatically — search it with `fs_tool_output_grep` / `fs_tool_output_read` \
+                using the handle in the truncation notice."
                 .into(),
             parameters: json!({
                 "type": "object",

--- a/crates/app/src/agent_native/tool_output.rs
+++ b/crates/app/src/agent_native/tool_output.rs
@@ -1,0 +1,583 @@
+//! `fs_tool_output_read` / `fs_tool_output_grep` — recover the full payload of
+//! a tool result that was truncated before it entered the conversation.
+//!
+//! When a tool's output exceeds `MAX_TOOL_RESULT_BYTES` (see `agent.rs`) the
+//! agent loop spills the full text to disk and replaces it inline with a head
+//! preview plus a `handle` (the tool call id). These two read-only tools serve
+//! that spilled file back: page a byte window, or substring-search the whole
+//! thing. This is the same idea as opencode's truncation directory, adapted to
+//! ferrisscope's native-tool surface.
+//!
+//! ## Layout & lifecycle
+//!
+//! `<cache_dir>/tool-output/<cluster>/<session>/<handle>`. Files are written
+//! under the OS cache dir (sibling concept to the session JSONL, which lives
+//! under the *config* dir). They deliberately **survive chat reopen and app
+//! restart** — a reopened chat rebuilds these tools against the same
+//! cluster/session path, so the handles from the rehydrated transcript still
+//! resolve. Cleanup is by TTL sweep ([`sweep_expired`], run on chat open),
+//! not on chat close, so the operator can still inspect a large result after
+//! closing and reopening the chat. Best-effort throughout: a missing cache
+//! dir or a failed write degrades to lossy truncation, never a panic.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+use directories::ProjectDirs;
+use ferrisscope_agent::native::{NativeTool, NativeToolError};
+use ferrisscope_agent::types::ToolSchema;
+use ferrisscope_agent::ToolCategory;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::agent::char_boundary_floor;
+
+/// How long a spilled output lingers before the sweep reaps it. Matches
+/// opencode's retention. The cache dir is OS-reapable anyway; this bounds our
+/// own footprint without cutting off an operator who comes back the next day.
+const RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+/// Default + max bytes one `fs_tool_output_read` window returns. Capped at the
+/// same order of magnitude as the transcript limit so paging the spool can't
+/// re-blow the context window it was meant to relieve.
+const READ_DEFAULT_LIMIT: usize = 30_000;
+const READ_MAX_LIMIT: usize = 100_000;
+
+/// `fs_tool_output_grep` guardrails.
+const GREP_DEFAULT_MAX_MATCHES: usize = 50;
+const GREP_MAX_MATCHES: usize = 500;
+const GREP_DEFAULT_CONTEXT: usize = 160;
+const GREP_MAX_CONTEXT: usize = 2_000;
+
+/// Keep path components tame — same shape as the session store's sanitiser.
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Root for all spilled tool output. `None` only when the platform exposes no
+/// cache dir (extremely rare); callers degrade to lossy truncation.
+fn spool_root() -> Option<PathBuf> {
+    ProjectDirs::from("dev", "ferrisscope", "ferrisscope")
+        .map(|p| p.cache_dir().join("tool-output"))
+}
+
+/// Handle to one chat's spool directory. Cheap to clone (a `PathBuf`). Shared
+/// between the agent loop (writes on truncation) and the read/grep tools
+/// (serve windows / matches). `dir == None` means no cache dir is available;
+/// `put` no-ops and the loop falls back to lossy truncation.
+#[derive(Clone)]
+pub(crate) struct ToolSpool {
+    dir: Option<PathBuf>,
+}
+
+impl ToolSpool {
+    pub(crate) fn new(cluster_id: &str, session_id: &str) -> Self {
+        let dir = spool_root().map(|r| r.join(sanitize(cluster_id)).join(sanitize(session_id)));
+        Self { dir }
+    }
+
+    fn path_for(&self, handle: &str) -> Option<PathBuf> {
+        self.dir.as_ref().map(|d| d.join(sanitize(handle)))
+    }
+
+    /// Persist `content` under `handle`. Best-effort: returns `false` (caller
+    /// falls back to lossy truncation) when there's no cache dir or the write
+    /// fails. Never panics.
+    pub(crate) async fn put(&self, handle: &str, content: &str) -> bool {
+        let (Some(dir), Some(path)) = (self.dir.as_ref(), self.path_for(handle)) else {
+            return false;
+        };
+        if let Err(e) = tokio::fs::create_dir_all(dir).await {
+            tracing::warn!(error = %e, "tool-output spool: mkdir failed");
+            return false;
+        }
+        if let Err(e) = tokio::fs::write(&path, content).await {
+            tracing::warn!(error = %e, "tool-output spool: write failed");
+            return false;
+        }
+        true
+    }
+
+    async fn load(&self, handle: &str) -> Result<String, NativeToolError> {
+        let path = self
+            .path_for(handle)
+            .ok_or_else(|| NativeToolError::msg("tool-output spool unavailable on this host"))?;
+        match tokio::fs::read_to_string(&path).await {
+            Ok(s) => Ok(s),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                Err(NativeToolError::msg(format!(
+                    "no spilled output for handle `{handle}` — it may have expired, or this \
+                     chat predates output spooling. Re-run the original tool with a narrower \
+                     request (label/field selector, a more specific name, namespace, or limit)."
+                )))
+            }
+            Err(e) => Err(NativeToolError::msg(format!("read spool failed: {e}"))),
+        }
+    }
+}
+
+/// Drop spilled outputs whose newest file is older than [`RETENTION`].
+/// Best-effort; called on chat open. Walks `<root>/<cluster>/<session>` and
+/// removes whole session dirs past the cutoff, then prunes emptied cluster
+/// dirs so the tree doesn't accrete forever.
+pub(crate) async fn sweep_expired() {
+    let Some(root) = spool_root() else { return };
+    let Some(cutoff) = SystemTime::now().checked_sub(RETENTION) else {
+        return;
+    };
+    let Ok(mut clusters) = tokio::fs::read_dir(&root).await else {
+        return; // no spool yet
+    };
+    while let Ok(Some(cluster)) = clusters.next_entry().await {
+        let cluster_path = cluster.path();
+        let Ok(mut sessions) = tokio::fs::read_dir(&cluster_path).await else {
+            continue;
+        };
+        let mut any_left = false;
+        while let Ok(Some(session)) = sessions.next_entry().await {
+            let session_path = session.path();
+            if dir_is_stale(&session_path, cutoff).await {
+                let _ = tokio::fs::remove_dir_all(&session_path).await;
+            } else {
+                any_left = true;
+            }
+        }
+        if !any_left {
+            let _ = tokio::fs::remove_dir(&cluster_path).await;
+        }
+    }
+}
+
+/// True when every file in `dir` is older than `cutoff` (or the dir is empty /
+/// unreadable). A session touched recently keeps all its handles.
+async fn dir_is_stale(dir: &Path, cutoff: SystemTime) -> bool {
+    let Ok(mut entries) = tokio::fs::read_dir(dir).await else {
+        return true;
+    };
+    let mut newest: Option<SystemTime> = None;
+    while let Ok(Some(e)) = entries.next_entry().await {
+        if let Ok(modified) = e.metadata().await.and_then(|m| m.modified()) {
+            newest = Some(newest.map_or(modified, |n| n.max(modified)));
+        }
+    }
+    newest.is_none_or(|m| m < cutoff)
+}
+
+// ── read ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct ReadArgs {
+    handle: String,
+    #[serde(default)]
+    offset: usize,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+pub(crate) struct ToolOutputRead {
+    spool: ToolSpool,
+}
+
+impl ToolOutputRead {
+    pub(crate) fn new(spool: ToolSpool) -> Self {
+        Self { spool }
+    }
+}
+
+#[async_trait]
+impl NativeTool for ToolOutputRead {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "fs_tool_output_read".to_string(),
+            description: format!(
+                "Page through the full output of a tool result that was truncated before it \
+                 entered the conversation. Oversized output is spilled to disk and shown \
+                 inline as a head preview plus a `handle` (the tool call id, e.g. \
+                 `call_abc123`). Pass that handle to read a byte window: up to {READ_MAX_LIMIT} \
+                 bytes per call (default {READ_DEFAULT_LIMIT}). Use the returned `next_offset` to \
+                 continue. To locate specific content in a large result prefer \
+                 `fs_tool_output_grep`. Spilled output persists for {days} days and survives \
+                 reopening the chat.",
+                days = RETENTION.as_secs() / 86_400,
+            ),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "handle": {
+                        "type": "string",
+                        "description": "Handle from the truncation notice (the tool call id)."
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": "Byte offset to start reading from."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": READ_MAX_LIMIT,
+                        "default": READ_DEFAULT_LIMIT,
+                        "description": "Max bytes to return."
+                    }
+                },
+                "required": ["handle"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Read
+    }
+
+    async fn call(&self, args: Value) -> Result<Value, NativeToolError> {
+        let a: ReadArgs = serde_json::from_value(args)
+            .map_err(|e| NativeToolError::msg(format!("invalid args: {e}")))?;
+        let content = self.spool.load(&a.handle).await?;
+        let total = content.len();
+        let limit = a
+            .limit
+            .unwrap_or(READ_DEFAULT_LIMIT)
+            .clamp(1, READ_MAX_LIMIT);
+        let start = char_boundary_floor(&content, a.offset.min(total));
+        let end = char_boundary_floor(&content, start.saturating_add(limit).min(total));
+        let slice = &content[start..end.max(start)];
+        Ok(json!({
+            "handle": a.handle,
+            "total_bytes": total,
+            "offset": start,
+            "returned_bytes": slice.len(),
+            "next_offset": if end < total { Some(end) } else { None },
+            "eof": end >= total,
+            "content": slice,
+        }))
+    }
+}
+
+// ── grep ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct GrepArgs {
+    handle: String,
+    pattern: String,
+    #[serde(default)]
+    ignore_case: bool,
+    #[serde(default)]
+    max_matches: Option<usize>,
+    #[serde(default)]
+    context_bytes: Option<usize>,
+}
+
+pub(crate) struct ToolOutputGrep {
+    spool: ToolSpool,
+}
+
+impl ToolOutputGrep {
+    pub(crate) fn new(spool: ToolSpool) -> Self {
+        Self { spool }
+    }
+}
+
+#[async_trait]
+impl NativeTool for ToolOutputGrep {
+    fn schema(&self) -> ToolSchema {
+        ToolSchema {
+            name: "fs_tool_output_grep".to_string(),
+            description: format!(
+                "Substring-search the full output of a tool result that was truncated before \
+                 it entered the conversation (see `fs_tool_output_read` for the handle). \
+                 Returns each match's byte offset, line number, and a surrounding snippet \
+                 (±{GREP_DEFAULT_CONTEXT} bytes by default). Plain substring match — not regex. \
+                 Caps at {GREP_DEFAULT_MAX_MATCHES} matches by default ({GREP_MAX_MATCHES} max); \
+                 `truncated: true` means more exist past the cap."
+            ),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "handle": {
+                        "type": "string",
+                        "description": "Handle from the truncation notice (the tool call id)."
+                    },
+                    "pattern": {
+                        "type": "string",
+                        "description": "Substring to search for. Not a regex."
+                    },
+                    "ignore_case": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "ASCII case-insensitive match."
+                    },
+                    "max_matches": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": GREP_MAX_MATCHES,
+                        "default": GREP_DEFAULT_MAX_MATCHES
+                    },
+                    "context_bytes": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": GREP_MAX_CONTEXT,
+                        "default": GREP_DEFAULT_CONTEXT,
+                        "description": "Bytes of surrounding context to include around each match."
+                    }
+                },
+                "required": ["handle", "pattern"],
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    fn category(&self) -> ToolCategory {
+        ToolCategory::Read
+    }
+
+    async fn call(&self, args: Value) -> Result<Value, NativeToolError> {
+        let a: GrepArgs = serde_json::from_value(args)
+            .map_err(|e| NativeToolError::msg(format!("invalid args: {e}")))?;
+        if a.pattern.is_empty() {
+            return Err(NativeToolError::msg("pattern must not be empty"));
+        }
+        let content = self.spool.load(&a.handle).await?;
+        let max_matches = a
+            .max_matches
+            .unwrap_or(GREP_DEFAULT_MAX_MATCHES)
+            .clamp(1, GREP_MAX_MATCHES);
+        let context = a
+            .context_bytes
+            .unwrap_or(GREP_DEFAULT_CONTEXT)
+            .clamp(0, GREP_MAX_CONTEXT);
+
+        let bytes = content.as_bytes();
+        let mut matches: Vec<Value> = Vec::new();
+        let mut from = 0usize;
+        let mut nl_counted_to = 0usize;
+        let mut line = 1usize;
+        while matches.len() < max_matches {
+            let Some(pos) = next_match(&content, &a.pattern, from, a.ignore_case) else {
+                break;
+            };
+            // Line number: count newlines between the last match and this one.
+            // Byte-slice (never str-slice) so a non-boundary offset from the
+            // case-insensitive path can't panic.
+            line += bytes[nl_counted_to..pos]
+                .iter()
+                .filter(|&&b| b == b'\n')
+                .count();
+            nl_counted_to = pos;
+            let (window_offset, snippet) = window(&content, pos, a.pattern.len(), context);
+            matches.push(json!({
+                "offset": pos,
+                "line": line,
+                "window_offset": window_offset,
+                "snippet": snippet,
+            }));
+            from = pos + a.pattern.len(); // pattern non-empty ⇒ forward progress
+        }
+        let truncated = matches.len() == max_matches
+            && next_match(&content, &a.pattern, from, a.ignore_case).is_some();
+
+        Ok(json!({
+            "handle": a.handle,
+            "pattern": a.pattern,
+            "ignore_case": a.ignore_case,
+            "total_bytes": content.len(),
+            "match_count": matches.len(),
+            "truncated": truncated,
+            "matches": matches,
+        }))
+    }
+}
+
+/// First match at or after byte `from`. Case-sensitive uses `str::find`
+/// (memchr-fast, boundary-aligned offsets). Case-insensitive folds ASCII only
+/// — which preserves byte length, so offsets still line up with the original
+/// content. Returns `None` past the end.
+fn next_match(content: &str, pattern: &str, from: usize, ignore_case: bool) -> Option<usize> {
+    let h = content.as_bytes();
+    let n = pattern.as_bytes();
+    if n.is_empty() || from > h.len() {
+        return None;
+    }
+    if ignore_case {
+        let mut i = from;
+        while i + n.len() <= h.len() {
+            if h[i..i + n.len()].eq_ignore_ascii_case(n) {
+                return Some(i);
+            }
+            i += 1;
+        }
+        None
+    } else {
+        // `from` is always a char boundary here (0, or the end of a previous
+        // case-sensitive match), so `get(from..)` is `Some`.
+        content.get(from..)?.find(pattern).map(|p| from + p)
+    }
+}
+
+/// Byte window of `content` around a match, clamped to char boundaries on both
+/// ends so the snippet is always valid UTF-8. Returns `(window_start, snippet)`.
+fn window(content: &str, pos: usize, match_len: usize, context: usize) -> (usize, String) {
+    let start = char_boundary_floor(content, pos.saturating_sub(context));
+    let raw_end = pos
+        .saturating_add(match_len)
+        .saturating_add(context)
+        .min(content.len());
+    let end = char_boundary_floor(content, raw_end).max(start);
+    (start, content[start..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_spool() -> ToolSpool {
+        let dir = std::env::temp_dir().join(format!("fs-spool-test-{}", uuid::Uuid::new_v4()));
+        ToolSpool { dir: Some(dir) }
+    }
+
+    #[test]
+    fn read_schema_advertises_prefix_and_required_handle() {
+        let s = ToolOutputRead::new(temp_spool()).schema();
+        assert_eq!(s.name, "fs_tool_output_read");
+        let required = s.parameters["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v == "handle"));
+    }
+
+    #[test]
+    fn grep_schema_and_categories_are_read() {
+        let g = ToolOutputGrep::new(temp_spool());
+        assert_eq!(g.schema().name, "fs_tool_output_grep");
+        assert_eq!(g.category(), ToolCategory::Read);
+        assert_eq!(
+            ToolOutputRead::new(temp_spool()).category(),
+            ToolCategory::Read
+        );
+    }
+
+    #[tokio::test]
+    async fn read_pages_window_and_reports_next_offset() {
+        let spool = temp_spool();
+        let body = "0123456789".repeat(10); // 100 bytes
+        assert!(spool.put("h1", &body).await);
+        let tool = ToolOutputRead::new(spool);
+
+        let first = tool
+            .call(json!({ "handle": "h1", "offset": 0, "limit": 40 }))
+            .await
+            .unwrap();
+        assert_eq!(first["total_bytes"], 100);
+        assert_eq!(first["returned_bytes"], 40);
+        assert_eq!(first["eof"], false);
+        assert_eq!(first["next_offset"], 40);
+        assert_eq!(first["content"].as_str().unwrap(), &body[..40]);
+
+        let last = tool
+            .call(json!({ "handle": "h1", "offset": 80, "limit": 40 }))
+            .await
+            .unwrap();
+        assert_eq!(last["returned_bytes"], 20);
+        assert_eq!(last["eof"], true);
+        assert!(last["next_offset"].is_null());
+    }
+
+    #[tokio::test]
+    async fn read_missing_handle_is_a_clear_error() {
+        let tool = ToolOutputRead::new(temp_spool());
+        let err = tool.call(json!({ "handle": "nope" })).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("nope"), "error names the handle: {msg}");
+        assert!(msg.contains("Re-run"), "error suggests recovery: {msg}");
+    }
+
+    #[tokio::test]
+    async fn grep_finds_matches_with_line_numbers() {
+        let spool = temp_spool();
+        let body = "alpha error one\nbeta ok\ngamma error two\ndelta ok\n";
+        assert!(spool.put("g1", body).await);
+        let tool = ToolOutputGrep::new(spool);
+
+        let out = tool
+            .call(json!({ "handle": "g1", "pattern": "error" }))
+            .await
+            .unwrap();
+        assert_eq!(out["match_count"], 2);
+        assert_eq!(out["truncated"], false);
+        let matches = out["matches"].as_array().unwrap();
+        assert_eq!(matches[0]["line"], 1);
+        assert_eq!(matches[1]["line"], 3);
+        assert!(matches[0]["snippet"]
+            .as_str()
+            .unwrap()
+            .contains("alpha error"));
+    }
+
+    #[tokio::test]
+    async fn grep_respects_max_matches_and_flags_truncation() {
+        let spool = temp_spool();
+        let body = "x\n".repeat(10); // 10 lines each containing 'x'
+        assert!(spool.put("g2", &body).await);
+        let tool = ToolOutputGrep::new(spool);
+
+        let out = tool
+            .call(json!({ "handle": "g2", "pattern": "x", "max_matches": 3 }))
+            .await
+            .unwrap();
+        assert_eq!(out["match_count"], 3);
+        assert_eq!(out["truncated"], true);
+    }
+
+    #[tokio::test]
+    async fn grep_ignore_case_folds_ascii() {
+        let spool = temp_spool();
+        assert!(spool.put("g3", "Found a FATAL Fault").await);
+        let tool = ToolOutputGrep::new(spool);
+
+        let sensitive = tool
+            .call(json!({ "handle": "g3", "pattern": "fatal" }))
+            .await
+            .unwrap();
+        assert_eq!(sensitive["match_count"], 0);
+
+        let insensitive = tool
+            .call(json!({ "handle": "g3", "pattern": "fatal", "ignore_case": true }))
+            .await
+            .unwrap();
+        assert_eq!(insensitive["match_count"], 1);
+    }
+
+    #[tokio::test]
+    async fn grep_handles_multibyte_without_panic() {
+        let spool = temp_spool();
+        // Multibyte chars around the match so naive slicing would panic.
+        assert!(spool.put("g4", "héllo wörld NEEDLE café").await);
+        let tool = ToolOutputGrep::new(spool);
+        let out = tool
+            .call(json!({ "handle": "g4", "pattern": "NEEDLE", "context_bytes": 3 }))
+            .await
+            .unwrap();
+        assert_eq!(out["match_count"], 1);
+        // Snippet is valid UTF-8 (it deserialised as a str at all).
+        assert!(out["matches"][0]["snippet"]
+            .as_str()
+            .unwrap()
+            .contains("NEEDLE"));
+    }
+
+    #[tokio::test]
+    async fn put_then_load_round_trips() {
+        let spool = temp_spool();
+        let body = "round trip payload";
+        assert!(spool.put("rt", body).await);
+        assert_eq!(spool.load("rt").await.unwrap(), body);
+    }
+}

--- a/ui/src/components/chat/ToolGroupBubble.test.tsx
+++ b/ui/src/components/chat/ToolGroupBubble.test.tsx
@@ -1,0 +1,156 @@
+// ToolGroupBubble wraps a run of tool activity in one collapsible card with
+// two independent layers of expansion: the group viewport (collapsed clips to
+// N rows) and per-row payloads. The bug these tests pin: a row click while the
+// group was collapsed silently recorded "open" state that did nothing until a
+// later group expand, which then sprang the row open as if pre-selected. The
+// fix keeps the two layers in sync — opening a row expands the group;
+// collapsing the group clears open rows.
+
+import { describe, it, expect } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { ToolGroupBubble, type ToolGroupItem } from "./ToolGroupBubble";
+import type { ChatViewMessage, ExecutingToolCall } from "./chatStreaming";
+
+function resultItem(
+  overrides: Partial<ChatViewMessage> & { id: string },
+): ToolGroupItem {
+  return {
+    kind: "result",
+    message: {
+      role: "tool",
+      content: "",
+      ...overrides,
+    } as ChatViewMessage,
+  };
+}
+
+const ITEMS: ToolGroupItem[] = [
+  resultItem({
+    id: "m1",
+    toolCallId: "call-1",
+    toolName: "fs_pods_list",
+    toolPreview: "preview-one",
+    toolLineCount: 3,
+    content: "PAYLOAD_ONE_BODY",
+  }),
+  resultItem({
+    id: "m2",
+    toolCallId: "call-2",
+    toolName: "fs_pods_get",
+    toolPreview: "preview-two",
+    toolLineCount: 5,
+    content: "PAYLOAD_TWO_BODY",
+  }),
+];
+
+function headerButton(container: HTMLElement): HTMLButtonElement {
+  // The group header is the first button; its title carries the group state.
+  const btn = container.querySelector<HTMLButtonElement>(
+    'button[title$="tool group"]',
+  );
+  if (!btn) throw new Error("group header button not found");
+  return btn;
+}
+
+function rowButtons(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>("button.fs-tool-strip"),
+  );
+}
+
+function rowButton(container: HTMLElement, index: number): HTMLButtonElement {
+  const btn = rowButtons(container)[index];
+  if (!btn) throw new Error(`row button ${index} not found`);
+  return btn;
+}
+
+describe("ToolGroupBubble", () => {
+  it("renders the group header with the tool-call count", () => {
+    const { getByText } = render(<ToolGroupBubble mode="dark" items={ITEMS} />);
+    expect(getByText("2 tool calls")).toBeInTheDocument();
+  });
+
+  it("starts collapsed: no row payload is visible", () => {
+    const { queryByText } = render(
+      <ToolGroupBubble mode="dark" items={ITEMS} />,
+    );
+    expect(queryByText("PAYLOAD_ONE_BODY")).toBeNull();
+    expect(queryByText("PAYLOAD_TWO_BODY")).toBeNull();
+  });
+
+  it("clicking a row while collapsed expands the group AND opens that row in one click", () => {
+    // Regression: previously a single click recorded hidden open state and
+    // showed nothing — the operator had to expand the group separately, then
+    // the row sprang open unexpectedly.
+    const { container, getByText, queryByText } = render(
+      <ToolGroupBubble mode="dark" items={ITEMS} />,
+    );
+    expect(queryByText("PAYLOAD_ONE_BODY")).toBeNull();
+
+    fireEvent.click(rowButton(container, 0));
+
+    // Group is now expanded (header title flipped) and the clicked row's
+    // payload is visible — without a second click.
+    expect(headerButton(container).title).toBe("Collapse tool group");
+    expect(getByText("PAYLOAD_ONE_BODY")).toBeInTheDocument();
+    // Sibling row stays closed — only the clicked row opened.
+    expect(queryByText("PAYLOAD_TWO_BODY")).toBeNull();
+  });
+
+  it("expanding the group via the header does NOT auto-open any row payload", () => {
+    // Regression: a leftover open id used to surface here as a ghost-expanded
+    // row. Expanding should reveal the row list, nothing more.
+    const { container, queryByText } = render(
+      <ToolGroupBubble mode="dark" items={ITEMS} />,
+    );
+    fireEvent.click(headerButton(container));
+    expect(headerButton(container).title).toBe("Collapse tool group");
+    expect(queryByText("PAYLOAD_ONE_BODY")).toBeNull();
+    expect(queryByText("PAYLOAD_TWO_BODY")).toBeNull();
+  });
+
+  it("collapsing the group clears open rows so re-expanding starts clean", () => {
+    const { container, getByText, queryByText } = render(
+      <ToolGroupBubble mode="dark" items={ITEMS} />,
+    );
+    // Expand group, open a row.
+    fireEvent.click(headerButton(container));
+    fireEvent.click(rowButton(container, 0));
+    expect(getByText("PAYLOAD_ONE_BODY")).toBeInTheDocument();
+
+    // Collapse, then expand again — no ghost-open row.
+    fireEvent.click(headerButton(container)); // collapse
+    expect(queryByText("PAYLOAD_ONE_BODY")).toBeNull();
+    fireEvent.click(headerButton(container)); // expand again
+    expect(queryByText("PAYLOAD_ONE_BODY")).toBeNull();
+  });
+
+  it("clicking an open row again collapses just that row, leaving the group expanded", () => {
+    const { container, getByText, queryByText } = render(
+      <ToolGroupBubble mode="dark" items={ITEMS} />,
+    );
+    fireEvent.click(rowButton(container, 0)); // expand group + open row
+    expect(getByText("PAYLOAD_ONE_BODY")).toBeInTheDocument();
+
+    fireEvent.click(rowButton(container, 0)); // close the row
+    expect(queryByText("PAYLOAD_ONE_BODY")).toBeNull();
+    // Group itself remains expanded.
+    expect(headerButton(container).title).toBe("Collapse tool group");
+  });
+
+  it("renders an in-flight execution row without a payload toggle", () => {
+    const executing: ExecutingToolCall = {
+      toolCallId: "call-run",
+      name: "fs_pods_run",
+      startedAt: Date.now(),
+    };
+    const items: ToolGroupItem[] = [{ kind: "executing", entry: executing }];
+    const { getByText, container } = render(
+      <ToolGroupBubble mode="dark" items={items} />,
+    );
+    expect(getByText("fs_pods_run")).toBeInTheDocument();
+    expect(getByText("running")).toBeInTheDocument();
+    // Executing rows are not clickable strips — no payload to expand yet.
+    expect(rowButtons(container)).toHaveLength(0);
+  });
+});

--- a/ui/src/components/chat/ToolGroupBubble.tsx
+++ b/ui/src/components/chat/ToolGroupBubble.tsx
@@ -125,13 +125,34 @@ function ToolGroupBubbleInner({ items }: Props) {
 
   if (!latest) return null;
 
-  const toggleOpen = (key: string) =>
+  // Collapsing the group resets per-row open state so re-expanding always
+  // starts from the clean summary view. Without this, a row left open
+  // before a collapse would silently reappear expanded on the next expand —
+  // state the operator can't see while collapsed, surfacing as a surprise.
+  const toggleGroup = () => {
+    if (expanded) {
+      setExpanded(false);
+      setOpenIds(new Set());
+    } else {
+      setExpanded(true);
+    }
+  };
+
+  // A row's payload only renders while the group is expanded (the collapsed
+  // viewport clips per-row height). So a row click in collapsed mode expands
+  // the group *and* opens that row in one batched update — the operator gets
+  // immediate, visible feedback. Previously the click only recorded hidden
+  // open state that did nothing until a later group expand, then sprang the
+  // row open as if pre-selected.
+  const toggleOpen = (key: string) => {
+    if (!expanded) setExpanded(true);
     setOpenIds((prev) => {
       const next = new Set(prev);
       if (next.has(key)) next.delete(key);
       else next.add(key);
       return next;
     });
+  };
 
   return (
     <div
@@ -150,7 +171,7 @@ function ToolGroupBubbleInner({ items }: Props) {
     >
       <button
         type="button"
-        onClick={() => setExpanded((v) => !v)}
+        onClick={toggleGroup}
         style={{
           display: "flex",
           alignItems: "center",
@@ -230,8 +251,9 @@ export const ToolGroupBubble = memo(ToolGroupBubbleInner);
 //     pulsing accent dot + "running Xs" elapsed counter, no payload
 //     expand (no content yet).
 //   - `result`: tool finished; renders ✓/✗ + name + preview + line
-//     count, click to expand the payload (only when the group itself
-//     is also expanded — collapsed view clips per-row height anyway).
+//     count, click to expand the payload. Clicking a row while the group
+//     is collapsed expands the group too, so the payload is visible (the
+//     collapsed viewport clips per-row height).
 // Keying both states under the same tool_call_id means the transition
 // is an in-place update, not a remount.
 function ToolRow({
@@ -331,8 +353,10 @@ function ResultRow({
   const content = message.content ?? "";
   const preview = message.toolPreview ?? "";
   const lineCount = message.toolLineCount ?? 0;
-  // Payload-expand only makes sense when the group itself is expanded —
-  // when collapsed the viewport clips to N rows anyway.
+  // The payload only renders when the group is expanded — the collapsed
+  // viewport clips to N rows. `open` is kept in sync with `expanded` by the
+  // group's toggle handlers (opening a row expands the group; collapsing the
+  // group clears open rows), so this AND never strands hidden open state.
   const showPayload = open && expanded;
 
   return (
@@ -359,14 +383,14 @@ function ResultRow({
           color: t.textMuted,
           fontFamily: FF_MONO,
           fontSize: FS_SM,
-          cursor: expanded ? "pointer" : "default",
+          cursor: "pointer",
           textAlign: "left",
           width: "100%",
           ["--fs-tool-hover" as string]: t.hover,
           ["--fs-tool-open-bg" as string]: t.surfaceAlt,
           contain: "content",
         }}
-        title={expanded ? (showPayload ? "Collapse" : "Expand") : undefined}
+        title={showPayload ? "Collapse" : "Expand"}
       >
         <span style={{ color: t.textDim, width: 8 }}>
           {showPayload ? "▾" : "▸"}

--- a/ui/src/components/settings/AiSection.mcpEnv.test.tsx
+++ b/ui/src/components/settings/AiSection.mcpEnv.test.tsx
@@ -1,0 +1,121 @@
+// The MCP server "Env" editor used to be a free-text `KEY=VALUE` textarea —
+// operators had to hand-type `=` (and sometimes empty-string quotes). It now
+// reuses the shared KvEditor (separate KEY / VALUE inputs + an Add button),
+// committing to the backend on blur of the whole editor (not per keystroke).
+// These tests pin that behaviour at the McpServerRow boundary.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, within } from "@testing-library/react";
+import { McpServerRow } from "./AiSection";
+import { tokens } from "../../theme";
+import type { McpServerConfig } from "../../types";
+
+const t = tokens("dark");
+// KvEditor paints invalid inputs with the theme's `bad` token; in the dark
+// palette that resolves to this rgb (mirrors edit.component.test.tsx).
+const BAD_RGB = "rgb(244, 63, 94)";
+
+function server(env: Record<string, string>): McpServerConfig {
+  return {
+    id: "s1",
+    name: "github",
+    transport: "stdio",
+    command: "/usr/local/bin/srv",
+    url: null,
+    args: [],
+    env,
+    headers: {},
+    trust_as_read: false,
+    enabled: true,
+  };
+}
+
+function renderRow(env: Record<string, string>) {
+  const onChange = vi.fn();
+  const utils = render(
+    <McpServerRow
+      t={t}
+      value={server(env)}
+      open
+      onToggleOpen={() => {}}
+      onChange={onChange}
+      onRemove={() => {}}
+    />,
+  );
+  return { ...utils, onChange };
+}
+
+describe("McpServerRow env editor", () => {
+  it("renders existing env as separate KEY / VALUE fields with an Add button", () => {
+    const { getByDisplayValue, getByText, queryByDisplayValue } = renderRow({
+      GITHUB_TOKEN: "abc",
+    });
+    expect(getByDisplayValue("GITHUB_TOKEN")).toBeInTheDocument();
+    expect(getByDisplayValue("abc")).toBeInTheDocument();
+    // Add affordance is present…
+    expect(getByText("Add")).toBeInTheDocument();
+    // …and the old combined `KEY=VALUE` string is gone.
+    expect(queryByDisplayValue("GITHUB_TOKEN=abc")).toBeNull();
+  });
+
+  it("editing a value does not commit per keystroke, only on blur-out", () => {
+    const { getByDisplayValue, onChange } = renderRow({ A: "1" });
+    const valueInput = getByDisplayValue("1");
+    fireEvent.change(valueInput, { target: { value: "2" } });
+    // No backend roundtrip yet — the draft lives in the local buffer.
+    expect(onChange).not.toHaveBeenCalled();
+    // Focus leaving the whole editor (relatedTarget outside) commits.
+    fireEvent.blur(valueInput, { relatedTarget: document.body });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ env: { A: "2" } });
+  });
+
+  it("tabbing between a row's KEY and VALUE does not commit", () => {
+    const { getByDisplayValue, onChange } = renderRow({ A: "1" });
+    const keyInput = getByDisplayValue("A");
+    const valueInput = getByDisplayValue("1");
+    fireEvent.change(keyInput, { target: { value: "B" } });
+    // Focus moves from KEY to VALUE — still inside the editor → no commit.
+    fireEvent.blur(keyInput, { relatedTarget: valueInput });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("Add + fill a new pair commits it on blur-out (no '=' typed)", () => {
+    const { getByText, getByPlaceholderText, onChange } = renderRow({});
+    fireEvent.click(getByText("Add"));
+    const keyInput = getByPlaceholderText("KEY");
+    const valueInput = getByPlaceholderText("VALUE");
+    fireEvent.change(keyInput, { target: { value: "API_KEY" } });
+    fireEvent.change(valueInput, { target: { value: "s3cr3t" } });
+    fireEvent.blur(valueInput, { relatedTarget: document.body });
+    expect(onChange).toHaveBeenCalledWith({ env: { API_KEY: "s3cr3t" } });
+  });
+
+  it("an empty value commits as an empty string (no quotes needed)", () => {
+    const { getByText, getByPlaceholderText, onChange } = renderRow({});
+    fireEvent.click(getByText("Add"));
+    const keyInput = getByPlaceholderText("KEY");
+    fireEvent.change(keyInput, { target: { value: "EMPTY" } });
+    // Value left blank.
+    fireEvent.blur(keyInput, { relatedTarget: document.body });
+    expect(onChange).toHaveBeenCalledWith({ env: { EMPTY: "" } });
+  });
+
+  it("flags a key containing '=' as invalid (red outline)", () => {
+    const { getByDisplayValue } = renderRow({ "FOO=BAR": "x" });
+    const keyInput = getByDisplayValue("FOO=BAR");
+    expect(keyInput.getAttribute("style")).toContain(BAD_RGB);
+  });
+
+  it("removing a row commits the env without that key", () => {
+    const { container, onChange } = renderRow({ KEEP: "1", DROP: "2" });
+    // The row × buttons carry the "Remove" title (vs the bottom +Add).
+    const removeButtons = within(container).getAllByTitle("Remove");
+    // Rows render in insertion order: KEEP first, DROP second.
+    fireEvent.click(removeButtons[1]!);
+    // Soft-delete lives in the buffer; commit on a subsequent blur-out.
+    const keepInput = within(container).getByDisplayValue("1");
+    fireEvent.blur(keepInput, { relatedTarget: document.body });
+    expect(onChange).toHaveBeenCalledWith({ env: { KEEP: "1" } });
+  });
+});

--- a/ui/src/components/settings/AiSection.mcpTransport.test.tsx
+++ b/ui/src/components/settings/AiSection.mcpTransport.test.tsx
@@ -1,0 +1,135 @@
+// The MCP server row gained a transport selector (stdio / sse / http) and a
+// per-server "trust" switch (auto-approve every tool). These tests pin the
+// conditional fields per transport, the trust toggle wiring, and the
+// transport-specific commits (URL, headers).
+
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import { McpServerRow } from "./AiSection";
+import { tokens } from "../../theme";
+import type { McpServerConfig } from "../../types";
+
+const t = tokens("dark");
+
+// The Select popover calls scrollIntoView on open; jsdom doesn't implement it.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+const STDIO_PLACEHOLDER = "/usr/local/bin/my-mcp-server";
+const URL_PLACEHOLDER = "https://mcp.example.com/rpc";
+
+function server(overrides: Partial<McpServerConfig> = {}): McpServerConfig {
+  return {
+    id: "s1",
+    name: "github",
+    transport: "stdio",
+    command: "/usr/local/bin/srv",
+    url: null,
+    args: [],
+    env: {},
+    headers: {},
+    trust_as_read: false,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+function renderRow(overrides: Partial<McpServerConfig> = {}) {
+  const onChange = vi.fn();
+  const utils = render(
+    <McpServerRow
+      t={t}
+      value={server(overrides)}
+      open
+      onToggleOpen={() => {}}
+      onChange={onChange}
+      onRemove={() => {}}
+    />,
+  );
+  return { ...utils, onChange };
+}
+
+describe("McpServerRow trust switch", () => {
+  it("enabling the trust toggle calls onChange({ trust_as_read: true })", () => {
+    const { getByText, onChange } = renderRow();
+    fireEvent.click(getByText("Auto-approve all tools"));
+    expect(onChange).toHaveBeenCalledWith({ trust_as_read: true });
+  });
+
+  it("shows a no-approval warning while trust is on", () => {
+    const { getByText } = renderRow({ trust_as_read: true });
+    expect(getByText("Tools run without approval")).toBeInTheDocument();
+  });
+});
+
+describe("McpServerRow transport fields", () => {
+  it("stdio shows command + Args + Env, not URL/Headers", () => {
+    const { getByPlaceholderText, getByText, queryByText, queryByPlaceholderText } =
+      renderRow({ transport: "stdio" });
+    expect(getByPlaceholderText(STDIO_PLACEHOLDER)).toBeInTheDocument();
+    expect(getByText("Args")).toBeInTheDocument();
+    expect(getByText("Env")).toBeInTheDocument();
+    expect(queryByText("Headers")).toBeNull();
+    expect(queryByPlaceholderText(URL_PLACEHOLDER)).toBeNull();
+  });
+
+  it("http shows URL + Headers, not command/Args/Env", () => {
+    const { getByPlaceholderText, getByText, queryByText, queryByPlaceholderText } =
+      renderRow({ transport: "http", command: "", url: "https://x" });
+    expect(getByPlaceholderText(URL_PLACEHOLDER)).toBeInTheDocument();
+    expect(getByText("Headers")).toBeInTheDocument();
+    expect(queryByText("Args")).toBeNull();
+    expect(queryByText("Env")).toBeNull();
+    expect(queryByPlaceholderText(STDIO_PLACEHOLDER)).toBeNull();
+  });
+
+  it("selecting the http transport calls onChange({ transport: 'http' })", () => {
+    const { getByRole, onChange } = renderRow({ transport: "stdio" });
+    fireEvent.click(getByRole("combobox"));
+    fireEvent.click(screen.getByRole("option", { name: "http" }));
+    expect(onChange).toHaveBeenCalledWith({ transport: "http" });
+  });
+
+  it("editing the URL and blurring commits onChange({ url })", () => {
+    const { getByPlaceholderText, onChange } = renderRow({
+      transport: "http",
+      command: "",
+      url: null,
+    });
+    const input = getByPlaceholderText(URL_PLACEHOLDER);
+    fireEvent.change(input, { target: { value: URL_PLACEHOLDER } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith({ url: URL_PLACEHOLDER });
+  });
+
+  it("clearing the URL commits onChange({ url: null })", () => {
+    const { getByPlaceholderText, onChange } = renderRow({
+      transport: "http",
+      command: "",
+      url: "https://old.example.com",
+    });
+    const input = getByPlaceholderText(URL_PLACEHOLDER);
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith({ url: null });
+  });
+
+  it("adding a header and blurring out commits onChange({ headers })", () => {
+    const { getByText, getByPlaceholderText, onChange } = renderRow({
+      transport: "http",
+      command: "",
+      url: "https://x",
+    });
+    fireEvent.click(getByText("Add"));
+    fireEvent.change(getByPlaceholderText("Header"), {
+      target: { value: "Authorization" },
+    });
+    const valueInput = getByPlaceholderText("value");
+    fireEvent.change(valueInput, { target: { value: "Bearer t" } });
+    fireEvent.blur(valueInput, { relatedTarget: document.body });
+    expect(onChange).toHaveBeenCalledWith({
+      headers: { Authorization: "Bearer t" },
+    });
+  });
+});

--- a/ui/src/components/settings/AiSection.tsx
+++ b/ui/src/components/settings/AiSection.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useResolvedTheme } from "../../store";
 import { api } from "../../api";
 import type {
@@ -6,6 +12,7 @@ import type {
   ApprovalMode,
   AuthMode,
   McpServerConfig,
+  McpTransport,
   McpTestResult,
   ModelInfo,
   ProviderKind,
@@ -25,6 +32,13 @@ import {
   hexWithAlpha,
 } from "../../theme";
 import { Btn, ErrorBlock, Field, SectionHeader, Select, Toggle } from "../ui";
+import {
+  KvEditor,
+  kvBufferFromPairs,
+  kvBufferToMap,
+  kvBufferDirty,
+  type KvBuffer,
+} from "../detail/edit";
 
 // AiSection — settings page tab for the cluster-aware AI agent. The
 // settings shape is provider-list + per-provider credential state. Each
@@ -936,9 +950,13 @@ function McpServersField({
       {
         id: makeServerId(),
         name: `server-${servers.length + 1}`,
+        transport: "stdio",
         command: "",
+        url: null,
         args: [],
         env: {},
+        headers: {},
+        trust_as_read: false,
         enabled: true,
       },
     ];
@@ -963,9 +981,13 @@ function McpServersField({
       {
         id: makeServerId(),
         name: "MCP server",
+        transport: "stdio",
         command: legacyPath,
+        url: null,
         args: [],
         env: {},
+        headers: {},
+        trust_as_read: false,
         enabled: true,
       },
     ];
@@ -1051,7 +1073,9 @@ function McpServersField({
   );
 }
 
-function McpServerRow({
+// Exported for the interaction test (`AiSection.mcpEnv.test.tsx`); the
+// settings page renders it via `McpServersField`.
+export function McpServerRow({
   t,
   value,
   open,
@@ -1071,17 +1095,70 @@ function McpServerRow({
   // the settings page.
   const [name, setName] = useState(value.name);
   const [command, setCommand] = useState(value.command);
+  const [url, setUrl] = useState(value.url ?? "");
   useEffect(() => setName(value.name), [value.name]);
   useEffect(() => setCommand(value.command), [value.command]);
+  useEffect(() => setUrl(value.url ?? ""), [value.url]);
+
+  const isRemote = value.transport === "sse" || value.transport === "http";
 
   const argsText = useMemo(() => value.args.join("\n"), [value.args]);
-  const envText = useMemo(
+
+  // Env is edited through the shared KvEditor (KEY / VALUE fields + Add),
+  // not a `KEY=VALUE` textarea. The buffer is the in-progress draft; we
+  // commit it to the backend on blur (see the wrapping div below) so typing
+  // doesn't roundtrip per keystroke. A stable signature of the upstream env
+  // re-seeds the buffer when the canonical value changes (our own commit, a
+  // migrate, or an external edit) without clobbering edits mid-typing.
+  const envSig = useMemo(
     () =>
       Object.entries(value.env)
         .map(([k, v]) => `${k}=${v}`)
         .join("\n"),
     [value.env],
   );
+  const [envBuffer, setEnvBuffer] = useState<KvBuffer>(() =>
+    kvBufferFromPairs(Object.entries(value.env)),
+  );
+  const seededEnvRef = useRef(envSig);
+  useEffect(() => {
+    if (seededEnvRef.current === envSig) return;
+    seededEnvRef.current = envSig;
+    setEnvBuffer(kvBufferFromPairs(Object.entries(value.env)));
+  }, [envSig, value.env]);
+
+  // Push the buffer to the backend only when something actually changed —
+  // kvBufferDirty is 0 right after a (re)seed, so re-renders don't trigger
+  // redundant saves.
+  const commitEnv = () => {
+    if (kvBufferDirty(envBuffer) > 0) {
+      onChange({ env: kvBufferToMap(envBuffer) });
+    }
+  };
+
+  // Headers (sse / http auth etc.) reuse the same KvEditor + blur-commit
+  // pattern as env — see the env buffer above for the mechanics.
+  const headersSig = useMemo(
+    () =>
+      Object.entries(value.headers)
+        .map(([k, v]) => `${k}=${v}`)
+        .join("\n"),
+    [value.headers],
+  );
+  const [headersBuffer, setHeadersBuffer] = useState<KvBuffer>(() =>
+    kvBufferFromPairs(Object.entries(value.headers)),
+  );
+  const seededHeadersRef = useRef(headersSig);
+  useEffect(() => {
+    if (seededHeadersRef.current === headersSig) return;
+    seededHeadersRef.current = headersSig;
+    setHeadersBuffer(kvBufferFromPairs(Object.entries(value.headers)));
+  }, [headersSig, value.headers]);
+  const commitHeaders = () => {
+    if (kvBufferDirty(headersBuffer) > 0) {
+      onChange({ headers: kvBufferToMap(headersBuffer) });
+    }
+  };
 
   // Test state — `running` is the in-flight request, `result` is the most
   // recent outcome. Cleared whenever the underlying value mutates so the
@@ -1090,15 +1167,23 @@ function McpServerRow({
   const [testResult, setTestResult] = useState<McpTestResult | null>(null);
   useEffect(() => {
     setTestResult(null);
-  }, [value.command, value.args, value.env, value.name]);
+  }, [
+    value.transport,
+    value.command,
+    value.url,
+    value.args,
+    value.env,
+    value.headers,
+    value.name,
+  ]);
 
   const runTest = async () => {
-    if (!command.trim()) {
+    if (isRemote ? !url.trim() : !command.trim()) {
       setTestResult({
         ok: false,
         tool_count: 0,
         tool_names: [],
-        error: "command is empty",
+        error: isRemote ? "url is empty" : "command is empty",
       });
       return;
     }
@@ -1107,8 +1192,16 @@ function McpServerRow({
     try {
       // Use the in-buffer values so the operator can validate edits that
       // haven't been blur-committed yet — the test is meant to be quick
-      // feedback, not "save first then test".
-      const res = await api.mcpTestServer({ ...value, name, command });
+      // feedback, not "save first then test". Env / headers come from the
+      // live KvEditor buffers for the same reason.
+      const res = await api.mcpTestServer({
+        ...value,
+        name,
+        command,
+        url: url.trim() ? url.trim() : null,
+        env: kvBufferToMap(envBuffer),
+        headers: kvBufferToMap(headersBuffer),
+      });
       setTestResult(res);
     } catch (e) {
       setTestResult({
@@ -1160,7 +1253,7 @@ function McpServerRow({
           }}
           placeholder="name"
           style={{
-            width: 120,
+            width: 110,
             background: t.surface,
             border: `1px solid ${t.borderSoft}`,
             color: t.text,
@@ -1170,32 +1263,71 @@ function McpServerRow({
             fontSize: FS_SM,
           }}
         />
-        <input
-          type="text"
-          value={command}
-          onChange={(e) => setCommand(e.target.value)}
-          onBlur={() => {
-            if (command !== value.command) onChange({ command });
-          }}
-          placeholder="/usr/local/bin/my-mcp-server"
-          style={{
-            flex: 1,
-            background: t.surface,
-            border: `1px solid ${t.borderSoft}`,
-            color: t.text,
-            borderRadius: R_MD,
-            padding: "4px 6px",
-            fontFamily: FF_MONO,
-            fontSize: FS_SM,
-          }}
+        <Select<McpTransport>
+          t={t}
+          value={value.transport}
+          onChange={(transport) => onChange({ transport })}
+          options={[
+            { value: "stdio", label: "stdio" },
+            { value: "http", label: "http" },
+            { value: "sse", label: "sse" },
+          ]}
+          fullWidth={false}
+          style={{ width: 84 }}
         />
+        {isRemote ? (
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onBlur={() => {
+              const next = url.trim() ? url.trim() : null;
+              if (next !== value.url) onChange({ url: next });
+            }}
+            placeholder="https://mcp.example.com/rpc"
+            style={{
+              flex: 1,
+              background: t.surface,
+              border: `1px solid ${t.borderSoft}`,
+              color: t.text,
+              borderRadius: R_MD,
+              padding: "4px 6px",
+              fontFamily: FF_MONO,
+              fontSize: FS_SM,
+            }}
+          />
+        ) : (
+          <input
+            type="text"
+            value={command}
+            onChange={(e) => setCommand(e.target.value)}
+            onBlur={() => {
+              if (command !== value.command) onChange({ command });
+            }}
+            placeholder="/usr/local/bin/my-mcp-server"
+            style={{
+              flex: 1,
+              background: t.surface,
+              border: `1px solid ${t.borderSoft}`,
+              color: t.text,
+              borderRadius: R_MD,
+              padding: "4px 6px",
+              fontFamily: FF_MONO,
+              fontSize: FS_SM,
+            }}
+          />
+        )}
         <Btn
           t={t}
           variant="ghost"
           size="sm"
           onClick={runTest}
-          disabled={testRunning || !command.trim()}
-          title="Spawn the server, run MCP initialize + tools/list, kill it. Confirms the binary is reachable and speaks MCP."
+          disabled={testRunning || (isRemote ? !url.trim() : !command.trim())}
+          title={
+            isRemote
+              ? "Connect to the URL, run MCP initialize + tools/list. Confirms the endpoint is reachable and speaks MCP."
+              : "Spawn the server, run MCP initialize + tools/list, kill it. Confirms the binary is reachable and speaks MCP."
+          }
         >
           {testRunning ? "Testing…" : "Test"}
         </Btn>
@@ -1232,90 +1364,142 @@ function McpServerRow({
             paddingLeft: 24,
           }}
         >
+          {/* Trust toggle — applies to every transport. */}
           <label
-            style={{
-              fontSize: FS_SM,
-              color: t.textMuted,
-              alignSelf: "start",
-              paddingTop: 4,
-            }}
-            title="Either paste a single shell-style line (`-y @scope/pkg /path`) or put one arg per line (preserves args with spaces)."
+            style={{ fontSize: FS_SM, color: t.textMuted, alignSelf: "center" }}
+            title="Treat every tool from this server as a read: auto-run with no approval prompt. Only enable for servers you fully trust — it bypasses the per-write approval gate."
           >
-            Args
+            Trust
           </label>
-          <textarea
-            // Uncontrolled — the textarea owns its in-progress text; we
-            // re-mount it (via `key`) only when the upstream value changes
-            // externally so a parent rerender doesn't blow away typing.
-            // After blur, the parsed args are joined back with newlines so
-            // the operator immediately sees how their input was tokenized.
-            key={`args-${argsText}`}
-            defaultValue={argsText}
-            onBlur={(e) => {
-              const next = parseMcpArgs(e.target.value);
-              if (
-                next.length !== value.args.length ||
-                next.some((a, i) => a !== value.args[i])
-              ) {
-                onChange({ args: next });
-              }
-            }}
-            rows={2}
-            placeholder={
-              "Paste shell-style: -y @modelcontextprotocol/server-filesystem /path\nor one per line"
-            }
-            style={{
-              background: t.surface,
-              border: `1px solid ${t.borderSoft}`,
-              color: t.text,
-              borderRadius: R_MD,
-              padding: "4px 6px",
-              fontFamily: FF_MONO,
-              fontSize: FS_SM,
-              resize: "vertical",
-              minHeight: 36,
-            }}
-          />
-          <label
-            style={{
-              fontSize: FS_SM,
-              color: t.textMuted,
-              alignSelf: "start",
-              paddingTop: 4,
-            }}
-          >
-            Env
-          </label>
-          <textarea
-            key={`env-${envText}`}
-            defaultValue={envText}
-            onBlur={(e) => {
-              const next: Record<string, string> = {};
-              for (const line of e.target.value.split("\n")) {
-                const trimmed = line.trim();
-                if (!trimmed) continue;
-                const eq = trimmed.indexOf("=");
-                if (eq <= 0) continue;
-                const k = trimmed.slice(0, eq).trim();
-                const v = trimmed.slice(eq + 1);
-                if (k) next[k] = v;
-              }
-              onChange({ env: next });
-            }}
-            rows={3}
-            placeholder="GITHUB_TOKEN=…"
-            style={{
-              background: t.surface,
-              border: `1px solid ${t.borderSoft}`,
-              color: t.text,
-              borderRadius: R_MD,
-              padding: "4px 6px",
-              fontFamily: FF_MONO,
-              fontSize: FS_SM,
-              resize: "vertical",
-              minHeight: 40,
-            }}
-          />
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <Toggle
+              t={t}
+              checked={value.trust_as_read}
+              onChange={(v) => onChange({ trust_as_read: v })}
+              label="Auto-approve all tools"
+            />
+            {value.trust_as_read && (
+              <span style={{ fontSize: FS_XS, color: t.warn }}>
+                Tools run without approval
+              </span>
+            )}
+          </div>
+
+          {!isRemote && (
+            <>
+              <label
+                style={{
+                  fontSize: FS_SM,
+                  color: t.textMuted,
+                  alignSelf: "start",
+                  paddingTop: 4,
+                }}
+                title="Either paste a single shell-style line (`-y @scope/pkg /path`) or put one arg per line (preserves args with spaces)."
+              >
+                Args
+              </label>
+              <textarea
+                // Uncontrolled — the textarea owns its in-progress text; we
+                // re-mount it (via `key`) only when the upstream value changes
+                // externally so a parent rerender doesn't blow away typing.
+                // After blur, the parsed args are joined back with newlines so
+                // the operator immediately sees how their input was tokenized.
+                key={`args-${argsText}`}
+                defaultValue={argsText}
+                onBlur={(e) => {
+                  const next = parseMcpArgs(e.target.value);
+                  if (
+                    next.length !== value.args.length ||
+                    next.some((a, i) => a !== value.args[i])
+                  ) {
+                    onChange({ args: next });
+                  }
+                }}
+                rows={2}
+                placeholder={
+                  "Paste shell-style: -y @modelcontextprotocol/server-filesystem /path\nor one per line"
+                }
+                style={{
+                  background: t.surface,
+                  border: `1px solid ${t.borderSoft}`,
+                  color: t.text,
+                  borderRadius: R_MD,
+                  padding: "4px 6px",
+                  fontFamily: FF_MONO,
+                  fontSize: FS_SM,
+                  resize: "vertical",
+                  minHeight: 36,
+                }}
+              />
+              <label
+                style={{
+                  fontSize: FS_SM,
+                  color: t.textMuted,
+                  alignSelf: "start",
+                  paddingTop: 4,
+                }}
+                title="Extra environment variables passed to the server process. One KEY / VALUE pair per row — no quotes or = needed."
+              >
+                Env
+              </label>
+              <div
+                // Commit on blur of the whole editor, not when tabbing between
+                // a row's KEY and VALUE inputs. relatedTarget inside the div
+                // means focus stayed within the editor → keep the draft local.
+                onBlur={(e) => {
+                  if (e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                    return;
+                  }
+                  commitEnv();
+                }}
+              >
+                <KvEditor
+                  t={t}
+                  buffer={envBuffer}
+                  onChange={setEnvBuffer}
+                  keyPlaceholder="KEY"
+                  valuePlaceholder="VALUE"
+                  // Reject keys with '=' or whitespace — invalid env names and
+                  // the exact mistake the old `KEY=VALUE` textarea invited.
+                  validateKey={(k) => !/[\s=]/.test(k)}
+                />
+              </div>
+            </>
+          )}
+
+          {isRemote && (
+            <>
+              <label
+                style={{
+                  fontSize: FS_SM,
+                  color: t.textMuted,
+                  alignSelf: "start",
+                  paddingTop: 4,
+                }}
+                title="Extra HTTP headers sent on every request — typically Authorization for a remote server's token. One NAME / VALUE pair per row."
+              >
+                Headers
+              </label>
+              <div
+                onBlur={(e) => {
+                  if (e.currentTarget.contains(e.relatedTarget as Node | null)) {
+                    return;
+                  }
+                  commitHeaders();
+                }}
+              >
+                <KvEditor
+                  t={t}
+                  buffer={headersBuffer}
+                  onChange={setHeadersBuffer}
+                  keyPlaceholder="Header"
+                  valuePlaceholder="value"
+                  // HTTP header names can't contain whitespace or a colon.
+                  validateKey={(k) => !/[\s:]/.test(k)}
+                />
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -2097,14 +2097,31 @@ export type ReasoningSettings = {
 /// One operator-configured external MCP server. Each entry produces one
 /// child process per chat; the JSON shape mirrors `mcpServers` in
 /// Claude Desktop / Cursor so configs copy-paste between tools.
+/// How FerrisScope connects to an MCP server. Mirrors the `type` field in
+/// Claude Desktop / Cursor configs. `stdio` spawns a subprocess; `sse` / `http`
+/// connect to a `url`.
+export type McpTransport = "stdio" | "sse" | "http";
+
 export type McpServerConfig = {
   /// Stable id from the backend. Used as the React key and as the address
   /// for per-server status updates over the chat event stream.
   id: string;
   name: string;
+  /// Connection type. Defaults to `stdio`.
+  transport: McpTransport;
+  /// Executable path (`stdio` only).
   command: string;
+  /// Endpoint URL (`sse` / `http` only).
+  url: string | null;
+  /// CLI args (`stdio` only).
   args: string[];
+  /// Extra env vars (`stdio` only).
   env: Record<string, string>;
+  /// Extra HTTP headers, e.g. Authorization (`sse` / `http` only).
+  headers: Record<string, string>;
+  /// Treat every tool from this server as a read — auto-run, no approval
+  /// prompt. Operator opt-in trust decision per server.
+  trust_as_read: boolean;
   enabled: boolean;
 };
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
