### PR TITLE
feat(ui): macOS integrated title bar + vibrancy

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -37,7 +37,11 @@ uuid.workspace = true
 # `keyring-core` + per-backend crates. The upstream README explicitly tells v3
 # users not to upgrade. Staying on v3 until we choose to port to keyring-core.
 keyring = { version = "3", default-features = false, features = ["sync-secret-service", "vendored", "apple-native", "windows-native"] }
-tauri = { version = "2.11", features = [] }
+# macos-private-api: required for the translucent window + NSVisualEffectView
+# vibrancy behind the integrated title bar / sidebar (macOS only; ignored on
+# other platforms). Enabled explicitly even though `macOSPrivateApi: true` in
+# tauri.macos.conf.json would auto-add it at build time.
+tauri = { version = "2.11", features = ["macos-private-api"] }
 tauri-plugin-fs = "2.5"
 tauri-plugin-dialog = "2.4"
 tauri-plugin-opener = "2.5"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -37,10 +37,12 @@ uuid.workspace = true
 # `keyring-core` + per-backend crates. The upstream README explicitly tells v3
 # users not to upgrade. Staying on v3 until we choose to port to keyring-core.
 keyring = { version = "3", default-features = false, features = ["sync-secret-service", "vendored", "apple-native", "windows-native"] }
-# macos-private-api: required for the translucent window + NSVisualEffectView
-# vibrancy behind the integrated title bar / sidebar (macOS only; ignored on
-# other platforms). Enabled explicitly even though `macOSPrivateApi: true` in
-# tauri.macos.conf.json would auto-add it at build time.
+# macos-private-api: enables the translucent window + NSVisualEffectView
+# vibrancy used on macOS (integrated title bar / sidebar). Tauri's build script
+# validates this Cargo feature against `macOSPrivateApi` in tauri.conf.json, and
+# Cargo features aren't per-platform — so the flag lives in the *base* config
+# (a no-op on Linux/Windows) to keep feature and allowlist in sync on every
+# target. Without that, Linux/Windows builds fail the allowlist check.
 tauri = { version = "2.11", features = ["macos-private-api"] }
 tauri-plugin-fs = "2.5"
 tauri-plugin-dialog = "2.4"

--- a/crates/app/capabilities/default.json
+++ b/crates/app/capabilities/default.json
@@ -10,6 +10,7 @@
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
+    "core:window:allow-set-theme",
     "fs:default",
     "dialog:default",
     "dialog:allow-open",

--- a/crates/app/src/agent_native/tool_output.rs
+++ b/crates/app/src/agent_native/tool_output.rs
@@ -36,6 +36,11 @@ use crate::agent::char_boundary_floor;
 /// How long a spilled output lingers before the sweep reaps it. Matches
 /// opencode's retention. The cache dir is OS-reapable anyway; this bounds our
 /// own footprint without cutting off an operator who comes back the next day.
+// clippy's `duration_suboptimal_units` (pedantic, 1.95+) wants a larger-unit
+// constructor here, but `Duration::from_days`/`from_hours` aren't stable as
+// const fns, so `from_secs` is required. `unknown_lints` keeps the allow
+// harmless on older clippy toolchains that don't know the lint yet.
+#[allow(unknown_lints, clippy::duration_suboptimal_units)]
 const RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
 /// Default + max bytes one `fs_tool_output_read` window returns. Capped at the

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -257,12 +257,21 @@ fn main() {
             // Wayland headerbar is oversized and themed via Adwaita,
             // which clashes with KDE/Plasma chrome — see the custom
             // `<TitleBar/>` in ui/src/components/TitleBar.tsx for the
-            // replacement. macOS keeps native decorations because the
-            // system titlebar is well-themed and gives us blur for free.
+            // replacement. macOS keeps its *native* decorations but runs an
+            // integrated, transparent title bar (`titleBarStyle: "Overlay"` +
+            // `hiddenTitle` in tauri.conf.json): the webview fills the window
+            // and the real OS traffic lights float over our own `<AppHeader/>`,
+            // which reserves the left inset and acts as the drag region (see
+            // ui/src/lib/macChrome.ts). Windows keeps the standard native bar.
             #[cfg(target_os = "linux")]
             if let Some(win) = app.get_webview_window("main") {
                 let _ = win.set_decorations(false);
             }
+
+            // macOS window appearance is kept in lockstep with the app theme
+            // from the frontend (App.tsx → getCurrentWindow().setTheme), so the
+            // title-bar vibrancy material and traffic-light rendering match the
+            // active theme: light theme → light frost, dark theme → dark frost.
 
             let handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {

--- a/crates/app/tauri.conf.json
+++ b/crates/app/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../../ui/dist"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "FerrisScope",

--- a/crates/app/tauri.conf.json
+++ b/crates/app/tauri.conf.json
@@ -17,7 +17,9 @@
         "height": 900,
         "minWidth": 900,
         "minHeight": 600,
-        "decorations": true
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/crates/app/tauri.macos.conf.json
+++ b/crates/app/tauri.macos.conf.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "macOSPrivateApi": true,
+    "windows": [
+      {
+        "title": "FerrisScope",
+        "width": 1400,
+        "height": 900,
+        "minWidth": 900,
+        "minHeight": 600,
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "transparent": true,
+        "windowEffects": {
+          "effects": ["sidebar"],
+          "state": "followsWindowActiveState"
+        }
+      }
+    ]
+  }
+}

--- a/crates/app/tauri.macos.conf.json
+++ b/crates/app/tauri.macos.conf.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "app": {
-    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "FerrisScope",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { api, onPortForwardStatus, onResourceDelta } from "./api";
 import { useAppStore, useResolvedTheme } from "./store";
 import type { AppInfo, ResourceKind } from "./types";
@@ -11,7 +12,11 @@ import {
   FS_MD,
 } from "./theme";
 import { AppHeader } from "./components/AppHeader";
-import { TitleBar, ResizeEdges, TITLEBAR_INSET_PX } from "./components/TitleBar";
+import {
+  TitleBar,
+  ResizeEdges,
+  TITLEBAR_INSET_PX,
+} from "./components/TitleBar";
 import { Rail } from "./components/Rail";
 import { ClusterPanel } from "./components/ClusterPanel";
 import { FleetLanding } from "./components/FleetLanding";
@@ -24,7 +29,7 @@ import { ModalHost } from "./components/ModalHost";
 import { NotificationsPanel } from "./components/NotificationsPanel";
 import { PortForwardsPanel } from "./components/PortForwardsPanel";
 import { confirm, toast } from "./lib/dialog";
-import { latinLetter } from "./lib/keyboard";
+import { latinLetter, IS_MAC } from "./lib/keyboard";
 import { Icons } from "./components/ui";
 
 const RAIL_COLLAPSED_W = 56;
@@ -113,6 +118,16 @@ export default function App() {
   // Set once after the initial prefs load — gates the persist effect so the
   // hydration write doesn't immediately echo defaults back to disk.
   const [prefsLoaded, setPrefsLoaded] = useState(false);
+
+  // macOS: keep the native window appearance in lockstep with the app theme so
+  // the title-bar vibrancy material (and traffic-light rendering) matches —
+  // light theme → light frost, dark theme → dark frost. No-op elsewhere.
+  useEffect(() => {
+    if (!IS_MAC) return;
+    getCurrentWindow()
+      .setTheme(themeMode)
+      .catch(() => {});
+  }, [themeMode]);
 
   useEffect(() => {
     api
@@ -385,7 +400,12 @@ export default function App() {
     if (import.meta.env.DEV) return;
     const onCtx = (e: MouseEvent) => {
       const tgt = e.target as HTMLElement | null;
-      if (tgt && tgt.closest("input, textarea, [contenteditable=''], [contenteditable='true']")) {
+      if (
+        tgt &&
+        tgt.closest(
+          "input, textarea, [contenteditable=''], [contenteditable='true']",
+        )
+      ) {
         return;
       }
       e.preventDefault();
@@ -447,7 +467,7 @@ export default function App() {
         openNsModal();
         return;
       }
-      if (meta && e.key === "," ) {
+      if (meta && e.key === ",") {
         e.preventDefault();
         openSettings();
         return;
@@ -555,6 +575,11 @@ export default function App() {
   // ResolvedTheme directly.
   document.body.style.fontFamily = resolved.typography.fontSans;
   document.body.style.fontSize = `${resolved.typography.base}px`;
+  // macOS vibrancy: the window is transparent and an NSVisualEffectView sits
+  // behind the webview (tauri.macos.conf.json). The page background must be
+  // clear for that material to show through; the opaque content area repaints
+  // t.bg itself. No-op (and reverts to the stylesheet) off macOS.
+  document.body.style.background = IS_MAC ? "transparent" : "";
   // Publish the typography + sizing scale as CSS custom properties so
   // components can read `var(--fs-fs-sm)` etc. without each one threading
   // ResolvedTheme through props. Incremental migration: components keep
@@ -607,7 +632,9 @@ export default function App() {
         width: "100vw",
         display: "flex",
         flexDirection: "column",
-        background: t.bg,
+        // Transparent on macOS so the chrome (header + rail) can let the
+        // vibrancy material show through; the <main> content repaints t.bg.
+        background: IS_MAC ? "transparent" : t.bg,
         color: t.text,
         fontFamily: FONT_SANS,
         overflow: "hidden",
@@ -647,6 +674,9 @@ export default function App() {
                 minHeight: 0,
                 display: "flex",
                 flexDirection: "column",
+                // Opaque so the dense table stays readable; macOS vibrancy is
+                // confined to the chrome (header + rail) around it.
+                background: t.bg,
               }}
             >
               <ClusterPanel mode={themeMode} context={selectedContext} />
@@ -660,6 +690,7 @@ export default function App() {
               minHeight: 0,
               display: "flex",
               flexDirection: "column",
+              background: t.bg,
             }}
           >
             <FleetLanding mode={themeMode} onSelect={selectContext} />
@@ -691,21 +722,19 @@ export default function App() {
 
       {/* Bulk action bar — shows when rows are selected. Per-kind action sets
           (pods today, nodes for cordon/drain/delete). Shape per R-03. */}
-      {selectedKind?.id === "pods" &&
-        selectedContext &&
-        selection.size > 0 && (
-          <BulkBar
-            mode={themeMode}
-            count={selection.size}
-            onClear={clearSelection}
-            actions={buildPodBulkActions(
-              selectedContext.id,
-              selection,
-              confirmDestructive,
-              clearSelection,
-            )}
-          />
-        )}
+      {selectedKind?.id === "pods" && selectedContext && selection.size > 0 && (
+        <BulkBar
+          mode={themeMode}
+          count={selection.size}
+          onClear={clearSelection}
+          actions={buildPodBulkActions(
+            selectedContext.id,
+            selection,
+            confirmDestructive,
+            clearSelection,
+          )}
+        />
+      )}
       {selectedKind?.id === "nodes" &&
         selectedContext &&
         selection.size > 0 && (
@@ -840,7 +869,9 @@ function buildPodBulkActions(
       toast.bad(
         `${label} failed for ${failures.length} of ${count}:\n${failures
           .slice(0, 8)
-          .join("\n")}${failures.length > 8 ? `\n…and ${failures.length - 8} more` : ""}`,
+          .join(
+            "\n",
+          )}${failures.length > 8 ? `\n…and ${failures.length - 8} more` : ""}`,
       );
     } else {
       toast.ok(`${label}: ${count} pod${count === 1 ? "" : "s"}.`);
@@ -879,9 +910,7 @@ function buildPodBulkActions(
               )
               .join("\n");
             const failureLines = [
-              ...(noNs > 0
-                ? [`${noNs} selected pod(s) had no namespace`]
-                : []),
+              ...(noNs > 0 ? [`${noNs} selected pod(s) had no namespace`] : []),
               ...report.failures.map(
                 (f) => `${f.namespace}/${f.pod}: ${f.error}`,
               ),
@@ -907,9 +936,7 @@ function buildPodBulkActions(
       label: "Copy names",
       onClick: () => {
         const text = entries
-          .map(([, m]) =>
-            m.namespace ? `${m.namespace}/${m.name}` : m.name,
-          )
+          .map(([, m]) => (m.namespace ? `${m.namespace}/${m.name}` : m.name))
           .join("\n");
         navigator.clipboard
           .writeText(text)
@@ -980,7 +1007,9 @@ function buildNodeBulkActions(
       toast.bad(
         `${label} failed for ${failures.length} of ${count}:\n${failures
           .slice(0, 8)
-          .join("\n")}${failures.length > 8 ? `\n…and ${failures.length - 8} more` : ""}`,
+          .join(
+            "\n",
+          )}${failures.length > 8 ? `\n…and ${failures.length - 8} more` : ""}`,
       );
     } else {
       toast.ok(`${label}: ${count} node${count === 1 ? "" : "s"}.`);
@@ -1165,7 +1194,9 @@ function buildGenericBulkActions(
           );
           const lines = [
             ...(noNs > 0
-              ? [`${noNs} selected ${noNs === 1 ? kindLabel : plural} had no namespace`]
+              ? [
+                  `${noNs} selected ${noNs === 1 ? kindLabel : plural} had no namespace`,
+                ]
               : []),
             ...failures,
           ];
@@ -1174,7 +1205,9 @@ function buildGenericBulkActions(
               `Restart failed for ${lines.length} of ${count}:\n${lines.slice(0, 8).join("\n")}${lines.length > 8 ? `\n…and ${lines.length - 8} more` : ""}`,
             );
           } else {
-            toast.ok(`Rollout restart triggered on ${count} ${count === 1 ? kindLabel : plural}.`);
+            toast.ok(
+              `Rollout restart triggered on ${count} ${count === 1 ? kindLabel : plural}.`,
+            );
           }
           clearSelection();
         })();
@@ -1188,9 +1221,7 @@ function buildGenericBulkActions(
       label: "Copy names",
       onClick: () => {
         const text = entries
-          .map(([, m]) =>
-            m.namespace ? `${m.namespace}/${m.name}` : m.name,
-          )
+          .map(([, m]) => (m.namespace ? `${m.namespace}/${m.name}` : m.name))
           .join("\n");
         navigator.clipboard
           .writeText(text)
@@ -1240,12 +1271,12 @@ function buildGenericBulkActions(
             toast.bad(
               `Delete failed for ${failures.length} of ${count}:\n${failures
                 .slice(0, 8)
-                .join("\n")}${failures.length > 8 ? `\n…and ${failures.length - 8} more` : ""}`,
+                .join(
+                  "\n",
+                )}${failures.length > 8 ? `\n…and ${failures.length - 8} more` : ""}`,
             );
           } else {
-            toast.ok(
-              `Deleted ${count} ${count === 1 ? kindLabel : plural}.`,
-            );
+            toast.ok(`Deleted ${count} ${count === 1 ? kindLabel : plural}.`);
           }
           clearSelection();
         })();

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+// Control IS_MAC per-test. The header is a single row everywhere; on macOS it
+// shares the integrated transparent title bar with the OS traffic lights, so
+// lib/macChrome insets it past them and turns it into a window drag handle.
+// AppHeader no longer reads IS_MAC directly, but macChrome (which it imports)
+// does — a getter-backed override on the keyboard module lets one file flip the
+// value at render time while the rest of the module stays real.
+const platform = vi.hoisted(() => ({ isMac: false }));
+vi.mock("../lib/keyboard", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/keyboard")>();
+  return {
+    ...actual,
+    get IS_MAC() {
+      return platform.isMac;
+    },
+  };
+});
+
+import { AppHeader } from "./AppHeader";
+
+const noop = () => {};
+
+function renderHeader() {
+  return render(
+    <AppHeader
+      mode="dark"
+      context={null}
+      selectedKindLabel={null}
+      unreadNotifications={0}
+      activeForwards={0}
+      onHome={noop}
+      onPalette={noop}
+      onToggleTheme={noop}
+      onOpenNotifications={noop}
+      onOpenSettings={noop}
+      onOpenForwards={noop}
+    />,
+  );
+}
+
+function row(container: HTMLElement): HTMLElement {
+  return (container.firstChild as HTMLElement).firstElementChild as HTMLElement;
+}
+
+afterEach(() => {
+  cleanup();
+  platform.isMac = false;
+});
+
+describe("AppHeader layout", () => {
+  it("is a single row holding brand, breadcrumb and controls", () => {
+    const { container, getByText } = renderHeader();
+    const shell = container.firstChild as HTMLElement;
+    expect(shell.children).toHaveLength(1);
+    const r = row(container);
+    expect(r.contains(getByText("FerrisScope"))).toBe(true);
+    expect(r.contains(getByText("Clusters"))).toBe(true);
+    expect(r.contains(getByText(/Search clusters/))).toBe(true);
+  });
+
+  it("insets past the traffic lights and becomes a drag region on macOS", () => {
+    platform.isMac = true;
+    const { container } = renderHeader();
+    const r = row(container);
+    // 72px traffic-light inset from lib/macChrome.
+    expect(r.style.paddingLeft).toBe("72px");
+    expect(r.getAttribute("data-tauri-drag-region")).not.toBeNull();
+  });
+
+  it("uses the normal gutter and no drag region off macOS", () => {
+    platform.isMac = false;
+    const { container } = renderHeader();
+    const r = row(container);
+    expect(r.style.paddingLeft).toBe("22px");
+    expect(r.getAttribute("data-tauri-drag-region")).toBeNull();
+  });
+
+  it("paints a translucent (vibrancy) header background on macOS", () => {
+    platform.isMac = true;
+    const { container } = renderHeader();
+    const shell = container.firstChild as HTMLElement;
+    // rgba(...) ⇒ the NSVisualEffectView material shows through behind the
+    // traffic lights so dimmed inactive buttons stay visible on light themes.
+    expect(shell.style.background).toContain("rgba");
+  });
+
+  it("keeps an opaque header background off macOS", () => {
+    platform.isMac = false;
+    const { container } = renderHeader();
+    const shell = container.firstChild as HTMLElement;
+    expect(shell.style.background).not.toContain("rgba");
+  });
+});

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -1,8 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ContextInfo } from "../types";
-import { FF_MONO, type ThemeMode, R_MD, R_SM, FS_LG, FS_MD, FS_SM, FS_XS } from "../theme";
+import {
+  FF_MONO,
+  type ThemeMode,
+  R_MD,
+  R_SM,
+  FS_LG,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  vibrantSurface,
+} from "../theme";
 import { BrandMark, IconBtn, Icons, Kbd } from "./ui";
-import { MOD_KEY } from "../lib/keyboard";
+import { MOD_KEY, IS_MAC } from "../lib/keyboard";
+import { headerPaddingLeft, dragRegionProps } from "../lib/macChrome";
 import { HeaderToast } from "./HeaderToast";
 import { parseTableFilter } from "../lib/tableFilter";
 import { useAppStore, useResolvedTheme } from "../store";
@@ -25,6 +36,12 @@ type Props = {
 // Top bar — brand, breadcrumb, command-palette stub, theme toggle. Per P6 the
 // cluster name is always visible while a context is selected; `Esc` is wired
 // at the App level (R-13).
+//
+// One row across all platforms. On macOS the window runs an integrated
+// transparent title bar (see lib/macChrome.ts): the row shares it with the OS
+// traffic lights, so it insets past them and acts as the window drag handle.
+// Linux / Windows render the same row without either (Linux adds the custom
+// <TitleBar/> above; Windows uses the native bar).
 export function AppHeader({
   mode,
   context,
@@ -63,474 +80,498 @@ export function AppHeader({
   // Parse the filter once for the chip's visual state. `invalid` flips
   // the border red so an unparseable regex doesn't look like "no
   // matches" — the operator can see the pattern itself is broken.
-  const parsedFilter = useMemo(() => parseTableFilter(tableFilter), [
-    tableFilter,
-  ]);
+  const parsedFilter = useMemo(
+    () => parseTableFilter(tableFilter),
+    [tableFilter],
+  );
   const filterInvalid = parsedFilter.invalid === true;
   const filterAccent = filterInvalid ? t.bad : t.accent;
 
-  return (
-    <div
+  // ── Brand: logo glyph + wordmark, doubles as a "go home" button. ──────────
+  const brand = (
+    <button
+      type="button"
+      onClick={onHome}
       style={{
-        background: t.header,
-        borderBottom: `1px solid ${t.border}`,
-        flexShrink: 0,
-        zIndex: 5,
+        display: "flex",
+        alignItems: "center",
+        gap: 9,
+        border: "none",
+        background: "transparent",
+        cursor: "pointer",
+        color: t.text,
+        fontFamily: "inherit",
+        padding: 0,
       }}
     >
       <div
         style={{
+          width: 26,
+          height: 26,
           display: "flex",
           alignItems: "center",
-          gap: 16,
-          padding: "12px 22px",
+          justifyContent: "center",
+          flexShrink: 0,
+          color: t.accent,
         }}
       >
-        <button
-          type="button"
-          onClick={onHome}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 9,
-            border: "none",
-            background: "transparent",
-            cursor: "pointer",
-            color: t.text,
-            fontFamily: "inherit",
-            padding: 0,
-          }}
-        >
-          <div
-            style={{
-              width: 26,
-              height: 26,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
-              color: t.accent,
-            }}
-          >
-            <BrandMark size={26} />
-          </div>
-          <div style={{ fontSize: FS_LG, fontWeight: 700, letterSpacing: -0.3 }}>
-            FerrisScope
-          </div>
-        </button>
+        <BrandMark size={26} />
+      </div>
+      <div style={{ fontSize: FS_LG, fontWeight: 700, letterSpacing: -0.3 }}>
+        FerrisScope
+      </div>
+    </button>
+  );
 
-        <div style={{ height: 18, width: 1, background: t.border }} />
-
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-            fontSize: FS_MD,
-            fontWeight: 500,
-            minWidth: 0,
-          }}
-        >
-          <button
-            type="button"
-            onClick={onHome}
+  // ── Breadcrumb: Clusters › <context> › <kind> · <count> + filter chip. ────
+  const breadcrumb = (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        fontSize: FS_MD,
+        fontWeight: 500,
+        minWidth: 0,
+      }}
+    >
+      <button
+        type="button"
+        onClick={onHome}
+        style={{
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          color: context ? t.textDim : t.text,
+          padding: "3px 6px",
+          borderRadius: R_MD,
+          fontFamily: "inherit",
+          fontSize: FS_MD,
+          fontWeight: 500,
+        }}
+      >
+        Clusters
+      </button>
+      {context && (
+        <>
+          <span style={{ color: t.textMuted, display: "inline-flex" }}>
+            {Icons.chevR}
+          </span>
+          <span
             style={{
-              border: "none",
-              background: "transparent",
-              cursor: "pointer",
-              color: context ? t.textDim : t.text,
               padding: "3px 6px",
-              borderRadius: R_MD,
-              fontFamily: "inherit",
-              fontSize: FS_MD,
-              fontWeight: 500,
+              fontWeight: 600,
+              letterSpacing: -0.2,
             }}
           >
-            Clusters
-          </button>
-          {context && (
+            {context.name}
+          </span>
+          {context.namespace && (
+            <span
+              style={{
+                fontSize: FS_SM,
+                padding: "1px 6px",
+                borderRadius: R_SM,
+                background: t.chip,
+                color: t.textDim,
+                fontWeight: 500,
+                marginLeft: 2,
+                fontFamily: FF_MONO,
+              }}
+            >
+              ns:{context.namespace}
+            </span>
+          )}
+          {selectedKindLabel && (
             <>
               <span style={{ color: t.textMuted, display: "inline-flex" }}>
                 {Icons.chevR}
               </span>
-              <span
-                style={{
-                  padding: "3px 6px",
-                  fontWeight: 600,
-                  letterSpacing: -0.2,
-                }}
-              >
-                {context.name}
+              <span style={{ padding: "3px 6px", color: t.textDim }}>
+                {selectedKindLabel}
               </span>
-              {context.namespace && (
+              {tableCount && (
                 <span
                   style={{
                     fontSize: FS_SM,
-                    padding: "1px 6px",
-                    borderRadius: R_SM,
-                    background: t.chip,
-                    color: t.textDim,
-                    fontWeight: 500,
-                    marginLeft: 2,
+                    color: t.textMuted,
                     fontFamily: FF_MONO,
+                    fontVariantNumeric: "tabular-nums",
                   }}
                 >
-                  ns:{context.namespace}
+                  ·{" "}
+                  {tableCount.filtered === tableCount.total
+                    ? tableCount.total
+                    : `${tableCount.filtered}/${tableCount.total}`}
                 </span>
               )}
-              {selectedKindLabel && (
-                <>
-                  <span style={{ color: t.textMuted, display: "inline-flex" }}>
-                    {Icons.chevR}
+              {/* Filter chip / inline input — same anchor point, two
+                  states. When `filterEditing` is true: a small input
+                  lives here, two-way-bound to `tableFilter` so typing
+                  live-narrows the table behind. Esc / Enter / blur
+                  collapses back to the chip; the filter persists.
+                  When idle: a funnel chip showing the active filter
+                  (or just the icon if no filter), clickable to
+                  re-open the input. */}
+              {filterEditing ? (
+                <div
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 4,
+                    padding: "2px 6px",
+                    border: `1px solid ${filterAccent}`,
+                    borderRadius: R_MD,
+                    background: t.surface,
+                    height: 24,
+                  }}
+                >
+                  <span
+                    style={{
+                      color: filterAccent,
+                      display: "inline-flex",
+                    }}
+                  >
+                    {Icons.filter}
                   </span>
-                  <span style={{ padding: "3px 6px", color: t.textDim }}>
-                    {selectedKindLabel}
-                  </span>
-                  {tableCount && (
-                    <span
-                      style={{
-                        fontSize: FS_SM,
-                        color: t.textMuted,
-                        fontFamily: FF_MONO,
-                        fontVariantNumeric: "tabular-nums",
+                  <input
+                    ref={filterInputRef}
+                    value={tableFilter}
+                    onChange={(e) => setTableFilter(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Escape" || e.key === "Enter") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        closeFilterEditor();
+                      }
+                    }}
+                    // Defer-close on blur so a click on the inline ×
+                    // (which momentarily steals focus) doesn't race the
+                    // state update and re-open the editor.
+                    onBlur={() => {
+                      window.setTimeout(closeFilterEditor, 0);
+                    }}
+                    placeholder="Filter rows…"
+                    title={
+                      filterInvalid
+                        ? "Invalid regex pattern"
+                        : "Plain text = substring · use | * + ? ( ) ^ $ to switch to regex"
+                    }
+                    style={{
+                      width: 220,
+                      border: "none",
+                      outline: "none",
+                      background: "transparent",
+                      color: filterInvalid ? t.bad : t.text,
+                      fontSize: FS_MD,
+                      fontFamily: FF_MONO,
+                      padding: 0,
+                    }}
+                  />
+                  {tableFilter && (
+                    <button
+                      type="button"
+                      // mousedown so this fires before the input's blur,
+                      // giving us the chance to clear before the editor
+                      // collapses (cleaner UX than blur → click-to-clear).
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        clearTableFilter();
+                        filterInputRef.current?.focus();
                       }}
-                    >
-                      ·{" "}
-                      {tableCount.filtered === tableCount.total
-                        ? tableCount.total
-                        : `${tableCount.filtered}/${tableCount.total}`}
-                    </span>
-                  )}
-                  {/* Filter chip / inline input — same anchor point, two
-                      states. When `filterEditing` is true: a small input
-                      lives here, two-way-bound to `tableFilter` so typing
-                      live-narrows the table behind. Esc / Enter / blur
-                      collapses back to the chip; the filter persists.
-                      When idle: a funnel chip showing the active filter
-                      (or just the icon if no filter), clickable to
-                      re-open the input. */}
-                  {filterEditing ? (
-                    <div
+                      title="Clear filter"
                       style={{
                         display: "inline-flex",
                         alignItems: "center",
-                        gap: 4,
-                        padding: "2px 6px",
-                        border: `1px solid ${filterAccent}`,
-                        borderRadius: R_MD,
-                        background: t.surface,
-                        height: 24,
+                        padding: 2,
+                        border: "none",
+                        borderRadius: R_SM,
+                        background: "transparent",
+                        color: t.textMuted,
+                        cursor: "pointer",
                       }}
                     >
+                      {Icons.close}
+                    </button>
+                  )}
+                </div>
+              ) : (
+                // Wrapper, not a button — the chip splits into two click
+                // targets: the funnel/text part opens the editor (so the
+                // operator can replace the term with a new one) and the
+                // × clears the active filter without opening the editor
+                // first. Both are nested buttons; the wrapper itself is
+                // visual only.
+                <span
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    border: `1px solid ${tableFilter ? filterAccent : t.borderSoft}`,
+                    borderRadius: R_MD,
+                    background: tableFilter
+                      ? filterInvalid
+                        ? t.surface
+                        : t.accentSoft
+                      : "transparent",
+                    color: tableFilter ? filterAccent : t.textMuted,
+                    height: 22,
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={openFilterEditor}
+                    title={
+                      filterInvalid
+                        ? `Invalid regex: ${tableFilter}`
+                        : tableFilter
+                          ? `Filter: "${tableFilter}" — edit (${MOD_KEY}F or /)`
+                          : `Filter visible rows (${MOD_KEY}F or /). Plain text matches substring; metachars switch to regex.`
+                    }
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 4,
+                      padding: tableFilter ? "0 4px 0 6px" : "0 6px",
+                      border: "none",
+                      background: "transparent",
+                      color: "inherit",
+                      cursor: "pointer",
+                      fontFamily: "inherit",
+                      fontSize: FS_SM,
+                      lineHeight: 1,
+                      height: "100%",
+                    }}
+                  >
+                    <span style={{ display: "inline-flex" }}>
+                      {Icons.filter}
+                    </span>
+                    {tableFilter && (
                       <span
                         style={{
-                          color: filterAccent,
-                          display: "inline-flex",
+                          fontFamily: FF_MONO,
+                          maxWidth: 140,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
                         }}
                       >
-                        {Icons.filter}
+                        {tableFilter}
                       </span>
-                      <input
-                        ref={filterInputRef}
-                        value={tableFilter}
-                        onChange={(e) => setTableFilter(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Escape" || e.key === "Enter") {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            closeFilterEditor();
-                          }
-                        }}
-                        // Defer-close on blur so a click on the inline ×
-                        // (which momentarily steals focus) doesn't race the
-                        // state update and re-open the editor.
-                        onBlur={() => {
-                          window.setTimeout(closeFilterEditor, 0);
-                        }}
-                        placeholder="Filter rows…"
-                        title={
-                          filterInvalid
-                            ? "Invalid regex pattern"
-                            : "Plain text = substring · use | * + ? ( ) ^ $ to switch to regex"
-                        }
-                        style={{
-                          width: 220,
-                          border: "none",
-                          outline: "none",
-                          background: "transparent",
-                          color: filterInvalid ? t.bad : t.text,
-                          fontSize: FS_MD,
-                          fontFamily: FF_MONO,
-                          padding: 0,
-                        }}
-                      />
-                      {tableFilter && (
-                        <button
-                          type="button"
-                          // mousedown so this fires before the input's blur,
-                          // giving us the chance to clear before the editor
-                          // collapses (cleaner UX than blur → click-to-clear).
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            clearTableFilter();
-                            filterInputRef.current?.focus();
-                          }}
-                          title="Clear filter"
-                          style={{
-                            display: "inline-flex",
-                            alignItems: "center",
-                            padding: 2,
-                            border: "none",
-                            borderRadius: R_SM,
-                            background: "transparent",
-                            color: t.textMuted,
-                            cursor: "pointer",
-                          }}
-                        >
-                          {Icons.close}
-                        </button>
-                      )}
-                    </div>
-                  ) : (
-                    // Wrapper, not a button — the chip splits into two click
-                    // targets: the funnel/text part opens the editor (so the
-                    // operator can replace the term with a new one) and the
-                    // × clears the active filter without opening the editor
-                    // first. Both are nested buttons; the wrapper itself is
-                    // visual only.
-                    <span
+                    )}
+                  </button>
+                  {tableFilter && (
+                    <button
+                      type="button"
+                      onClick={clearTableFilter}
+                      title="Clear filter"
                       style={{
                         display: "inline-flex",
                         alignItems: "center",
-                        border: `1px solid ${tableFilter ? filterAccent : t.borderSoft}`,
-                        borderRadius: R_MD,
-                        background: tableFilter
-                          ? filterInvalid
-                            ? t.surface
-                            : t.accentSoft
-                          : "transparent",
-                        color: tableFilter ? filterAccent : t.textMuted,
-                        height: 22,
+                        padding: "0 5px",
+                        border: "none",
+                        borderLeft: `1px solid ${filterAccent}`,
+                        background: "transparent",
+                        color: "inherit",
+                        cursor: "pointer",
+                        height: "100%",
                       }}
                     >
-                      <button
-                        type="button"
-                        onClick={openFilterEditor}
-                        title={
-                          filterInvalid
-                            ? `Invalid regex: ${tableFilter}`
-                            : tableFilter
-                              ? `Filter: "${tableFilter}" — edit (${MOD_KEY}F or /)`
-                              : `Filter visible rows (${MOD_KEY}F or /). Plain text matches substring; metachars switch to regex.`
-                        }
-                        style={{
-                          display: "inline-flex",
-                          alignItems: "center",
-                          gap: 4,
-                          padding: tableFilter ? "0 4px 0 6px" : "0 6px",
-                          border: "none",
-                          background: "transparent",
-                          color: "inherit",
-                          cursor: "pointer",
-                          fontFamily: "inherit",
-                          fontSize: FS_SM,
-                          lineHeight: 1,
-                          height: "100%",
-                        }}
-                      >
-                        <span style={{ display: "inline-flex" }}>
-                          {Icons.filter}
-                        </span>
-                        {tableFilter && (
-                          <span
-                            style={{
-                              fontFamily: FF_MONO,
-                              maxWidth: 140,
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            {tableFilter}
-                          </span>
-                        )}
-                      </button>
-                      {tableFilter && (
-                        <button
-                          type="button"
-                          onClick={clearTableFilter}
-                          title="Clear filter"
-                          style={{
-                            display: "inline-flex",
-                            alignItems: "center",
-                            padding: "0 5px",
-                            border: "none",
-                            borderLeft: `1px solid ${filterAccent}`,
-                            background: "transparent",
-                            color: "inherit",
-                            cursor: "pointer",
-                            height: "100%",
-                          }}
-                        >
-                          {Icons.close}
-                        </button>
-                      )}
-                    </span>
+                      {Icons.close}
+                    </button>
                   )}
-                </>
+                </span>
               )}
             </>
           )}
-        </div>
+        </>
+      )}
+    </div>
+  );
 
-        <div style={{ flex: 1 }} />
+  // ── Controls: dev HUD, transient toast, command palette, global icons. ────
+  const controls = (
+    <>
+      <DevMemoryChip />
 
-        <DevMemoryChip />
+      <HeaderToast mode={mode} />
 
-        <HeaderToast mode={mode} />
-
-        <button
-          type="button"
-          onClick={onPalette}
+      <button
+        type="button"
+        onClick={onPalette}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          border: `1px solid ${t.border}`,
+          background: t.surface,
+          borderRadius: R_MD,
+          padding: "6px 12px",
+          width: 280,
+          cursor: "pointer",
+          fontFamily: "inherit",
+          color: "inherit",
+          // `minHeight` instead of fixed `height` so the row stays
+          // single-line and centered at any theme's base font size.
+          minHeight: 32,
+          // Hide vertical overflow that 14-px-base themes would otherwise
+          // push past the row.
+          whiteSpace: "nowrap",
+        }}
+      >
+        <span
+          style={{ color: t.textMuted, display: "inline-flex", flexShrink: 0 }}
+        >
+          {Icons.search}
+        </span>
+        <span
           style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            border: `1px solid ${t.border}`,
-            background: t.surface,
-            borderRadius: R_MD,
-            padding: "6px 12px",
-            width: 280,
-            cursor: "pointer",
-            fontFamily: "inherit",
-            color: "inherit",
-            // `minHeight` instead of fixed `height` so the row stays
-            // single-line and centered at any theme's base font size.
-            minHeight: 32,
-            // Hide vertical overflow that 14-px-base themes would otherwise
-            // push past the row.
+            // `flex + minWidth: 0` lets the placeholder ellipsis-truncate
+            // instead of wrapping to a second line at larger base fonts.
+            flex: 1,
+            minWidth: 0,
+            color: t.textMuted,
+            fontSize: FS_MD,
+            textAlign: "left",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
             whiteSpace: "nowrap",
           }}
         >
-          <span
-            style={{ color: t.textMuted, display: "inline-flex", flexShrink: 0 }}
-          >
-            {Icons.search}
-          </span>
-          <span
-            style={{
-              // `flex + minWidth: 0` lets the placeholder ellipsis-truncate
-              // instead of wrapping to a second line at larger base fonts.
-              flex: 1,
-              minWidth: 0,
-              color: t.textMuted,
-              fontSize: FS_MD,
-              textAlign: "left",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            Search clusters, pods, nodes…
-          </span>
-          <span style={{ flexShrink: 0 }}>
-            <Kbd t={t}>{MOD_KEY}K</Kbd>
-          </span>
-        </button>
+          Search clusters, pods, nodes…
+        </span>
+        <span style={{ flexShrink: 0 }}>
+          <Kbd t={t}>{MOD_KEY}K</Kbd>
+        </span>
+      </button>
 
-        <div style={{ position: "relative", display: "inline-flex" }}>
-          <IconBtn
-            t={t}
-            title={
-              activeForwards > 0
-                ? `${activeForwards} active port-forward${activeForwards === 1 ? "" : "s"}`
-                : "Port forwards"
-            }
-            onClick={onOpenForwards}
-          >
-            {Icons.forward}
-          </IconBtn>
-          {activeForwards > 0 && (
-            <span
-              aria-hidden
-              style={{
-                position: "absolute",
-                top: 2,
-                right: 2,
-                minWidth: 14,
-                height: 14,
-                padding: "0 3px",
-                borderRadius: R_MD,
-                background: t.accent,
-                color: "#fff",
-                fontSize: FS_XS,
-                fontWeight: 700,
-                fontFamily: FF_MONO,
-                fontVariantNumeric: "tabular-nums",
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                lineHeight: 1,
-                pointerEvents: "none",
-              }}
-            >
-              {activeForwards > 99 ? "99+" : activeForwards}
-            </span>
-          )}
-        </div>
-
-        <div style={{ position: "relative", display: "inline-flex" }}>
-          <IconBtn
-            t={t}
-            title={
-              unreadNotifications > 0
-                ? `${unreadNotifications} new notification${unreadNotifications === 1 ? "" : "s"}`
-                : "Notifications"
-            }
-            onClick={onOpenNotifications}
-          >
-            {Icons.bell}
-          </IconBtn>
-          {unreadNotifications > 0 && (
-            <span
-              aria-hidden
-              style={{
-                position: "absolute",
-                top: 2,
-                right: 2,
-                minWidth: 14,
-                height: 14,
-                padding: "0 3px",
-                borderRadius: R_MD,
-                background: t.bad,
-                color: "#fff",
-                fontSize: FS_XS,
-                fontWeight: 700,
-                fontFamily: FF_MONO,
-                fontVariantNumeric: "tabular-nums",
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
-                lineHeight: 1,
-                pointerEvents: "none",
-              }}
-            >
-              {unreadNotifications > 99 ? "99+" : unreadNotifications}
-            </span>
-          )}
-        </div>
-
+      <div style={{ position: "relative", display: "inline-flex" }}>
         <IconBtn
           t={t}
-          title={mode === "dark" ? "Switch to light theme" : "Switch to dark theme"}
-          onClick={onToggleTheme}
+          title={
+            activeForwards > 0
+              ? `${activeForwards} active port-forward${activeForwards === 1 ? "" : "s"}`
+              : "Port forwards"
+          }
+          onClick={onOpenForwards}
         >
-          {mode === "dark" ? Icons.sun : Icons.moon}
+          {Icons.forward}
         </IconBtn>
+        {activeForwards > 0 && (
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: 2,
+              right: 2,
+              minWidth: 14,
+              height: 14,
+              padding: "0 3px",
+              borderRadius: R_MD,
+              background: t.accent,
+              color: "#fff",
+              fontSize: FS_XS,
+              fontWeight: 700,
+              fontFamily: FF_MONO,
+              fontVariantNumeric: "tabular-nums",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              lineHeight: 1,
+              pointerEvents: "none",
+            }}
+          >
+            {activeForwards > 99 ? "99+" : activeForwards}
+          </span>
+        )}
+      </div>
 
-        <IconBtn t={t} title="Settings" onClick={onOpenSettings}>
-          {Icons.settings}
+      <div style={{ position: "relative", display: "inline-flex" }}>
+        <IconBtn
+          t={t}
+          title={
+            unreadNotifications > 0
+              ? `${unreadNotifications} new notification${unreadNotifications === 1 ? "" : "s"}`
+              : "Notifications"
+          }
+          onClick={onOpenNotifications}
+        >
+          {Icons.bell}
         </IconBtn>
+        {unreadNotifications > 0 && (
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: 2,
+              right: 2,
+              minWidth: 14,
+              height: 14,
+              padding: "0 3px",
+              borderRadius: R_MD,
+              background: t.bad,
+              color: "#fff",
+              fontSize: FS_XS,
+              fontWeight: 700,
+              fontFamily: FF_MONO,
+              fontVariantNumeric: "tabular-nums",
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              lineHeight: 1,
+              pointerEvents: "none",
+            }}
+          >
+            {unreadNotifications > 99 ? "99+" : unreadNotifications}
+          </span>
+        )}
+      </div>
+
+      <IconBtn
+        t={t}
+        title={
+          mode === "dark" ? "Switch to light theme" : "Switch to dark theme"
+        }
+        onClick={onToggleTheme}
+      >
+        {mode === "dark" ? Icons.sun : Icons.moon}
+      </IconBtn>
+
+      <IconBtn t={t} title="Settings" onClick={onOpenSettings}>
+        {Icons.settings}
+      </IconBtn>
+    </>
+  );
+
+  const shell: React.CSSProperties = {
+    // Translucent on macOS so the NSVisualEffectView material shows through the
+    // header — gives the (dimmed, gray) inactive traffic lights a frosted
+    // backdrop instead of flat white, where they were otherwise invisible.
+    background: IS_MAC ? vibrantSurface(t.header, mode) : t.header,
+    borderBottom: `1px solid ${t.border}`,
+    flexShrink: 0,
+    zIndex: 5,
+  };
+
+  return (
+    <div style={shell}>
+      <div
+        {...dragRegionProps()}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 16,
+          paddingTop: 12,
+          paddingBottom: 12,
+          paddingRight: 22,
+          // macOS insets past the traffic lights; 22px gutter elsewhere.
+          paddingLeft: headerPaddingLeft(22),
+        }}
+      >
+        {brand}
+        <div style={{ height: 18, width: 1, background: t.border }} />
+        {breadcrumb}
+        <div {...dragRegionProps()} style={{ flex: 1 }} />
+        {controls}
       </div>
     </div>
   );
@@ -577,11 +618,12 @@ function DevMemoryChip() {
   if (unsupported) return null;
 
   const label = rssBytes == null ? "RSS —" : `RSS ${formatBytes(rssBytes)}`;
-  const deltaLabel = lastDelta == null
-    ? null
-    : lastDelta > 0
-    ? `−${formatBytes(lastDelta)}`
-    : "no change";
+  const deltaLabel =
+    lastDelta == null
+      ? null
+      : lastDelta > 0
+        ? `−${formatBytes(lastDelta)}`
+        : "no change";
 
   const compact = async () => {
     try {
@@ -643,7 +685,9 @@ function DevMemoryChip() {
     >
       <span>{label}</span>
       {deltaLabel && (
-        <span style={{ color: lastDelta && lastDelta > 0 ? t.good : t.textDim }}>
+        <span
+          style={{ color: lastDelta && lastDelta > 0 ? t.good : t.textDim }}
+        >
           {deltaLabel}
         </span>
       )}

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -2,7 +2,19 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { useAppStore, useResolvedTheme } from "../store";
 import type { Category, PrefsRailMode, ResourceKind } from "../types";
-import { tokens, FF_MONO, type ThemeMode, type Tokens, R_MD, R_SM, FS_MD, FS_SM, FS_XS } from "../theme";
+import {
+  tokens,
+  FF_MONO,
+  type ThemeMode,
+  type Tokens,
+  R_MD,
+  R_SM,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  vibrantSurface,
+} from "../theme";
+import { IS_MAC } from "../lib/keyboard";
 import { ErrorBlock, Icons, Tooltip, resolveKindIcon } from "./ui";
 
 const CATEGORY_ORDER: Category[] = [
@@ -30,7 +42,9 @@ type Props = {
 // rail (every CRD falls back to the same icon, so the collapsed list would
 // be a stack of indistinguishable glyphs).
 export function Rail({}: Props) {
-  const t = useResolvedTheme().tokens;
+  const resolved = useResolvedTheme();
+  const t = resolved.tokens;
+  const themeMode = resolved.mode;
   const {
     kinds,
     kindsStatus,
@@ -191,7 +205,9 @@ export function Rail({}: Props) {
           bottom: 0,
           left: 0,
           width: open ? W_OPEN : W_COLLAPSED,
-          background: t.rail,
+          // Translucent on macOS so the vibrancy material shows through the
+          // sidebar; opaque elsewhere. The <main> content stays opaque.
+          background: IS_MAC ? vibrantSurface(t.rail, themeMode) : t.rail,
           borderRight: `1px solid ${t.border}`,
           boxShadow:
             open && !isPinned ? "4px 0 16px rgba(15,20,30,0.08)" : "none",
@@ -352,8 +368,7 @@ function RailFooter({
                     flex: 1,
                     padding: 0,
                     border: "none",
-                    borderLeft:
-                      i === 0 ? "none" : `1px solid ${t.border}`,
+                    borderLeft: i === 0 ? "none" : `1px solid ${t.border}`,
                     background: active ? t.accentSoft : "transparent",
                     color: active ? t.accent : t.textMuted,
                     fontFamily: FF_MONO,
@@ -459,7 +474,13 @@ function FooterRowButton({
       )}
     </button>
   );
-  return open ? btn : <Tooltip label={title} side="right">{btn}</Tooltip>;
+  return open ? (
+    btn
+  ) : (
+    <Tooltip label={title} side="right">
+      {btn}
+    </Tooltip>
+  );
 }
 
 function RailGroup({
@@ -577,8 +598,7 @@ function CustomResourcesBody({
   // 30+ CRDs across many vendors, so showing all of them by default makes
   // the rail unscannable. Auto-expand the group that contains the active
   // selection so the user always sees where they are.
-  const activeGroup =
-    dynamic.find((k) => k.id === selectedId)?.group ?? null;
+  const activeGroup = dynamic.find((k) => k.id === selectedId)?.group ?? null;
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const toggle = (g: string) =>
     setExpanded((prev) => {
@@ -607,52 +627,54 @@ function CustomResourcesBody({
         return (
           <div key={g} style={{ marginTop: 4 }}>
             {open && (
-              <Tooltip label={`${g} — ${groupItems.length} kind${groupItems.length === 1 ? "" : "s"}`}>
-              <button
-                type="button"
-                onClick={() => toggle(g)}
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 6,
-                  width: "100%",
-                  padding: "4px 8px",
-                  background: "transparent",
-                  border: "none",
-                  cursor: "pointer",
-                  color: t.textMuted,
-                  fontFamily: FF_MONO,
-                  fontSize: FS_XS,
-                  textAlign: "left",
-                  letterSpacing: 0.2,
-                }}
+              <Tooltip
+                label={`${g} — ${groupItems.length} kind${groupItems.length === 1 ? "" : "s"}`}
               >
-                <span
+                <button
+                  type="button"
+                  onClick={() => toggle(g)}
                   style={{
-                    display: "inline-block",
-                    width: 8,
-                    transform: isOpen ? "rotate(0deg)" : "rotate(-90deg)",
-                    transition: "transform .12s",
-                    color: t.textDim,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    width: "100%",
+                    padding: "4px 8px",
+                    background: "transparent",
+                    border: "none",
+                    cursor: "pointer",
+                    color: t.textMuted,
+                    fontFamily: FF_MONO,
+                    fontSize: FS_XS,
+                    textAlign: "left",
+                    letterSpacing: 0.2,
                   }}
                 >
-                  ▾
-                </span>
-                <span
-                  style={{
-                    flex: 1,
-                    minWidth: 0,
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {g}
-                </span>
-                <span style={{ color: t.textDim, fontSize: FS_XS }}>
-                  {groupItems.length}
-                </span>
-              </button>
+                  <span
+                    style={{
+                      display: "inline-block",
+                      width: 8,
+                      transform: isOpen ? "rotate(0deg)" : "rotate(-90deg)",
+                      transition: "transform .12s",
+                      color: t.textDim,
+                    }}
+                  >
+                    ▾
+                  </span>
+                  <span
+                    style={{
+                      flex: 1,
+                      minWidth: 0,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {g}
+                  </span>
+                  <span style={{ color: t.textDim, fontSize: FS_XS }}>
+                    {groupItems.length}
+                  </span>
+                </button>
               </Tooltip>
             )}
             {isOpen && (

--- a/ui/src/components/TitleBar.tsx
+++ b/ui/src/components/TitleBar.tsx
@@ -22,9 +22,12 @@ import { Icons } from "./ui";
 // supplies the replacement: drag region + min/max/close, themed via
 // `theme.ts` tokens so it tracks the rest of the app's chrome.
 //
-// macOS / Windows keep native decorations because the system titlebar is
-// well-themed and gives us blur for free; on those platforms this
-// component renders nothing and `TITLEBAR_INSET_PX` is 0.
+// macOS keeps its native decorations but runs an integrated, transparent
+// title bar (titleBarStyle: "Overlay" + hiddenTitle in tauri.conf.json): the
+// real OS traffic lights float over <AppHeader/>, which reserves the left
+// inset and provides the drag region (see lib/macChrome.ts). Windows keeps
+// the standard native bar. On both, this component renders nothing and
+// `TITLEBAR_INSET_PX` is 0.
 export const IS_LINUX_TITLEBAR = /linux/i.test(
   typeof navigator === "undefined" ? "" : navigator.userAgent,
 );

--- a/ui/src/lib/keyboard.ts
+++ b/ui/src/lib/keyboard.ts
@@ -3,7 +3,7 @@
 // hints shown to the user need to know the difference. macOS gets ⌘/⇧/⌥
 // glyphs; everyone else gets the spelled-out modifier name.
 
-const IS_MAC = (() => {
+export const IS_MAC = (() => {
   if (typeof navigator === "undefined") return false;
   // navigator.platform is the most reliable signal on desktop browsers and is
   // what Tauri's WebView surfaces. UA fallback covers the rare case where it's

--- a/ui/src/lib/macChrome.test.ts
+++ b/ui/src/lib/macChrome.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAC_TRAFFIC_LIGHT_INSET_PX,
+  headerPaddingLeft,
+  dragRegionProps,
+} from "./macChrome";
+
+describe("headerPaddingLeft", () => {
+  it("reserves the traffic-light inset on macOS", () => {
+    expect(headerPaddingLeft(22, true)).toBe(MAC_TRAFFIC_LIGHT_INSET_PX);
+  });
+
+  it("uses the caller's normal gutter off macOS", () => {
+    expect(headerPaddingLeft(22, false)).toBe(22);
+  });
+
+  it("inset clears the traffic-light buttons but hugs them (no big gap)", () => {
+    // 3 buttons (~14px) from x≈16 ⇒ rightmost edge ≈68px. The inset must
+    // clear that, yet stay tight so adjacent content hugs the lights rather
+    // than floating off to the right.
+    expect(MAC_TRAFFIC_LIGHT_INSET_PX).toBeGreaterThanOrEqual(70);
+    expect(MAC_TRAFFIC_LIGHT_INSET_PX).toBeLessThanOrEqual(76);
+  });
+});
+
+describe("dragRegionProps", () => {
+  it("emits the Tauri drag-region attribute on macOS", () => {
+    expect(dragRegionProps(true)).toEqual({ "data-tauri-drag-region": true });
+  });
+
+  it("emits nothing off macOS so other platforms are untouched", () => {
+    expect(dragRegionProps(false)).toEqual({});
+  });
+});

--- a/ui/src/lib/macChrome.ts
+++ b/ui/src/lib/macChrome.ts
@@ -1,0 +1,43 @@
+// macOS integrated title-bar helpers.
+//
+// On macOS the window keeps its *native* decorations (real OS traffic-light
+// buttons, native drag/resize/fullscreen) but uses Tauri's `titleBarStyle:
+// "Overlay"` (tauri.conf.json) — the same AppKit mechanism a native Swift app
+// uses for an integrated toolbar window. The webview fills the whole window and
+// the genuine OS buttons float over our own <AppHeader/>.
+//
+// So the header must (a) reserve a left inset for any row whose left-most
+// content shares the traffic-light row, and (b) act as the window drag handle,
+// since a transparent title bar has no native drag strip. These helpers
+// centralise both so the platform branch lives in one tested place rather than
+// inline in JSX.
+//
+// Linux draws a fully custom title bar instead (see TitleBar.tsx); Windows
+// keeps the standard native bar. Neither needs these — hence the `isMac` gate
+// defaulting to the runtime value.
+import { IS_MAC } from "./keyboard";
+
+// Width reserved at the top-left for the three macOS traffic-light buttons.
+// At the default position the rightmost button edge sits at ~68px; 72 clears
+// the buttons with just a few px to spare so adjacent content hugs them rather
+// than floating off to the right with an awkward gap.
+export const MAC_TRAFFIC_LIGHT_INSET_PX = 72;
+
+// Left padding that clears the traffic lights on macOS, otherwise the caller's
+// normal gutter. Use on any header row whose left-most content shares the
+// traffic-light row.
+export function headerPaddingLeft(
+  normal: number,
+  isMac: boolean = IS_MAC,
+): number {
+  return isMac ? MAC_TRAFFIC_LIGHT_INSET_PX : normal;
+}
+
+// Spread onto a header container / spacer to turn its empty area into a window
+// drag handle on macOS. Interactive children (buttons, inputs) stay clickable —
+// Tauri only drags when the click lands on the element carrying the attribute,
+// not on its children. Returns nothing off macOS so other platforms are
+// untouched (Linux drags via TitleBar.tsx; Windows uses the native bar).
+export function dragRegionProps(isMac: boolean = IS_MAC): Record<string, true> {
+  return isMac ? { "data-tauri-drag-region": true } : {};
+}

--- a/ui/src/theme.test.ts
+++ b/ui/src/theme.test.ts
@@ -10,10 +10,37 @@ import {
   statusDot,
   statusFill,
   tokens,
+  vibrantSurface,
+  vibrancyAlpha,
+  MAC_VIBRANCY_ALPHA_DARK,
+  MAC_VIBRANCY_ALPHA_LIGHT,
   UI_SCALE_DEFAULT,
   UI_SCALE_MAX,
   UI_SCALE_MIN,
 } from "./theme";
+
+describe("vibrantSurface / vibrancyAlpha", () => {
+  it("uses the darker, more translucent alpha in dark mode", () => {
+    expect(vibrancyAlpha("dark")).toBe(MAC_VIBRANCY_ALPHA_DARK);
+    expect(vibrantSurface("#11141a", "dark")).toBe(
+      `rgba(17, 20, 26, ${MAC_VIBRANCY_ALPHA_DARK})`,
+    );
+  });
+
+  it("keeps a subtle (mostly opaque) frost in light mode", () => {
+    expect(vibrancyAlpha("light")).toBe(MAC_VIBRANCY_ALPHA_LIGHT);
+    expect(vibrantSurface("#ffffff", "light")).toBe(
+      `rgba(255, 255, 255, ${MAC_VIBRANCY_ALPHA_LIGHT})`,
+    );
+  });
+
+  it("frosts both modes — translucent, with light subtler (more opaque) than dark", () => {
+    expect(MAC_VIBRANCY_ALPHA_DARK).toBeGreaterThan(0);
+    expect(MAC_VIBRANCY_ALPHA_DARK).toBeLessThan(1);
+    expect(MAC_VIBRANCY_ALPHA_LIGHT).toBeGreaterThan(MAC_VIBRANCY_ALPHA_DARK);
+    expect(MAC_VIBRANCY_ALPHA_LIGHT).toBeLessThan(1);
+  });
+});
 
 describe("clampUiScale", () => {
   it("returns default for non-finite input", () => {

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -1070,6 +1070,28 @@ export function hexWithAlpha(color: string, alpha: number): string {
   return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
 }
 
+// macOS vibrancy: opacity applied to chrome surfaces (header, rail) so the
+// NSVisualEffectView material behind the transparent webview shows through.
+// Mode-dependent because the trade differs. Dark chrome stays legible quite
+// translucent. Light/white chrome muddies and loses text contrast if pushed too
+// far, so light keeps a *subtle* frost (mostly white) — enough to read as
+// vibrant and give the inactive traffic lights some backdrop, without dropping
+// to an obvious gray. The window appearance follows the theme (App.tsx) so the
+// light material stays light. Tunable knobs; lives here, not inline in
+// components, per the no-hardcoded-alpha rule. Lower light → more frost / more
+// button contrast / less white; raise → whiter / fainter buttons.
+export const MAC_VIBRANCY_ALPHA_DARK = 0.5;
+export const MAC_VIBRANCY_ALPHA_LIGHT = 0.7;
+
+export function vibrancyAlpha(mode: ThemeMode): number {
+  return mode === "dark" ? MAC_VIBRANCY_ALPHA_DARK : MAC_VIBRANCY_ALPHA_LIGHT;
+}
+
+// Translucent variant of a chrome surface colour for macOS vibrancy.
+export function vibrantSurface(color: string, mode: ThemeMode): string {
+  return hexWithAlpha(color, vibrancyAlpha(mode));
+}
+
 /// Mix a color toward black by `amount` (0 = original, 1 = black). Used
 /// for the light-mode pill foreground so the bucket color stays vivid on
 /// dark themes but darkens on light ones for contrast.
@@ -1097,9 +1119,7 @@ function toRgb(color: string): { r: number; g: number; b: number } | null {
     if ([r, g, b].some((v) => Number.isNaN(v))) return null;
     return { r, g, b };
   }
-  const m = color.match(
-    /rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i,
-  );
+  const m = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
   if (m && m[1] && m[2] && m[3])
     return {
       r: parseInt(m[1], 10),


### PR DESCRIPTION
Integrate the macOS window chrome. The window runs a transparent overlay title bar (titleBarStyle Overlay + hiddenTitle) so the native OS traffic lights float over a single-row AppHeader, which insets past the buttons and acts as the window drag region. Add NSVisualEffectView vibrancy (macos-private-api + transparent window + sidebar windowEffects) behind a translucent header and rail, with the content area kept opaque for readability. The native window appearance follows the app theme so the frosted material matches (light frost / dark frost) and the inactive traffic lights stay visible.

- ui/src/lib/macChrome.ts: dragRegionProps + headerPaddingLeft helpers
- ui/src/theme.ts: vibrantSurface + per-mode vibrancy alpha (dark 0.5, light 0.7)
- ui/src/App.tsx: transparent root/body on macOS, opaque main content, window appearance synced to the theme
- ui/src/components/AppHeader.tsx: single-row layout with traffic-light inset + drag region + translucent header
- ui/src/components/Rail.tsx: translucent sidebar on macOS
- crates/app/tauri.macos.conf.json: transparent + macOSPrivateApi + windowEffects (sidebar)
- crates/app/capabilities: core:window:allow-set-theme
- tests: macChrome, AppHeader layout, vibrancy helpers

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
