### PR TITLE
feat(ui): dark console + log/terminal search, chat dock minimize pill

### DIFF
--- a/crates/core/src/prefs.rs
+++ b/crates/core/src/prefs.rs
@@ -153,6 +153,10 @@ fn default_ui_scale() -> f32 {
     1.0
 }
 
+fn default_dark_console() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
     pub refresh_sec: u32,
@@ -165,6 +169,11 @@ pub struct Settings {
     pub ui_scale: f32,
     #[serde(default)]
     pub fleet_view: FleetView,
+    /// Force logs + terminal surfaces to a dark, console-style palette even
+    /// when the active theme is light. Defaults to true — operators expect a
+    /// terminal to look like a terminal. Toggleable in Settings → Appearance.
+    #[serde(default = "default_dark_console")]
+    pub dark_console: bool,
 }
 
 impl Default for Settings {
@@ -178,6 +187,7 @@ impl Default for Settings {
             refresh_on_launch: true,
             ui_scale: default_ui_scale(),
             fleet_view: FleetView::default(),
+            dark_console: default_dark_console(),
         }
     }
 }
@@ -329,6 +339,42 @@ mod tests {
             prefs.update.auto_check_enabled,
             "auto_check_enabled must default to true so legacy installs opt in"
         );
+    }
+
+    #[test]
+    fn legacy_prefs_without_dark_console_defaults_to_true() {
+        // `dark_console` post-dates the first Settings shape. A prefs.json
+        // written before it existed must deserialise with the field defaulting
+        // to true so existing installs get the dark console without re-opting.
+        let legacy = r#"{
+            "theme": "dark",
+            "settings": {
+                "refresh_sec": 15,
+                "confirm_destructive": true,
+                "show_system_ns": false,
+                "density": "comfortable",
+                "mono_tables": true,
+                "refresh_on_launch": true
+            },
+            "ui": {}
+        }"#;
+        let prefs = parse(legacy);
+        assert!(
+            prefs.settings.dark_console,
+            "dark_console must default to true for prefs files written before it existed"
+        );
+    }
+
+    #[test]
+    fn dark_console_round_trips_when_disabled() {
+        // An operator who turns the dark console off must have that choice
+        // survive a serialise → parse round-trip.
+        let mut prefs = Prefs::default();
+        assert!(prefs.settings.dark_console, "default is on");
+        prefs.settings.dark_console = false;
+        let json = serde_json::to_string(&prefs).unwrap();
+        let parsed = parse(&json);
+        assert!(!parsed.settings.dark_console);
     }
 
     #[test]

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,6 +16,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.1",
         "@tauri-apps/plugin-opener": "^2.5.4",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "anser": "^2.3.5",
@@ -1759,6 +1760,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-search": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
+      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-web-links": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "anser": "^2.3.5",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -190,6 +190,7 @@ export default function App() {
             refresh_on_launch: settings.refreshOnLaunch,
             ui_scale: settings.uiScale,
             fleet_view: settings.fleetView,
+            dark_console: settings.darkConsole,
           },
           ui: {
             selected_context: selectedContextName,

--- a/ui/src/components/Dock.tsx
+++ b/ui/src/components/Dock.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -8,10 +9,17 @@ import {
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { SearchAddon, type ISearchOptions } from "@xterm/addon-search";
 import "@xterm/xterm/css/xterm.css";
 import jsYaml from "js-yaml";
 import Editor from "@monaco-editor/react";
-import { useAppStore, type DockPlacement, type DockTab, useResolvedTheme } from "../store";
+import {
+  useAppStore,
+  type DockPlacement,
+  type DockTab,
+  useConsoleTokens,
+  useResolvedTheme,
+} from "../store";
 import { DockChat } from "./chat/DockChat";
 import {
   FF_MONO,
@@ -24,8 +32,10 @@ import {
   hexWithAlpha,
 } from "../theme";
 import { Btn, ErrorBlock, IconBtn, Icons, Select } from "./ui";
+import { MinimizedChatPill } from "./MinimizedChatPill";
 import { api } from "../api";
 import type { DocApplyResult } from "../types";
+import { latinLetter } from "../lib/keyboard";
 import { installClipboardShortcuts } from "../lib/monacoClipboard";
 import {
   YAML_TEMPLATES,
@@ -220,65 +230,12 @@ export function Dock({
     ? null
     : horizontal
     ? (
-        <div
-          style={{
-            position: "fixed",
-            top: "calc(60px + var(--fs-titlebar-h, 0px))",
-            right: 0,
-            background: t.headerAlt,
-            borderLeft: `1px solid ${t.border}`,
-            borderTop: `1px solid ${t.border}`,
-            borderBottom: `1px solid ${t.border}`,
-            borderTopLeftRadius: 6,
-            borderBottomLeftRadius: 6,
-            padding: "8px 8px",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            gap: 8,
-            zIndex: 25,
-            fontSize: FS_SM,
-          }}
-        >
-          <span style={{ color: t.textDim, display: "inline-flex" }}>
-            {Icons.chat}
-          </span>
-          <span
-            style={{
-              color: t.textMuted,
-              writingMode: "vertical-rl",
-              transform: "rotate(180deg)",
-              fontWeight: 500,
-              letterSpacing: 0.4,
-            }}
-          >
-            {tabs.length} chat{tabs.length === 1 ? "" : "s"}
-          </span>
-          <IconBtn
-            t={t}
-            title="Restore"
-            onClick={() => setDockMin(placement, false)}
-          >
-            <svg
-              width="11"
-              height="11"
-              viewBox="0 0 12 12"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.6"
-              strokeLinecap="round"
-            >
-              <path d="M3 6h6M6 3v6" />
-            </svg>
-          </IconBtn>
-          <IconBtn
-            t={t}
-            title="Close all chats"
-            onClick={() => closeAllPlacement(placement)}
-          >
-            {Icons.close}
-          </IconBtn>
-        </div>
+        <MinimizedChatPill
+          t={t}
+          count={tabs.length}
+          onRestore={() => setDockMin(placement, false)}
+          onClose={() => closeAllPlacement(placement)}
+        />
       )
     : (
         <div
@@ -667,15 +624,129 @@ function DockTerminal({
   visible: boolean;
 }) {
   const resolved = useResolvedTheme();
-  const t = resolved.tokens;
+  // The terminal is a console — dark by default even under a light theme.
+  // xterm reads literal colors at construction time, so the live-update effect
+  // below re-applies `term.options.theme` when the operator toggles the
+  // setting on an open session.
+  const consoleT = useConsoleTokens();
   const hostRef = useRef<HTMLDivElement | null>(null);
   const sessionIdRef = useRef<string | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  const searchRef = useRef<SearchAddon | null>(null);
   const [status, setStatus] = useState<
     "starting" | "ready" | "exited" | "error"
   >("starting");
   const [error, setError] = useState<string | null>(null);
+
+  // ── Find-in-place (Cmd/Ctrl+F) ──────────────────────────────────────────
+  // Backed by xterm's SearchAddon. Cmd+F is intercepted via the terminal's
+  // custom-key handler (fires only when the terminal is focused) so it doesn't
+  // collide with the shell or the app-global table filter; the find input owns
+  // its own keys while it has focus.
+  const findInputRef = useRef<HTMLInputElement | null>(null);
+  const findOpenRef = useRef(false);
+  const [findOpen, setFindOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  // Mirrors `query` for the mount-bound custom-key handler (Cmd+G), which
+  // would otherwise capture a stale empty string.
+  const queryRef = useRef("");
+  const [findResults, setFindResults] = useState({ index: -1, count: 0 });
+
+  // Search decorations follow the console palette. Kept in a ref so the
+  // mount-time custom-key handler and the React find input share one source,
+  // and `consoleT` changes (theme / dark-console toggle) re-tint live.
+  const searchOptsRef = useRef<ISearchOptions>({
+    decorations: {
+      matchBackground: consoleT.warn,
+      matchBorder: consoleT.warn,
+      matchOverviewRuler: consoleT.warn,
+      activeMatchBackground: consoleT.accent,
+      activeMatchColorOverviewRuler: consoleT.accent,
+    },
+  });
+  useEffect(() => {
+    searchOptsRef.current = {
+      decorations: {
+        matchBackground: consoleT.warn,
+        matchBorder: consoleT.warn,
+        matchOverviewRuler: consoleT.warn,
+        activeMatchBackground: consoleT.accent,
+        activeMatchColorOverviewRuler: consoleT.accent,
+      },
+    };
+  }, [consoleT.warn, consoleT.accent]);
+
+  const runSearch = useCallback((q: string, dir: "next" | "prev") => {
+    const s = searchRef.current;
+    if (!s || q.length === 0) return;
+    if (dir === "next") s.findNext(q, searchOptsRef.current);
+    else s.findPrevious(q, searchOptsRef.current);
+  }, []);
+
+  const openFind = useCallback(() => {
+    setFindOpen(true);
+    findOpenRef.current = true;
+    requestAnimationFrame(() => {
+      findInputRef.current?.focus();
+      findInputRef.current?.select();
+    });
+  }, []);
+
+  const closeFind = useCallback(() => {
+    setFindOpen(false);
+    findOpenRef.current = false;
+    setQuery("");
+    queryRef.current = "";
+    setFindResults({ index: -1, count: 0 });
+    searchRef.current?.clearDecorations();
+    termRef.current?.focus();
+  }, []);
+
+  // Re-run the search as the operator types — jumps to the first hit and keeps
+  // the live counter accurate. Empty query clears decorations.
+  const onFindChange = useCallback(
+    (v: string) => {
+      setQuery(v);
+      queryRef.current = v;
+      if (v.length === 0) {
+        searchRef.current?.clearDecorations();
+        setFindResults({ index: -1, count: 0 });
+        return;
+      }
+      runSearch(v, "next");
+    },
+    [runSearch],
+  );
+
+  const onFindKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Keep find keys out of the app-global handler while the input is focused.
+      e.stopPropagation();
+      const meta = e.metaKey || e.ctrlKey;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeFind();
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        runSearch(queryRef.current, e.shiftKey ? "prev" : "next");
+        return;
+      }
+      const letter = latinLetter(e);
+      if (meta && letter === "f") {
+        e.preventDefault();
+        findInputRef.current?.select();
+        return;
+      }
+      if (meta && letter === "g") {
+        e.preventDefault();
+        runSearch(queryRef.current, e.shiftKey ? "prev" : "next");
+      }
+    },
+    [closeFind, runSearch],
+  );
 
   const spec = tab.state.spec as TerminalTabSpec | undefined;
 
@@ -777,19 +848,55 @@ function DockTerminal({
           allowProposedApi: true,
           theme: {
             // xterm reads literal colors at construction time — it doesn't
-            // respond to subsequent token changes. The active palette's
-            // surface + text flow through here so light themes get a
-            // light-paper terminal (IDE-style) and dark themes stay dark.
-            // ANSI colors emitted by the shell aren't remapped — that's
-            // the program's choice.
-            background: t.surfaceAlt,
-            foreground: t.text,
-            cursor: t.good,
+            // respond to subsequent token changes (the live-update effect
+            // below handles toggles). The *console* palette flows through
+            // here: dark by default even under a light theme, so the terminal
+            // reads like a terminal. ANSI colors emitted by the shell aren't
+            // remapped — that's the program's choice.
+            background: consoleT.surfaceAlt,
+            foreground: consoleT.text,
+            cursor: consoleT.good,
+            // xterm's default selection is a translucent white — invisible on
+            // a light console. Derive a veil from the text colour so it stays
+            // visible (and glyphs readable) on both light and dark consoles.
+            selectionBackground: hexWithAlpha(consoleT.text, 0.3),
+            selectionInactiveBackground: hexWithAlpha(consoleT.text, 0.18),
           },
         });
         fit = new FitAddon();
         term.loadAddon(fit);
         term.loadAddon(new WebLinksAddon());
+        const search = new SearchAddon();
+        term.loadAddon(search);
+        searchRef.current = search;
+        // Live match counter for the find bar. `resultIndex` is -1 when there
+        // are no matches.
+        search.onDidChangeResults(({ resultIndex, resultCount }) => {
+          setFindResults({ index: resultIndex, count: resultCount });
+        });
+        // Cmd/Ctrl+F opens the find bar; Cmd/Ctrl+G steps matches while it's
+        // open. Both are swallowed (return false + stopPropagation) so the
+        // shell never sees them and the app-global Cmd+F (table filter)
+        // doesn't also fire. Everything else falls through to the PTY.
+        term.attachCustomKeyEventHandler((e) => {
+          if (e.type !== "keydown") return true;
+          const meta = e.metaKey || e.ctrlKey;
+          if (!meta) return true;
+          const letter = latinLetter(e);
+          if (letter === "f") {
+            e.preventDefault();
+            e.stopPropagation();
+            openFind();
+            return false;
+          }
+          if (letter === "g" && findOpenRef.current) {
+            e.preventDefault();
+            e.stopPropagation();
+            runSearch(queryRef.current, e.shiftKey ? "prev" : "next");
+            return false;
+          }
+          return true;
+        });
         term.open(host);
         // Auto-copy on selection (terminal-style UX): the moment the
         // operator finishes a drag-select / shift-arrow extension, the
@@ -945,6 +1052,7 @@ function DockTerminal({
       term?.dispose();
       termRef.current = null;
       fitRef.current = null;
+      searchRef.current = null;
     };
     // Spec is captured once at mount on purpose — the tab state doesn't change.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -988,6 +1096,24 @@ function DockTerminal({
     };
   }, [visible]);
 
+  // Re-apply the console palette to an already-open terminal when the operator
+  // toggles "Dark console" or switches theme. xterm caches theme colors at
+  // construction, so reassigning `options.theme` is the supported way to
+  // recolor a live session. ANSI runs already on screen keep their codes;
+  // only the default fg/bg/cursor follow.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.theme = {
+      background: consoleT.surfaceAlt,
+      foreground: consoleT.text,
+      cursor: consoleT.good,
+      selectionBackground: hexWithAlpha(consoleT.text, 0.3),
+      selectionInactiveBackground: hexWithAlpha(consoleT.text, 0.18),
+    };
+    term.refresh(0, term.rows - 1);
+  }, [consoleT.surfaceAlt, consoleT.text, consoleT.good]);
+
   return (
     <div
       style={{
@@ -995,7 +1121,7 @@ function DockTerminal({
         inset: 0,
         // Matches the xterm theme background so the surrounding chrome
         // doesn't peek through during fit-resizes.
-        background: t.surfaceAlt,
+        background: consoleT.surfaceAlt,
         display: "flex",
         flexDirection: "column",
         // Padding belongs on the outer wrapper, not the host. xterm's inner
@@ -1006,6 +1132,116 @@ function DockTerminal({
         padding: 8,
       }}
     >
+      {findOpen && (
+        <div
+          style={{
+            position: "absolute",
+            top: 12,
+            right: 20,
+            zIndex: 5,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "4px 6px",
+            background: consoleT.surface,
+            border: `1px solid ${consoleT.border}`,
+            borderRadius: R_MD,
+            boxShadow: "0 6px 18px rgba(0,0,0,0.35)",
+          }}
+        >
+          <input
+            ref={findInputRef}
+            value={query}
+            onChange={(e) => onFindChange(e.target.value)}
+            onKeyDown={onFindKeyDown}
+            placeholder="Find"
+            spellCheck={false}
+            style={{
+              width: 180,
+              border: "none",
+              outline: "none",
+              background: "transparent",
+              color: consoleT.text,
+              fontFamily: FF_MONO,
+              fontSize: FS_SM,
+            }}
+          />
+          <span
+            style={{
+              minWidth: 36,
+              textAlign: "right",
+              color:
+                query.length > 0 && findResults.count === 0
+                  ? consoleT.bad
+                  : consoleT.textMuted,
+              fontFamily: FF_MONO,
+              fontSize: FS_XS,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {query.length === 0
+              ? ""
+              : findResults.count === 0
+                ? "0/0"
+                : `${findResults.index + 1}/${findResults.count}`}
+          </span>
+          <button
+            type="button"
+            onClick={() => runSearch(query, "prev")}
+            disabled={findResults.count === 0}
+            title="Previous match (Shift+Enter)"
+            style={{
+              border: "none",
+              background: "transparent",
+              color:
+                findResults.count === 0 ? consoleT.textMuted : consoleT.textDim,
+              cursor: findResults.count === 0 ? "default" : "pointer",
+              fontFamily: FF_MONO,
+              fontSize: FS_SM,
+              padding: "2px 4px",
+              lineHeight: 1,
+            }}
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            onClick={() => runSearch(query, "next")}
+            disabled={findResults.count === 0}
+            title="Next match (Enter)"
+            style={{
+              border: "none",
+              background: "transparent",
+              color:
+                findResults.count === 0 ? consoleT.textMuted : consoleT.textDim,
+              cursor: findResults.count === 0 ? "default" : "pointer",
+              fontFamily: FF_MONO,
+              fontSize: FS_SM,
+              padding: "2px 4px",
+              lineHeight: 1,
+            }}
+          >
+            ↓
+          </button>
+          <button
+            type="button"
+            onClick={closeFind}
+            title="Close (Esc)"
+            style={{
+              border: "none",
+              background: "transparent",
+              color: consoleT.textDim,
+              cursor: "pointer",
+              fontFamily: FF_MONO,
+              fontSize: FS_SM,
+              padding: "2px 4px",
+              lineHeight: 1,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
       <div
         ref={hostRef}
         style={{ flex: 1, minHeight: 0 }}
@@ -1015,12 +1251,12 @@ function DockTerminal({
         <div
           style={{
             padding: "6px 10px",
-            background: hexWithAlpha(t.bad, 0.13),
-            borderTop: `1px solid ${t.border}`,
+            background: hexWithAlpha(consoleT.bad, 0.13),
+            borderTop: `1px solid ${consoleT.border}`,
           }}
         >
           <ErrorBlock
-            t={t}
+            t={consoleT}
             message={error ?? "failed to start session"}
             kindLabel="terminal session"
             inline

--- a/ui/src/components/LogPanel.tsx
+++ b/ui/src/components/LogPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { useResolvedTheme } from "../store";
+import { useConsoleTokens, useResolvedTheme } from "../store";
 import { tokens, FF_MONO, type ThemeMode, FS_LG, FS_SM } from "../theme";
 import {
   Eyebrow,
@@ -41,6 +41,9 @@ export function LogPanel({
   onClose,
 }: Props) {
   const t = useResolvedTheme().tokens;
+  // Panel chrome (title bar, container Select) follows the theme; the log
+  // body + footer render as a console (dark by default).
+  const consoleT = useConsoleTokens();
   const initialContainer =
     (defaultContainer && pod.containers.includes(defaultContainer)
       ? defaultContainer
@@ -181,7 +184,7 @@ export function LogPanel({
         </header>
 
         <LogView
-          t={t}
+          t={consoleT}
           clusterId={clusterId}
           namespace={pod.namespace}
           pod={pod.name}

--- a/ui/src/components/MinimizedChatPill.test.tsx
+++ b/ui/src/components/MinimizedChatPill.test.tsx
@@ -1,0 +1,80 @@
+// The minimised chat pill is the right-edge affordance shown while the chat
+// dock is hidden. With sessions living inside one chat window the dock holds a
+// single chat tab, so the pill behaves as one unit: clicking anywhere on it
+// restores the chat, and a single close button (which must NOT also restore)
+// tears it down. These tests pin that contract.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { MinimizedChatPill } from "./MinimizedChatPill";
+import { tokens } from "../theme";
+
+const T = tokens("dark");
+
+// The pill body is a div[role="button"] labelled "Restore chat"; the close
+// control is the only real <button> rendered inside it.
+function closeButton(container: HTMLElement): HTMLButtonElement {
+  const btn = container.querySelector("button");
+  if (!btn) throw new Error("close button not found");
+  return btn;
+}
+
+describe("MinimizedChatPill", () => {
+  it("labels the pill 'Chat' for a single chat", () => {
+    const { getByText } = render(
+      <MinimizedChatPill t={T} count={1} onRestore={() => {}} onClose={() => {}} />,
+    );
+    expect(getByText("Chat")).toBeInTheDocument();
+  });
+
+  it("pluralises the label when more than one chat is open", () => {
+    const { getByText } = render(
+      <MinimizedChatPill t={T} count={3} onRestore={() => {}} onClose={() => {}} />,
+    );
+    expect(getByText("3 chats")).toBeInTheDocument();
+  });
+
+  it("uses no native title attribute on the restore body (themed tooltip only)", () => {
+    // Regression: the pill once carried `title="Restore chat"`, which renders
+    // the OS tooltip the rest of the app deliberately replaces with <Tooltip>.
+    const { getByRole } = render(
+      <MinimizedChatPill t={T} count={1} onRestore={() => {}} onClose={() => {}} />,
+    );
+    expect(getByRole("button", { name: "Restore chat" })).not.toHaveAttribute(
+      "title",
+    );
+  });
+
+  it("restores when the pill body is clicked", () => {
+    const onRestore = vi.fn();
+    const { getByRole } = render(
+      <MinimizedChatPill t={T} count={1} onRestore={onRestore} onClose={() => {}} />,
+    );
+    fireEvent.click(getByRole("button", { name: "Restore chat" }));
+    expect(onRestore).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores on Enter / Space for keyboard users", () => {
+    const onRestore = vi.fn();
+    const { getByRole } = render(
+      <MinimizedChatPill t={T} count={1} onRestore={onRestore} onClose={() => {}} />,
+    );
+    const pill = getByRole("button", { name: "Restore chat" });
+    fireEvent.keyDown(pill, { key: "Enter" });
+    fireEvent.keyDown(pill, { key: " " });
+    expect(onRestore).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes — and does NOT restore — when the close button is clicked", () => {
+    // The close button lives inside the clickable pill; stopPropagation must
+    // keep its click from bubbling up into the restore handler.
+    const onRestore = vi.fn();
+    const onClose = vi.fn();
+    const { container } = render(
+      <MinimizedChatPill t={T} count={1} onRestore={onRestore} onClose={onClose} />,
+    );
+    fireEvent.click(closeButton(container));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onRestore).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/MinimizedChatPill.tsx
+++ b/ui/src/components/MinimizedChatPill.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { FS_SM, type Tokens } from "../theme";
+import { IconBtn, Icons, Tooltip } from "./ui";
+
+// Right-placement (chat) minimised pill. With sessions living inside a single
+// chat window the steady state is one chat tab, so the whole pill is the
+// restore affordance — click anywhere on it to bring the chat back — and a
+// single close button (stopPropagation so it doesn't also restore) tears the
+// chat down. The vertical label reads "Chat" for the common single-tab case
+// and "{n} chats" only when more than one cluster's chat is open at once.
+export function MinimizedChatPill({
+  t,
+  count,
+  onRestore,
+  onClose,
+}: {
+  t: Tokens;
+  count: number;
+  onRestore: () => void;
+  onClose: () => void;
+}) {
+  const [hover, setHover] = useState(false);
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="Restore chat"
+      onClick={onRestore}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onRestore();
+        }
+      }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        position: "fixed",
+        top: "calc(60px + var(--fs-titlebar-h, 0px))",
+        right: 0,
+        background: hover ? t.hover : t.headerAlt,
+        borderLeft: `1px solid ${t.border}`,
+        borderTop: `1px solid ${t.border}`,
+        borderBottom: `1px solid ${t.border}`,
+        borderTopLeftRadius: 6,
+        borderBottomLeftRadius: 6,
+        padding: "8px 8px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 8,
+        zIndex: 25,
+        fontSize: FS_SM,
+        cursor: "pointer",
+        transition: "background .12s",
+      }}
+    >
+      {/*
+        Themed hint on the obvious target (icon + label) rather than the whole
+        pill — wrapping the whole pill would surface this tooltip at the same
+        time as the close button's own when the cursor is over the ×.
+      */}
+      <Tooltip label="Restore chat" side="left">
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 8,
+          }}
+        >
+          <span style={{ color: t.textDim, display: "inline-flex" }}>
+            {Icons.chat}
+          </span>
+          <span
+            style={{
+              color: t.textMuted,
+              writingMode: "vertical-rl",
+              transform: "rotate(180deg)",
+              fontWeight: 500,
+              letterSpacing: 0.4,
+            }}
+          >
+            {count === 1 ? "Chat" : `${count} chats`}
+          </span>
+        </div>
+      </Tooltip>
+      <IconBtn
+        t={t}
+        title={count === 1 ? "Close chat" : "Close all chats"}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+      >
+        {Icons.close}
+      </IconBtn>
+    </div>
+  );
+}

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -604,6 +604,18 @@ function AppearanceSection({}: { mode: ThemeMode }) {
       </Field>
       <Field
         t={t}
+        label="Dark console"
+        hint="Keep pod logs and terminals dark even under a light theme, so they read like a terminal."
+      >
+        <Toggle
+          t={t}
+          checked={settings.darkConsole}
+          onChange={(v) => patchSettings({ darkConsole: v })}
+          label={settings.darkConsole ? "On" : "Off"}
+        />
+      </Field>
+      <Field
+        t={t}
         label="Interface scale"
         hint={`Zoom the whole UI. ${MOD_KEY}+− / ${MOD_KEY}+= to nudge, ${MOD_KEY}+0 to reset.`}
       >

--- a/ui/src/components/detail/InlineLogTab.tsx
+++ b/ui/src/components/detail/InlineLogTab.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useResolvedTheme } from "../../store";
+import { useConsoleTokens, useResolvedTheme } from "../../store";
 import { FF_MONO, type ThemeMode, FS_SM } from "../../theme";
 import { Select } from "../ui";
 import { LogView, type LogViewState } from "../log/LogView";
@@ -41,6 +41,9 @@ export function InlineLogTab({
   defaultContainer?: string | null;
 }) {
   const t = useResolvedTheme().tokens;
+  // The log body + footer render as a console (dark by default); the tab
+  // chrome above stays in the active theme. See `useConsoleTokens`.
+  const consoleT = useConsoleTokens();
   const initialContainer =
     (defaultContainer && containers.includes(defaultContainer)
       ? defaultContainer
@@ -148,7 +151,7 @@ export function InlineLogTab({
         </span>
       </div>
       <LogView
-        t={t}
+        t={consoleT}
         clusterId={clusterId}
         namespace={namespace}
         pod={name}

--- a/ui/src/components/log/LogView.test.tsx
+++ b/ui/src/components/log/LogView.test.tsx
@@ -8,7 +8,7 @@
 //   • no container:                no stream opened at all
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, act } from "@testing-library/react";
+import { render, act, fireEvent } from "@testing-library/react";
 import { LogView, type LogViewState } from "./LogView";
 import { tokens } from "../../theme";
 import { setMockInvoke, resetMockInvoke, Channel } from "../../test/tauri-mock";
@@ -150,6 +150,53 @@ describe("LogView", () => {
     expect(last.status).toEqual({ kind: "ended", reason: "stream closed" });
     // Unlike `waiting`, `ended` does append a system line to the body.
     expect(last.lineCount).toBe(1);
+  });
+
+  it("Cmd+F opens an in-place find bar that counts matches", async () => {
+    const m = mockLogStream();
+    let utils!: ReturnType<typeof render>;
+    await act(async () => {
+      utils = renderLogView("app");
+    });
+    // A single batch (one ring flush) seeds both lines — emitting two
+    // separate `line` events would trip the synchronous-rAF test stub, where
+    // requestAnimationFrame returns 0 and the per-line flush guard blocks the
+    // second coalesced setLines.
+    await m.emit({ kind: "batch", lines: ["hello world", "goodbye world"] });
+
+    const root = utils.container.firstChild as HTMLElement;
+    // Closed by default.
+    expect(utils.queryByPlaceholderText("Find")).toBeNull();
+
+    await act(async () => {
+      fireEvent.keyDown(root, { key: "f", code: "KeyF", metaKey: true });
+    });
+    const input = utils.getByPlaceholderText("Find") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+
+    // Two lines contain "world" → 1/2 (first match active).
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "world" } });
+    });
+    expect(utils.getByText("1/2")).toBeInTheDocument();
+
+    // One line contains "hello" → 1/1.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "hello" } });
+    });
+    expect(utils.getByText("1/1")).toBeInTheDocument();
+
+    // No match → 0/0.
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "zzz" } });
+    });
+    expect(utils.getByText("0/0")).toBeInTheDocument();
+
+    // Esc closes the bar.
+    await act(async () => {
+      fireEvent.keyDown(root, { key: "Escape" });
+    });
+    expect(utils.queryByPlaceholderText("Find")).toBeNull();
   });
 
   it("stops the backend stream on unmount", async () => {

--- a/ui/src/components/log/LogView.tsx
+++ b/ui/src/components/log/LogView.tsx
@@ -3,15 +3,18 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { api } from "../../api";
-import { FF_MONO, FS_SM, FS_XS, type Tokens } from "../../theme";
+import { FF_MONO, FS_SM, FS_XS, hexWithAlpha, type Tokens } from "../../theme";
 import { ErrorBlock } from "../ui";
-import { ansiToReact } from "../../lib/ansi";
+import { ansiToReact, stripAnsi } from "../../lib/ansi";
 import { splitTimestamp } from "../../lib/logFormat";
+import { findLogMatches, splitHighlight } from "../../lib/logSearch";
+import { latinLetter } from "../../lib/keyboard";
 
 // Pod-log surface body. Both surfaces (`InlineLogTab` — detail-panel Logs
 // tab; `LogPanel` — slide-in overlay) render their own chrome around this
@@ -126,6 +129,48 @@ export function LogView({
   // flushed.
   const programmaticScrollRef = useRef(false);
   const releaseRafRef = useRef<number | null>(null);
+
+  // ── Find-in-place (Cmd/Ctrl+F) ──────────────────────────────────────────
+  // The root wrapper is focusable (`tabIndex=-1`) and owns the keydown layer.
+  // Because the wrapper sits below React's root in the DOM, calling
+  // `stopPropagation()` here prevents the app-global Cmd+F (which opens the
+  // table filter) from also firing — find applies to the focused pane.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const findInputRef = useRef<HTMLInputElement | null>(null);
+  const [findOpen, setFindOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  // Index *into `matches`*, not into `lines`.
+  const [activeMatch, setActiveMatch] = useState(0);
+
+  // Line indices whose visible (ANSI-stripped) text contains the query.
+  const matches = useMemo(() => findLogMatches(lines, query), [lines, query]);
+  const activeLineIndex =
+    matches.length > 0 ? matches[Math.min(activeMatch, matches.length - 1)]! : -1;
+
+  // The app's `color-scheme` follows the theme, not the console, so the UA
+  // default text selection can render invisibly on a light theme with the dark
+  // console (or vice versa). Publish a console-derived veil for the
+  // `.fs-log-body ::selection` rule. Set via `setProperty` because csstype's
+  // inline-style type doesn't admit custom properties.
+  useEffect(() => {
+    scrollRef.current?.style.setProperty(
+      "--fs-console-selection",
+      hexWithAlpha(t.text, 0.3),
+    );
+  }, [t.text]);
+
+  // Focus the surface on mount so Cmd/Ctrl+F lands here (the keydown layer is
+  // on this wrapper) without the operator clicking in first. Skipped if an
+  // input already has focus, so we never steal from the container Select.
+  useEffect(() => {
+    const active = document.activeElement as HTMLElement | null;
+    const inField =
+      !!active &&
+      (active.tagName === "INPUT" ||
+        active.tagName === "TEXTAREA" ||
+        active.isContentEditable);
+    if (!inField) rootRef.current?.focus({ preventScroll: true });
+  }, []);
 
   // Mirror pause into a ref so the IPC handler (created once per stream)
   // can branch on the latest value.
@@ -333,12 +378,130 @@ export function LogView({
     });
   }, []);
 
+  const openFind = useCallback(() => {
+    setFindOpen(true);
+    // Tail-follow would yank the viewport off a match the moment a new line
+    // arrives. Park it while searching; the operator can re-enable it.
+    setAutoScroll(false);
+    // Focus + select after the input mounts so reopening over an existing
+    // query lets the operator type a replacement immediately.
+    requestAnimationFrame(() => {
+      findInputRef.current?.focus();
+      findInputRef.current?.select();
+    });
+  }, []);
+
+  const closeFind = useCallback(() => {
+    setFindOpen(false);
+    setQuery("");
+    rootRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  const gotoMatch = useCallback(
+    (dir: 1 | -1) => {
+      setActiveMatch((m) => {
+        if (matches.length === 0) return 0;
+        return (m + dir + matches.length) % matches.length;
+      });
+    },
+    [matches.length],
+  );
+
+  // Keep the active pointer in range as the match set shrinks/grows while typing.
+  useEffect(() => {
+    setActiveMatch((m) =>
+      matches.length === 0 ? 0 : Math.min(m, matches.length - 1),
+    );
+  }, [matches.length]);
+
+  // Scroll the active match into view (also fires as matches change while
+  // typing, jumping to the first hit). Marked programmatic so `handleScroll`
+  // doesn't misread it as the user scrolling away from the tail.
+  useEffect(() => {
+    if (!findOpen || activeLineIndex < 0) return;
+    programmaticScrollRef.current = true;
+    virtualizer.scrollToIndex(activeLineIndex, { align: "center" });
+    const raf = requestAnimationFrame(() => {
+      programmaticScrollRef.current = false;
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [findOpen, activeLineIndex, virtualizer]);
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const meta = e.metaKey || e.ctrlKey;
+      const letter = latinLetter(e);
+      if (meta && letter === "f") {
+        e.preventDefault();
+        // Stop the app-global Cmd+F (table filter) from also firing.
+        e.stopPropagation();
+        openFind();
+        return;
+      }
+      if (!findOpen) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        // Stop the app-global Esc from closing the whole log panel — first
+        // Esc dismisses the find bar only.
+        e.stopPropagation();
+        closeFind();
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        gotoMatch(e.shiftKey ? -1 : 1);
+        return;
+      }
+      // Cmd/Ctrl+G — next / prev match (macOS find convention).
+      if (meta && letter === "g") {
+        e.preventDefault();
+        e.stopPropagation();
+        gotoMatch(e.shiftKey ? -1 : 1);
+      }
+    },
+    [findOpen, openFind, closeFind, gotoMatch],
+  );
+
+  // Highlight tints, derived once per render from the console palette so the
+  // memoised rows compare equal across unrelated re-renders.
+  const matchBg = hexWithAlpha(t.warn, 0.38);
+  const activeMatchBg = hexWithAlpha(t.accent, 0.55);
+  const activeRowBg = hexWithAlpha(t.accent, 0.12);
+
   return (
-    <>
+    <div
+      ref={rootRef}
+      tabIndex={-1}
+      onKeyDown={onKeyDown}
+      style={{
+        position: "relative",
+        flex: 1,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+        outline: "none",
+      }}
+    >
+      {findOpen && (
+        <LogFindBar
+          t={t}
+          inputRef={findInputRef}
+          query={query}
+          onQueryChange={(v) => {
+            setQuery(v);
+            setActiveMatch(0);
+          }}
+          matchCount={matches.length}
+          activeMatch={activeMatch}
+          onPrev={() => gotoMatch(-1)}
+          onNext={() => gotoMatch(1)}
+          onClose={closeFind}
+        />
+      )}
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="fs-selectable"
+        className="fs-selectable fs-log-body"
         style={{
           flex: 1,
           minHeight: 0,
@@ -402,6 +565,11 @@ export function LogView({
                     gutterDim={t.textDim}
                     divider={t.borderSoft}
                     showTs={showTs}
+                    query={findOpen ? query : ""}
+                    active={findOpen && vi.index === activeLineIndex}
+                    matchBg={matchBg}
+                    activeMatchBg={activeMatchBg}
+                    activeRowBg={activeRowBg}
                   />
                 </div>
               );
@@ -478,11 +646,31 @@ export function LogView({
           />
           timestamps
         </label>
+        <button
+          type="button"
+          onClick={() => (findOpen ? closeFind() : openFind())}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "2px 10px",
+            border: `1px solid ${t.border}`,
+            borderRadius: 4,
+            background: findOpen ? t.accentSoft : t.surface,
+            color: findOpen ? t.accent : t.text,
+            fontFamily: FF_MONO,
+            fontSize: FS_SM,
+            cursor: "pointer",
+          }}
+          title="Find in logs (Ctrl/⌘+F)"
+        >
+          Find
+        </button>
         <span style={{ marginLeft: "auto" }}>
           drops oldest beyond {MAX_LINES.toLocaleString()}
         </span>
       </div>
-    </>
+    </div>
   );
 }
 
@@ -503,6 +691,11 @@ const LogLine = memo(function LogLine({
   gutterDim,
   divider,
   showTs,
+  query,
+  active,
+  matchBg,
+  activeMatchBg,
+  activeRowBg,
 }: {
   entry: LineEntry;
   text: string;
@@ -511,6 +704,14 @@ const LogLine = memo(function LogLine({
   gutterDim: string;
   divider: string;
   showTs: boolean;
+  // Active find query ("" when the find bar is closed). Highlighting only
+  // kicks in for a non-empty query.
+  query: string;
+  // This row is the current find result (scrolled to, brighter highlight).
+  active: boolean;
+  matchBg: string;
+  activeMatchBg: string;
+  activeRowBg: string;
 }) {
   return (
     <div
@@ -518,6 +719,7 @@ const LogLine = memo(function LogLine({
         display: "flex",
         alignItems: "flex-start",
         contain: "content",
+        background: active ? activeRowBg : undefined,
       }}
     >
       <span
@@ -571,8 +773,170 @@ const LogLine = memo(function LogLine({
           wordBreak: "break-all",
         }}
       >
-        {entry.system ? entry.text : ansiToReact(entry.text)}
+        {renderLineBody(entry, query, active, matchBg, activeMatchBg)}
       </div>
     </div>
   );
 });
+
+// Render a line's body. With no active query we keep the fast path: system
+// lines render plain, everything else through `ansiToReact`. While searching,
+// only the lines that actually contain the query are re-rendered with
+// <mark>-style highlights over their ANSI-stripped text — non-matching lines
+// keep their colours untouched, so the matches stand out.
+function renderLineBody(
+  entry: LineEntry,
+  query: string,
+  active: boolean,
+  matchBg: string,
+  activeMatchBg: string,
+) {
+  if (query.length === 0) {
+    return entry.system ? entry.text : ansiToReact(entry.text);
+  }
+  const visible = entry.system ? entry.text : stripAnsi(entry.text);
+  const segments = splitHighlight(visible, query);
+  // No hit on this line → leave the original rendering (and ANSI colours) be.
+  if (segments.length === 1 && !segments[0]!.match) {
+    return entry.system ? entry.text : ansiToReact(entry.text);
+  }
+  return segments.map((seg, i) =>
+    seg.match ? (
+      <mark
+        key={i}
+        style={{
+          background: active ? activeMatchBg : matchBg,
+          color: "inherit",
+          borderRadius: 2,
+        }}
+      >
+        {seg.text}
+      </mark>
+    ) : (
+      <span key={i}>{seg.text}</span>
+    ),
+  );
+}
+
+// Floating find bar pinned to the top-right of the log surface. Styled with
+// the console palette so it sits on the dark body. Keyboard (Enter / Esc /
+// Cmd+G) is handled by the parent's root `onKeyDown`; the buttons are the
+// pointer affordances for the same actions.
+function LogFindBar({
+  t,
+  inputRef,
+  query,
+  onQueryChange,
+  matchCount,
+  activeMatch,
+  onPrev,
+  onNext,
+  onClose,
+}: {
+  t: Tokens;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  query: string;
+  onQueryChange: (v: string) => void;
+  matchCount: number;
+  activeMatch: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onClose: () => void;
+}) {
+  const counter =
+    query.length === 0
+      ? ""
+      : matchCount === 0
+        ? "0/0"
+        : `${Math.min(activeMatch, matchCount - 1) + 1}/${matchCount}`;
+  const navBtn = (
+    label: string,
+    onClick: () => void,
+    title: string,
+  ) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={matchCount === 0}
+      title={title}
+      style={{
+        border: "none",
+        background: "transparent",
+        color: matchCount === 0 ? t.textMuted : t.textDim,
+        cursor: matchCount === 0 ? "default" : "pointer",
+        fontFamily: FF_MONO,
+        fontSize: FS_SM,
+        padding: "2px 4px",
+        lineHeight: 1,
+      }}
+    >
+      {label}
+    </button>
+  );
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: 8,
+        right: 16,
+        zIndex: 5,
+        display: "flex",
+        alignItems: "center",
+        gap: 4,
+        padding: "4px 6px",
+        background: t.surface,
+        border: `1px solid ${t.border}`,
+        borderRadius: 6,
+        boxShadow: "0 6px 18px rgba(0,0,0,0.35)",
+      }}
+    >
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="Find"
+        spellCheck={false}
+        style={{
+          width: 180,
+          border: "none",
+          outline: "none",
+          background: "transparent",
+          color: t.text,
+          fontFamily: FF_MONO,
+          fontSize: FS_SM,
+        }}
+      />
+      <span
+        style={{
+          minWidth: 36,
+          textAlign: "right",
+          color: query.length > 0 && matchCount === 0 ? t.bad : t.textMuted,
+          fontFamily: FF_MONO,
+          fontSize: FS_XS,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {counter}
+      </span>
+      {navBtn("↑", onPrev, "Previous match (Shift+Enter)")}
+      {navBtn("↓", onNext, "Next match (Enter)")}
+      <button
+        type="button"
+        onClick={onClose}
+        title="Close (Esc)"
+        style={{
+          border: "none",
+          background: "transparent",
+          color: t.textDim,
+          cursor: "pointer",
+          fontFamily: FF_MONO,
+          fontSize: FS_SM,
+          padding: "2px 4px",
+          lineHeight: 1,
+        }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -43,6 +43,16 @@ textarea,
   -webkit-user-select: text;
 }
 
+/* Console (pod-log) text selection. `color-scheme` tracks the app theme, not
+   the console surface, so on a light theme with the dark console the UA's
+   default selection can come out invisible. `LogView` sets
+   `--fs-console-selection` from the console text colour; pin it explicitly so
+   the highlight is always visible and glyphs stay readable through the veil. */
+.fs-log-body::selection,
+.fs-log-body ::selection {
+  background: var(--fs-console-selection, rgba(110, 120, 140, 0.4));
+}
+
 @keyframes fs-pulse-dot-kf {
   0%,
   100% {

--- a/ui/src/lib/logSearch.test.ts
+++ b/ui/src/lib/logSearch.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { findLogMatches, splitHighlight } from "./logSearch";
+
+describe("findLogMatches", () => {
+  const lines = [
+    { text: "starting up" },
+    { text: "connection refused" },
+    { text: "Connection re-established" },
+    { text: "all good" },
+  ];
+
+  it("returns indices of lines containing the query, case-insensitively", () => {
+    expect(findLogMatches(lines, "connection")).toEqual([1, 2]);
+  });
+
+  it("matches a substring anywhere in the line", () => {
+    expect(findLogMatches(lines, "refused")).toEqual([1]);
+  });
+
+  it("returns an empty array for a blank query (matches nothing)", () => {
+    expect(findLogMatches(lines, "")).toEqual([]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(findLogMatches(lines, "zzz")).toEqual([]);
+  });
+
+  it("strips ANSI before matching so coloured lines still hit", () => {
+    const colored = [{ text: "\x1b[31mfatal error\x1b[0m here" }];
+    expect(findLogMatches(colored, "fatal error")).toEqual([0]);
+    // The escape bytes themselves are never matchable.
+    expect(findLogMatches(colored, "[31m")).toEqual([]);
+  });
+});
+
+describe("splitHighlight", () => {
+  it("splits a single match into non-match / match / non-match", () => {
+    expect(splitHighlight("the error here", "error")).toEqual([
+      { text: "the ", match: false },
+      { text: "error", match: true },
+      { text: " here", match: false },
+    ]);
+  });
+
+  it("preserves the source casing while matching case-insensitively", () => {
+    expect(splitHighlight("Error: ERROR", "error")).toEqual([
+      { text: "Error", match: true },
+      { text: ": ", match: false },
+      { text: "ERROR", match: true },
+    ]);
+  });
+
+  it("highlights a match at the start and end", () => {
+    expect(splitHighlight("abcabc", "abc")).toEqual([
+      { text: "abc", match: true },
+      { text: "abc", match: true },
+    ]);
+  });
+
+  it("returns a single non-match segment for a blank query", () => {
+    const segs = splitHighlight("anything", "");
+    expect(segs).toEqual([{ text: "anything", match: false }]);
+    expect(segs.length === 1 && !segs[0]!.match).toBe(true);
+  });
+
+  it("returns a single non-match segment when there is no match", () => {
+    expect(splitHighlight("nothing to see", "xyz")).toEqual([
+      { text: "nothing to see", match: false },
+    ]);
+  });
+});

--- a/ui/src/lib/logSearch.ts
+++ b/ui/src/lib/logSearch.ts
@@ -1,0 +1,53 @@
+// Pure helpers for the in-place log find bar. Kept React-free so the matching
+// and highlight-splitting logic can be unit-tested without rendering a
+// virtualized list. `LogView` owns the find UI; these own the string work.
+
+import { stripAnsi } from "./ansi";
+
+// Indices (into `lines`) of every line whose *visible* text contains `query`,
+// case-insensitive. ANSI escape codes are stripped before matching so a search
+// for "error" still hits a red-coloured `\x1b[31merror\x1b[0m` line. A blank
+// query matches nothing — the find bar shows "0" rather than selecting every
+// line.
+export function findLogMatches(
+  lines: { text: string }[],
+  query: string,
+): number[] {
+  const q = query.toLowerCase();
+  if (q.length === 0) return [];
+  const out: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (stripAnsi(lines[i]!.text).toLowerCase().includes(q)) out.push(i);
+  }
+  return out;
+}
+
+export type HighlightSegment = { text: string; match: boolean };
+
+// Split `text` into alternating non-match / match segments for `query`
+// (case-insensitive, non-overlapping, left-to-right). Used to render
+// <mark>-style highlights on matched lines while preserving the original
+// casing of the source text. An empty query (or empty text) returns the whole
+// string as a single non-match segment, so callers can detect "no highlight"
+// via `segments.length === 1 && !segments[0].match`.
+export function splitHighlight(
+  text: string,
+  query: string,
+): HighlightSegment[] {
+  if (query.length === 0 || text.length === 0) {
+    return [{ text, match: false }];
+  }
+  const hay = text.toLowerCase();
+  const needle = query.toLowerCase();
+  const out: HighlightSegment[] = [];
+  let from = 0;
+  let idx = hay.indexOf(needle, from);
+  while (idx !== -1) {
+    if (idx > from) out.push({ text: text.slice(from, idx), match: false });
+    out.push({ text: text.slice(idx, idx + needle.length), match: true });
+    from = idx + needle.length;
+    idx = hay.indexOf(needle, from);
+  }
+  if (from < text.length) out.push({ text: text.slice(from), match: false });
+  return out;
+}

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -89,6 +89,18 @@ describe("setTheme", () => {
   });
 });
 
+describe("darkConsole setting", () => {
+  it("defaults to on", () => {
+    expect(useAppStore.getState().settings.darkConsole).toBe(true);
+  });
+  it("patchSettings toggles it", () => {
+    useAppStore.getState().patchSettings({ darkConsole: false });
+    expect(useAppStore.getState().settings.darkConsole).toBe(false);
+    useAppStore.getState().patchSettings({ darkConsole: true });
+    expect(useAppStore.getState().settings.darkConsole).toBe(true);
+  });
+});
+
 describe("setPalette", () => {
   it("swaps palette inside the current theme", () => {
     useAppStore.getState().setTheme("default");

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -71,10 +71,16 @@ import {
   UI_SCALE_DEFAULT,
   UI_SCALE_STEP,
   clampUiScale,
+  consoleTokens,
   getTheme,
   resolveTheme,
 } from "./theme";
-import type { ResolvedTheme, ThemeMode, ThemeOverrides } from "./theme";
+import type {
+  ColorTokens,
+  ResolvedTheme,
+  ThemeMode,
+  ThemeOverrides,
+} from "./theme";
 
 type Status = "idle" | "loading" | "ready" | "error";
 
@@ -285,6 +291,9 @@ type AppState = {
     refreshOnLaunch: boolean;
     uiScale: number;
     fleetView: "tiles" | "mini" | "rows";
+    // Force the logs + terminal surfaces to a dark, console-style palette even
+    // under a light theme. Default on; toggled in Settings → Appearance.
+    darkConsole: boolean;
   };
 
   setContexts: (cs: ContextInfo[]) => void;
@@ -465,6 +474,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     refreshOnLaunch: true,
     uiScale: UI_SCALE_DEFAULT,
     fleetView: "tiles",
+    darkConsole: true,
   },
 
   appVersion: null,
@@ -829,6 +839,9 @@ export const useAppStore = create<AppState>((set, get) => ({
         // but be tolerant if a stale type ever ships through.
         uiScale: clampUiScale(prefs.settings.ui_scale ?? UI_SCALE_DEFAULT),
         fleetView: prefs.settings.fleet_view ?? "tiles",
+        // Older prefs predate dark_console; default on so a light-theme user
+        // gets the console treatment without re-opting.
+        darkConsole: prefs.settings.dark_console ?? true,
       },
       // `prefs.update` lands populated by `#[serde(default)]` on the Rust side
       // for prefs.json files written before this block existed.
@@ -994,5 +1007,21 @@ export function useResolvedTheme(): ResolvedTheme {
   return useMemo(
     () => resolveTheme({ themeId, paletteId, mode, overrides }),
     [themeId, paletteId, mode, overrides],
+  );
+}
+
+/// Console (logs + terminal) color tokens. Mirrors `useResolvedTheme` but
+/// honours the `darkConsole` setting: when on, the surface resolves the active
+/// theme's dark palette even under a light theme so it reads like a terminal.
+/// When off, it follows the active mode like any other panel.
+export function useConsoleTokens(): ColorTokens {
+  const themeId = useAppStore((s) => s.themeId);
+  const paletteId = useAppStore((s) => s.paletteId);
+  const mode = useAppStore((s) => s.themeMode);
+  const overrides = useAppStore((s) => s.themeOverrides);
+  const darkConsole = useAppStore((s) => s.settings.darkConsole);
+  return useMemo(
+    () => consoleTokens({ themeId, paletteId, mode, overrides, darkConsole }),
+    [themeId, paletteId, mode, overrides, darkConsole],
   );
 }

--- a/ui/src/theme.test.ts
+++ b/ui/src/theme.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   THEMES,
   clampUiScale,
+  consoleTokens,
   getPalette,
   getTheme,
   resolveTheme,
@@ -244,6 +245,56 @@ describe("resolveTheme", () => {
     expect(r.typography.scale.lg).toBe(14);
     expect(r.display.showRailIcons).toBe(false);
     expect(r.display.showDetailIcons).toBe(true);
+  });
+});
+
+describe("consoleTokens", () => {
+  it("forces the dark palette under a light theme when darkConsole is on", () => {
+    const c = consoleTokens({
+      themeId: "default",
+      paletteId: "default",
+      mode: "light",
+      darkConsole: true,
+    });
+    // Light mode would give surfaceAlt #f7f8fa; the forced-dark console must
+    // resolve the dark palette instead.
+    expect(c.surfaceAlt).toBe(
+      resolveTheme({ themeId: "default", paletteId: "default", mode: "dark" })
+        .tokens.surfaceAlt,
+    );
+    expect(c.surfaceAlt).not.toBe(
+      resolveTheme({ themeId: "default", paletteId: "default", mode: "light" })
+        .tokens.surfaceAlt,
+    );
+  });
+
+  it("follows the active light mode when darkConsole is off", () => {
+    const c = consoleTokens({
+      themeId: "default",
+      paletteId: "default",
+      mode: "light",
+      darkConsole: false,
+    });
+    expect(c.surfaceAlt).toBe(
+      resolveTheme({ themeId: "default", paletteId: "default", mode: "light" })
+        .tokens.surfaceAlt,
+    );
+  });
+
+  it("is a no-op in dark mode regardless of the toggle", () => {
+    const on = consoleTokens({
+      themeId: "default",
+      paletteId: "default",
+      mode: "dark",
+      darkConsole: true,
+    });
+    const off = consoleTokens({
+      themeId: "default",
+      paletteId: "default",
+      mode: "dark",
+      darkConsole: false,
+    });
+    expect(on.surfaceAlt).toBe(off.surfaceAlt);
   });
 });
 

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -892,6 +892,28 @@ export function resolveTheme(opts: {
   };
 }
 
+// ── Console (logs + terminal) surface ───────────────────────────────────────
+// Logs and terminals conventionally read like a terminal — dark, regardless of
+// the surrounding chrome. With `darkConsole` on we resolve the *dark* palette of
+// the active theme even in light mode, so the surface stays a console while the
+// rest of the app follows the theme. Off → it follows the active mode like any
+// other panel. Overrides ride along exactly as the mode toggle reuses them.
+export function consoleTokens(opts: {
+  themeId: string;
+  paletteId: string;
+  mode: ThemeMode;
+  overrides?: ThemeOverrides | null;
+  darkConsole: boolean;
+}): ColorTokens {
+  const mode: ThemeMode = opts.darkConsole ? "dark" : opts.mode;
+  return resolveTheme({
+    themeId: opts.themeId,
+    paletteId: opts.paletteId,
+    mode,
+    overrides: opts.overrides,
+  }).tokens;
+}
+
 // ── Legacy `tokens(mode)` shim ─────────────────────────────────────────────
 // Existing call sites pass only `mode`. They get the Default theme's palette,
 // matching today's behaviour exactly. New code should read `tokens` off

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -194,6 +194,7 @@ export type PrefsSettings = {
   refresh_on_launch: boolean;
   ui_scale: number;
   fleet_view: PrefsFleetView;
+  dark_console: boolean;
 };
 export type PrefsUiState = {
   selected_context: string | null;


### PR DESCRIPTION
Bundles two UI workstreams sitting in the tree.

Dark console + log/terminal search:
- `darkConsole` setting forces pod logs + terminals to the active theme's dark palette even under a light theme, so a console reads like a console. New `consoleTokens()` resolver + `useConsoleTokens()` hook, `dark_console` pref (defaults on, with a prefs migration so older installs opt in), and a Settings -> Appearance toggle.
- In-terminal Cmd+F search in the dock via xterm `SearchAddon`.
- LogView search bar with match navigation, backed by `logSearch.ts`.

Chat dock minimize pill:
- The minimized chat pill is now a single click target that restores the chat; one close button, with stopPropagation so it doesn't also restore.
- Replaces the native `title` (OS tooltip) with the themed `<Tooltip>`; extracted into `MinimizedChatPill` with render/interaction tests.

Tests: vitest 602 pass; cargo clippy --workspace clean; cargo fmt clean.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
