### PR TITLE
feat(chat): image attachments via clipboard paste + file attach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1742,6 +1742,7 @@ dependencies = [
  "keyring",
  "kube",
  "mimalloc",
+ "png 0.17.16",
  "portable-pty",
  "pretty_assertions",
  "reqwest",

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -27,4 +27,4 @@ pub use provider::{
 pub use session::{
     SessionData, SessionError, SessionEvent, SessionMeta, SessionStore, SessionUpdate,
 };
-pub use types::{ChatMessage, MessageRole, ToolCall, ToolSchema};
+pub use types::{ChatMessage, ImageAttachment, MessageRole, ToolCall, ToolSchema};

--- a/crates/agent/src/provider/anthropic.rs
+++ b/crates/agent/src/provider/anthropic.rs
@@ -15,8 +15,8 @@
 //! the agent loop and the UI don't have to care about Anthropic specifics.
 
 use super::{
-    merge_top_level, ChatProvider, CompletionEvent, CompletionFinal, CompletionRequest, EventSink,
-    FinishReason, ModelInfo, ProviderError, Usage,
+    dropped_images_note, merge_top_level, ChatProvider, CompletionEvent, CompletionFinal,
+    CompletionRequest, EventSink, FinishReason, ModelInfo, ProviderError, Usage,
 };
 use crate::config::Credential;
 use crate::provider::meta::{self, ProviderMeta};
@@ -77,13 +77,48 @@ impl AnthropicProvider {
 
 // ─── Request body construction ──────────────────────────────────────────────
 
+/// Build the `content` array for a user message: an optional text block
+/// followed by one `image` block per attachment. When the model can't see
+/// images we drop them and fold a short note into the text so the model
+/// isn't blind to something the operator attached. Anthropic requires a
+/// non-empty content array, so the no-image / no-text path still emits a
+/// single (possibly empty) text block — preserving the prior behaviour.
+fn user_content(m: &ChatMessage, supports_vision: bool) -> Vec<Value> {
+    if supports_vision && !m.images.is_empty() {
+        let mut blocks: Vec<Value> = Vec::new();
+        if !m.content.is_empty() {
+            blocks.push(json!({ "type": "text", "text": m.content }));
+        }
+        for img in &m.images {
+            blocks.push(json!({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": img.mime,
+                    "data": img.data,
+                },
+            }));
+        }
+        blocks
+    } else {
+        let text = if m.images.is_empty() {
+            m.content.clone()
+        } else {
+            dropped_images_note(&m.content, m.images.len())
+        };
+        vec![json!({ "type": "text", "text": text })]
+    }
+}
+
 /// Convert the agent's neutral `Vec<ChatMessage>` into Anthropic's
 /// `(system: String, messages: [...] )` shape. System messages collapse
 /// into the top-level `system` field; assistant tool_calls become
 /// `tool_use` content blocks; `Tool` role messages become a `user`
 /// message containing a `tool_result` block (Anthropic's protocol uses
 /// `user` with `tool_result` blocks rather than a dedicated tool role).
-fn build_messages(messages: &[ChatMessage]) -> (String, Vec<Value>) {
+/// `supports_vision` gates whether user-message image attachments are
+/// emitted as `image` blocks or dropped with a note.
+fn build_messages(messages: &[ChatMessage], supports_vision: bool) -> (String, Vec<Value>) {
     let mut system_parts: Vec<String> = Vec::new();
     let mut out: Vec<Value> = Vec::new();
 
@@ -97,7 +132,7 @@ fn build_messages(messages: &[ChatMessage]) -> (String, Vec<Value>) {
             MessageRole::User => {
                 out.push(json!({
                     "role": "user",
-                    "content": [{ "type": "text", "text": m.content }],
+                    "content": user_content(m, supports_vision),
                 }));
             }
             MessageRole::Assistant => {
@@ -206,7 +241,14 @@ impl ChatProvider for AnthropicProvider {
         req: CompletionRequest,
         sink: EventSink,
     ) -> Result<CompletionFinal, ProviderError> {
-        let (system, messages) = build_messages(&req.messages);
+        // Drop image blocks only when models.dev positively says the
+        // model is text-only; unknown models default to "try it" and let
+        // the apiserver be the arbiter.
+        let supports_vision = crate::provider::catalogue::supports_vision(
+            crate::config::ProviderKind::Anthropic,
+            &req.model,
+        );
+        let (system, messages) = build_messages(&req.messages, supports_vision);
 
         let mut body = json!({
             "model": req.model,
@@ -487,7 +529,7 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let (sys, body) = build_messages(&msgs);
+        let (sys, body) = build_messages(&msgs, true);
         assert_eq!(sys, "You are helpful.");
         assert_eq!(body.len(), 3);
         assert_eq!(body[0]["role"], "user");
@@ -497,6 +539,48 @@ mod tests {
         assert_eq!(body[2]["role"], "user");
         assert_eq!(body[2]["content"][0]["type"], "tool_result");
         assert_eq!(body[2]["content"][0]["tool_use_id"], "call_1");
+    }
+
+    #[test]
+    fn user_message_with_image_emits_image_block_when_vision_supported() {
+        let msg = ChatMessage {
+            role: MessageRole::User,
+            content: "what is this?".into(),
+            images: vec![crate::types::ImageAttachment {
+                mime: "image/png".into(),
+                data: "AAAA".into(),
+            }],
+            ..Default::default()
+        };
+        let (_sys, body) = build_messages(std::slice::from_ref(&msg), true);
+        assert_eq!(body.len(), 1);
+        let content = body[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "what is this?");
+        assert_eq!(content[1]["type"], "image");
+        assert_eq!(content[1]["source"]["type"], "base64");
+        assert_eq!(content[1]["source"]["media_type"], "image/png");
+        assert_eq!(content[1]["source"]["data"], "AAAA");
+    }
+
+    #[test]
+    fn user_message_with_image_drops_to_note_when_vision_unsupported() {
+        let msg = ChatMessage {
+            role: MessageRole::User,
+            content: "look".into(),
+            images: vec![crate::types::ImageAttachment {
+                mime: "image/png".into(),
+                data: "AAAA".into(),
+            }],
+            ..Default::default()
+        };
+        let (_sys, body) = build_messages(std::slice::from_ref(&msg), false);
+        let content = body[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        let text = content[0]["text"].as_str().unwrap();
+        assert!(text.starts_with("look"));
+        assert!(text.contains("does not support image input"));
     }
 
     #[test]

--- a/crates/agent/src/provider/catalogue.rs
+++ b/crates/agent/src/provider/catalogue.rs
@@ -60,6 +60,14 @@ pub struct ModelCapabilities {
     pub reasoning: bool,
     pub tool_call: bool,
     pub temperature: bool,
+    /// True when the model accepts image input (models.dev
+    /// `modalities.input` contains `"image"`). Drives whether the
+    /// providers emit image content blocks for attached images or drop
+    /// them with a note. Defaults to `false` when the catalogue lists the
+    /// model without modalities — callers treat a *missing* catalogue
+    /// entry (lookup returns `None`) as permissive, so unknown models
+    /// still get a chance to render attachments.
+    pub vision: bool,
     /// When set, the OpenAI-compat backend expects every assistant
     /// message to carry the named field with the previously-emitted
     /// reasoning text. The field name itself ("reasoning_content" or
@@ -109,6 +117,16 @@ struct ModelEntry {
     temperature: Option<bool>,
     #[serde(default)]
     interleaved: Option<InterleavedJson>,
+    /// `{ "input": ["text", "image", "pdf"], "output": ["text"] }`.
+    /// We only read `input` to decide vision support.
+    #[serde(default)]
+    modalities: Option<ModalitiesJson>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModalitiesJson {
+    #[serde(default)]
+    input: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -323,10 +341,15 @@ fn parse_catalogue(resp: ApiResponse) -> CatalogueMaps {
                 InterleavedJson::Bool(_) => None,
                 InterleavedJson::Obj { field } => field.filter(|s| !s.is_empty()),
             });
+            let vision = m
+                .modalities
+                .as_ref()
+                .is_some_and(|md| md.input.iter().any(|s| s == "image"));
             let caps = ModelCapabilities {
                 reasoning: m.reasoning.unwrap_or(false),
                 tool_call: m.tool_call.unwrap_or(true),
                 temperature: m.temperature.unwrap_or(true),
+                vision,
                 interleaved_field,
             };
             caps_by_id.insert(key, caps);
@@ -352,6 +375,17 @@ pub fn capabilities(kind: ProviderKind, model_id: &str) -> Option<ModelCapabilit
     g.caps_by_id
         .get(&(mdid.to_string(), model_id.to_string()))
         .cloned()
+}
+
+/// True iff `(kind, model)` is known to accept image input. Returns
+/// `true` when the model isn't in the catalogue yet — callers default to
+/// "try it" rather than silently dropping attachments for a model we have
+/// no data on (the apiserver is the final arbiter and surfaces a clean
+/// 400). Returns `false` only when models.dev lists the model *and* its
+/// input modalities exclude images, which is the one case where we can
+/// confidently drop the attachment with a note instead of erroring.
+pub fn supports_vision(kind: ProviderKind, model_id: &str) -> bool {
+    capabilities(kind, model_id).is_none_or(|c| c.vision)
 }
 
 /// Round-trip slot for OpenAI-compat assistant messages — when present,
@@ -501,6 +535,48 @@ mod tests {
             .expect("deepseek-chat caps");
         assert!(chat.interleaved_field.is_none());
         assert!(!chat.reasoning);
+    }
+
+    #[test]
+    fn parse_catalogue_extracts_vision_from_modalities() {
+        let raw = serde_json::json!({
+            "anthropic": {
+                "models": {
+                    "claude-opus": {
+                        "limit": { "context": 200000, "output": 8192 },
+                        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+                    },
+                    "text-only": {
+                        "limit": { "context": 128000, "output": 8192 },
+                        "modalities": { "input": ["text"], "output": ["text"] },
+                    },
+                    "no-modalities": {
+                        "limit": { "context": 128000, "output": 8192 },
+                    },
+                }
+            }
+        });
+        let resp: ApiResponse = serde_json::from_value(raw).unwrap();
+        let (_limits, _cost, caps) = parse_catalogue(resp);
+        assert!(
+            caps.get(&("anthropic".to_string(), "claude-opus".to_string()))
+                .unwrap()
+                .vision
+        );
+        assert!(
+            !caps
+                .get(&("anthropic".to_string(), "text-only".to_string()))
+                .unwrap()
+                .vision
+        );
+        // Missing modalities block → vision defaults to false (we only
+        // claim vision when models.dev positively lists "image").
+        assert!(
+            !caps
+                .get(&("anthropic".to_string(), "no-modalities".to_string()))
+                .unwrap()
+                .vision
+        );
     }
 
     #[test]

--- a/crates/agent/src/provider/mod.rs
+++ b/crates/agent/src/provider/mod.rs
@@ -140,6 +140,24 @@ pub(crate) fn merge_top_level(body: &mut serde_json::Value, overrides: &serde_js
     }
 }
 
+/// Build the replacement text when image attachments are dropped because
+/// the active model can't accept image input. Keeps the operator's prose
+/// and tells the model an image existed, so its reply isn't confusingly
+/// blind to something the operator clearly attached. Shared across
+/// providers so the wording (and the "drop, don't 400" policy) stays
+/// consistent.
+pub(crate) fn dropped_images_note(text: &str, count: usize) -> String {
+    let plural = if count == 1 { "image" } else { "images" };
+    let note = format!(
+        "[{count} {plural} attached but omitted: the selected model does not support image input.]"
+    );
+    if text.is_empty() {
+        note
+    } else {
+        format!("{text}\n\n{note}")
+    }
+}
+
 #[async_trait]
 pub trait ChatProvider: Send + Sync {
     fn name(&self) -> &'static str;

--- a/crates/agent/src/provider/openai_codex.rs
+++ b/crates/agent/src/provider/openai_codex.rs
@@ -25,8 +25,8 @@
 //! Subsequent 401s surface as `ProviderError::Auth`.
 
 use super::{
-    merge_top_level, ChatProvider, CompletionEvent, CompletionFinal, CompletionRequest, EventSink,
-    FinishReason, ModelInfo, ProviderError, Usage,
+    dropped_images_note, merge_top_level, ChatProvider, CompletionEvent, CompletionFinal,
+    CompletionRequest, EventSink, FinishReason, ModelInfo, ProviderError, Usage,
 };
 use crate::config::Credential;
 use crate::provider::meta;
@@ -207,11 +207,42 @@ impl OpenAICodexProvider {
 
 // ─── Request body construction ──────────────────────────────────────────────
 
+/// Build the Responses `content` array for a user message: an optional
+/// `input_text` block followed by one `input_image` block per attachment
+/// (the Responses API takes the image as a data-URI string under
+/// `image_url`). When the model can't see images we drop them and fold a
+/// note into the text. Always emits at least one block — Codex rejects an
+/// empty content array.
+fn user_input_content(m: &ChatMessage, supports_vision: bool) -> Vec<Value> {
+    if supports_vision && !m.images.is_empty() {
+        let mut content: Vec<Value> = Vec::new();
+        if !m.content.is_empty() {
+            content.push(json!({ "type": "input_text", "text": m.content }));
+        }
+        for img in &m.images {
+            content.push(json!({
+                "type": "input_image",
+                "image_url": format!("data:{};base64,{}", img.mime, img.data),
+            }));
+        }
+        content
+    } else {
+        let text = if m.images.is_empty() {
+            m.content.clone()
+        } else {
+            dropped_images_note(&m.content, m.images.len())
+        };
+        vec![json!({ "type": "input_text", "text": text })]
+    }
+}
+
 /// Convert `Vec<ChatMessage>` into Codex Responses input items. The
 /// `instructions` system field is split off and returned separately so
 /// the caller can drop it into the top-level `instructions` slot
-/// (preferred over an in-line `system` message).
-fn build_input(messages: &[ChatMessage]) -> (String, Vec<Value>) {
+/// (preferred over an in-line `system` message). `supports_vision` gates
+/// whether user-message image attachments become `input_image` blocks or
+/// are dropped with a note.
+fn build_input(messages: &[ChatMessage], supports_vision: bool) -> (String, Vec<Value>) {
     let mut instructions: Vec<String> = Vec::new();
     let mut input: Vec<Value> = Vec::new();
 
@@ -225,7 +256,7 @@ fn build_input(messages: &[ChatMessage]) -> (String, Vec<Value>) {
             MessageRole::User => {
                 input.push(json!({
                     "role": "user",
-                    "content": [{ "type": "input_text", "text": m.content }],
+                    "content": user_input_content(m, supports_vision),
                 }));
             }
             MessageRole::Assistant => {
@@ -294,7 +325,13 @@ impl ChatProvider for OpenAICodexProvider {
             }
         }
 
-        let (instructions, input) = build_input(&req.messages);
+        // Codex uses the OpenAI models.dev catalogue. Drop image blocks
+        // only when it positively marks the model text-only.
+        let supports_vision = crate::provider::catalogue::supports_vision(
+            crate::config::ProviderKind::OpenAI,
+            &req.model,
+        );
+        let (instructions, input) = build_input(&req.messages, supports_vision);
 
         let body = build_request_body(&req, &instructions, &input);
 
@@ -619,7 +656,7 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let (instr, input) = build_input(&msgs);
+        let (instr, input) = build_input(&msgs, true);
         assert_eq!(instr, "be helpful");
         // user, function_call, function_call_output (assistant-text was empty)
         assert_eq!(input.len(), 3);
@@ -629,6 +666,46 @@ mod tests {
         assert_eq!(input[2]["type"], "function_call_output");
         assert_eq!(input[2]["call_id"], "call_a");
         assert_eq!(input[2]["output"], "[]");
+    }
+
+    #[test]
+    fn user_message_with_image_emits_input_image_when_vision_supported() {
+        let msg = ChatMessage {
+            role: MessageRole::User,
+            content: "explain".into(),
+            images: vec![crate::types::ImageAttachment {
+                mime: "image/webp".into(),
+                data: "YmFy".into(),
+            }],
+            ..Default::default()
+        };
+        let (_instr, input) = build_input(std::slice::from_ref(&msg), true);
+        let content = input[0]["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "input_text");
+        assert_eq!(content[0]["text"], "explain");
+        assert_eq!(content[1]["type"], "input_image");
+        assert_eq!(content[1]["image_url"], "data:image/webp;base64,YmFy");
+    }
+
+    #[test]
+    fn user_message_with_image_drops_to_note_when_vision_unsupported() {
+        let msg = ChatMessage {
+            role: MessageRole::User,
+            content: "explain".into(),
+            images: vec![crate::types::ImageAttachment {
+                mime: "image/webp".into(),
+                data: "YmFy".into(),
+            }],
+            ..Default::default()
+        };
+        let (_instr, input) = build_input(std::slice::from_ref(&msg), false);
+        let content = input[0]["content"].as_array().unwrap();
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "input_text");
+        assert!(content[0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("does not support image input"));
     }
 
     #[test]

--- a/crates/agent/src/provider/openai_compat.rs
+++ b/crates/agent/src/provider/openai_compat.rs
@@ -6,8 +6,8 @@
 //! [`crate::provider::meta`].
 
 use super::{
-    merge_top_level, ChatProvider, CompletionEvent, CompletionFinal, CompletionRequest, EventSink,
-    FinishReason, ModelInfo, ProviderError, Usage,
+    dropped_images_note, merge_top_level, ChatProvider, CompletionEvent, CompletionFinal,
+    CompletionRequest, EventSink, FinishReason, ModelInfo, ProviderError, Usage,
 };
 use crate::config::{Credential, ProviderKind};
 use crate::provider::catalogue;
@@ -143,11 +143,35 @@ fn role_str(r: MessageRole) -> &'static str {
 /// names the per-model round-trip field (typically "reasoning_content")
 /// from models.dev — when set, every assistant message in the request
 /// body must carry it (empty string when the message has no captured
-/// reasoning) or DeepSeek-family backends 400.
-fn message_to_oa(m: &ChatMessage, interleaved: Option<&str>) -> Value {
+/// reasoning) or DeepSeek-family backends 400. `supports_vision` gates
+/// whether user-message image attachments are emitted as `image_url`
+/// content parts (which forces the array content form) or dropped with a
+/// note folded into the text.
+fn message_to_oa(m: &ChatMessage, interleaved: Option<&str>, supports_vision: bool) -> Value {
     let mut obj = serde_json::Map::new();
     obj.insert("role".to_string(), Value::String(role_str(m.role).into()));
-    if !m.content.is_empty() {
+    let user_with_images = matches!(m.role, MessageRole::User) && !m.images.is_empty();
+    if user_with_images && supports_vision {
+        // Multimodal user turn: content is an array of typed parts. OpenAI
+        // (and every vision-capable compat backend) takes images as a
+        // data-URI under `image_url.url`.
+        let mut parts: Vec<Value> = Vec::new();
+        if !m.content.is_empty() {
+            parts.push(json!({ "type": "text", "text": m.content }));
+        }
+        for img in &m.images {
+            parts.push(json!({
+                "type": "image_url",
+                "image_url": { "url": format!("data:{};base64,{}", img.mime, img.data) },
+            }));
+        }
+        obj.insert("content".to_string(), Value::Array(parts));
+    } else if user_with_images {
+        // Vision-incapable model: keep the text, fold in a note so the
+        // model knows an image was attached, never send `image_url`.
+        let text = dropped_images_note(&m.content, m.images.len());
+        obj.insert("content".to_string(), Value::String(text));
+    } else if !m.content.is_empty() {
         obj.insert("content".to_string(), Value::String(m.content.clone()));
     }
     if let Some(name) = &m.name {
@@ -332,11 +356,14 @@ impl ChatProvider for OpenAICompatibleProvider {
         let interleaved = caps.as_ref().and_then(|c| c.interleaved_field.clone());
         let supports_temperature = caps.as_ref().is_none_or(|c| c.temperature);
         let supports_tools = caps.as_ref().is_none_or(|c| c.tool_call);
+        // Unknown models (no catalogue entry) default to "try it" — only
+        // drop images when models.dev positively marks the model text-only.
+        let supports_vision = caps.as_ref().is_none_or(|c| c.vision);
 
         let oa_messages: Vec<Value> = req
             .messages
             .iter()
-            .map(|m| message_to_oa(m, interleaved.as_deref()))
+            .map(|m| message_to_oa(m, interleaved.as_deref(), supports_vision))
             .collect();
 
         let mut body = json!({
@@ -601,7 +628,7 @@ mod tests {
             reasoning_content: Some("step 1; step 2".into()),
             ..Default::default()
         };
-        let v = message_to_oa(&msg, Some("reasoning_content"));
+        let v = message_to_oa(&msg, Some("reasoning_content"), true);
         assert_eq!(v["role"], "assistant");
         assert_eq!(v["content"], "hi");
         assert_eq!(v["reasoning_content"], "step 1; step 2");
@@ -618,7 +645,7 @@ mod tests {
             reasoning_content: None,
             ..Default::default()
         };
-        let v = message_to_oa(&msg, Some("reasoning_content"));
+        let v = message_to_oa(&msg, Some("reasoning_content"), true);
         assert_eq!(v["reasoning_content"], "");
     }
 
@@ -629,7 +656,7 @@ mod tests {
             content: "hi".into(),
             ..Default::default()
         };
-        let v = message_to_oa(&msg, Some("reasoning_content"));
+        let v = message_to_oa(&msg, Some("reasoning_content"), true);
         assert!(v.get("reasoning_content").is_none());
     }
 
@@ -641,8 +668,44 @@ mod tests {
             reasoning_content: Some("noise".into()),
             ..Default::default()
         };
-        let v = message_to_oa(&msg, None);
+        let v = message_to_oa(&msg, None, true);
         assert!(v.get("reasoning_content").is_none());
         assert!(v.get("reasoning_details").is_none());
+    }
+
+    #[test]
+    fn user_message_with_image_uses_array_content_with_image_url() {
+        let msg = ChatMessage {
+            role: MessageRole::User,
+            content: "describe".into(),
+            images: vec![crate::types::ImageAttachment {
+                mime: "image/jpeg".into(),
+                data: "Zm9v".into(),
+            }],
+            ..Default::default()
+        };
+        let v = message_to_oa(&msg, None, true);
+        let parts = v["content"].as_array().unwrap();
+        assert_eq!(parts[0]["type"], "text");
+        assert_eq!(parts[0]["text"], "describe");
+        assert_eq!(parts[1]["type"], "image_url");
+        assert_eq!(parts[1]["image_url"]["url"], "data:image/jpeg;base64,Zm9v");
+    }
+
+    #[test]
+    fn user_message_with_image_drops_to_string_note_when_vision_unsupported() {
+        let msg = ChatMessage {
+            role: MessageRole::User,
+            content: "describe".into(),
+            images: vec![crate::types::ImageAttachment {
+                mime: "image/jpeg".into(),
+                data: "Zm9v".into(),
+            }],
+            ..Default::default()
+        };
+        let v = message_to_oa(&msg, None, false);
+        let content = v["content"].as_str().unwrap();
+        assert!(content.starts_with("describe"));
+        assert!(content.contains("does not support image input"));
     }
 }

--- a/crates/agent/src/session/mod.rs
+++ b/crates/agent/src/session/mod.rs
@@ -230,6 +230,7 @@ pub(crate) fn apply_compaction(events: Vec<SessionEvent>) -> Vec<SessionEvent> {
             // Provider impls don't read it; the agent loop uses it.
             name: Some("context_checkpoint".to_string()),
             reasoning_content: None,
+            images: vec![],
         },
         ts,
     });

--- a/crates/agent/src/types.rs
+++ b/crates/agent/src/types.rs
@@ -40,6 +40,27 @@ pub struct ChatMessage {
     /// session JSONLs so reload restores correct round-trip behaviour.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
+    /// Image attachments on a `user` message (clipboard paste / file
+    /// attach). Each is base64-encoded bytes plus a MIME type; providers
+    /// that support vision turn these into their native image content
+    /// blocks (Anthropic `image`, OpenAI `image_url`, Codex
+    /// `input_image`). Persisted in the session JSONL so reopening a chat
+    /// keeps the model's visual context. Empty (the common case) is
+    /// skipped on the wire.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub images: Vec<ImageAttachment>,
+}
+
+/// A single image attached to a user message. `data` is standard base64
+/// **without** the `data:<mime>;base64,` prefix — providers reconstruct a
+/// data URI (OpenAI / Codex) or pass `mime` + `data` separately
+/// (Anthropic) as their wire requires.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageAttachment {
+    /// MIME type, e.g. `"image/png"`, `"image/jpeg"`, `"image/webp"`.
+    pub mime: String,
+    /// Base64-encoded image bytes, no data-URL prefix.
+    pub data: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -59,6 +59,10 @@ serde_yaml.workspace = true
 portable-pty = "0.9"
 directories.workspace = true
 base64 = "0.22"
+# Re-encode raw RGBA bitmaps read off the system clipboard into PNG for chat
+# image attachments (WebKitGTK doesn't surface clipboard images on the DOM
+# paste event). Already in the tree via tauri's image stack.
+png = "0.17"
 getrandom = "0.4"
 futures.workspace = true
 kube.workspace = true

--- a/crates/app/src/agent.rs
+++ b/crates/app/src/agent.rs
@@ -21,7 +21,7 @@ use ferrisscope_agent::session::{
     ApprovalDecision, SessionData, SessionError, SessionEvent, SessionMeta, SessionStore,
     SessionUpdate,
 };
-use ferrisscope_agent::types::{ChatMessage, MessageRole, ToolSchema};
+use ferrisscope_agent::types::{ChatMessage, ImageAttachment, MessageRole, ToolSchema};
 use ferrisscope_agent::{
     classify_tool, AgentSettings, ApprovalMode, ChatProvider, CompletionEvent, CompletionRequest,
     Credential, FinishReason, ModelInfo, NativeRegistry, ProviderConfig, ProviderError,
@@ -2046,6 +2046,10 @@ pub(crate) async fn chat_send_message(
     chat_id: String,
     content: String,
     view_context: Option<ViewContextWire>,
+    // Image attachments (clipboard paste / file attach). `mime` + base64
+    // `data`, no data-URL prefix. Persisted on the user message and turned
+    // into provider-native image blocks for vision-capable models.
+    images: Option<Vec<ImageAttachment>>,
     state: State<'_, AgentState>,
     app_state: State<'_, AppState>,
 ) -> Result<(), String> {
@@ -2097,6 +2101,7 @@ pub(crate) async fn chat_send_message(
         tool_call_id: None,
         name: None,
         reasoning_content: None,
+        images: images.unwrap_or_default(),
     };
     let (cluster_id, session_id, queue_only, title_snapshot) = {
         let mut rt = runtime.lock().await;
@@ -2704,6 +2709,7 @@ async fn autocontinue_if_idle(
         tool_call_id: None,
         name: Some(AUTO_CONTINUE_NAME.to_string()),
         reasoning_content: None,
+        images: vec![],
     };
     let should_spawn = {
         let mut g = runtime.lock().await;
@@ -3177,6 +3183,7 @@ async fn run_turn_loop(
             tool_call_id: None,
             name: None,
             reasoning_content: None,
+            images: vec![],
         });
         full_messages.extend(messages_so_far);
 
@@ -3219,6 +3226,7 @@ async fn run_turn_loop(
                         tool_call_id: None,
                         name: None,
                         reasoning_content: None,
+                        images: vec![],
                     };
                     let now = chrono::Utc::now().timestamp_millis();
                     let _ = store
@@ -3284,6 +3292,7 @@ async fn run_turn_loop(
                         tool_call_id: None,
                         name: None,
                         reasoning_content: None,
+                        images: vec![],
                     };
                     let now = chrono::Utc::now().timestamp_millis();
                     let _ = store
@@ -3356,6 +3365,7 @@ async fn run_turn_loop(
                         tool_call_id: None,
                         name: None,
                         reasoning_content: None,
+                        images: vec![],
                     };
                     let now = chrono::Utc::now().timestamp_millis();
                     let _ = store
@@ -3513,6 +3523,7 @@ async fn run_turn_loop(
                 tool_call_id: Some(tc.id.clone()),
                 name: Some(tc.name.clone()),
                 reasoning_content: None,
+                images: vec![],
             })
             .collect();
         {
@@ -3622,6 +3633,7 @@ fn merge_trailing_user_run(mut messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
         tool_call_id: None,
         name: None,
         reasoning_content: None,
+        images: vec![],
     });
     messages
 }
@@ -4001,6 +4013,7 @@ async fn run_provider_round(
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                images: vec![],
             };
             let now = chrono::Utc::now().timestamp_millis();
             let _ = store
@@ -4053,6 +4066,7 @@ async fn run_provider_round(
         tool_call_id: None,
         name: None,
         reasoning_content,
+        images: vec![],
     };
     runtime.lock().await.in_flight_message_id = None;
     let now = chrono::Utc::now().timestamp_millis();
@@ -4541,6 +4555,7 @@ fn build_title_request(snapshot: &TitleSnapshot, model: String) -> CompletionReq
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                images: vec![],
             },
             ChatMessage {
                 role: MessageRole::User,
@@ -4549,6 +4564,7 @@ fn build_title_request(snapshot: &TitleSnapshot, model: String) -> CompletionReq
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                images: vec![],
             },
         ],
         tools: vec![],
@@ -4795,6 +4811,7 @@ async fn repair_orphan_tool_calls(
                     tool_call_id: Some(tc.id.clone()),
                     name: Some(tc.name.clone()),
                     reasoning_content: None,
+                    images: vec![],
                 };
                 g.messages.insert(insert_at, msg.clone());
                 synthetic.push(msg);
@@ -4936,6 +4953,7 @@ async fn run_compaction_internal(
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                images: vec![],
             },
             ChatMessage {
                 role: MessageRole::User,
@@ -4944,6 +4962,7 @@ async fn run_compaction_internal(
                 tool_call_id: None,
                 name: None,
                 reasoning_content: None,
+                images: vec![],
             },
         ],
         tools: vec![],
@@ -5019,6 +5038,7 @@ async fn run_compaction_internal(
             tool_call_id: None,
             name: Some("context_checkpoint".to_string()),
             reasoning_content: None,
+            images: vec![],
         });
         g.messages.extend(tail);
         g.last_total_tokens = 0;

--- a/crates/app/src/clipboard_image.rs
+++ b/crates/app/src/clipboard_image.rs
@@ -1,0 +1,113 @@
+//! Reading images off the system clipboard for chat attachments.
+//!
+//! WebKitGTK (the Linux webview) doesn't expose a pasted image as a `File`
+//! on the DOM `paste` event's `clipboardData.items`, so the frontend's
+//! standard paste path comes up empty for images even when the clipboard
+//! clearly holds one. This command bridges to the *native* clipboard via the
+//! clipboard-manager plugin (arboard) — the same path the app already uses
+//! for text copy/paste on webkit2gtk — and hands back the image as a
+//! base64-encoded PNG, ready to attach as an `ImageAttachment`.
+
+use base64::Engine;
+use serde::Serialize;
+use tauri_plugin_clipboard_manager::ClipboardExt;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ClipboardImageWire {
+    /// Always `"image/png"` — we re-encode the clipboard's raw RGBA bitmap.
+    pub mime: String,
+    /// Base64 PNG bytes, no data-URL prefix (matches `ImageAttachment`).
+    pub data: String,
+}
+
+/// Encode a raw RGBA8 bitmap as PNG bytes. Pure + total: validates the buffer
+/// length against the dimensions so a malformed clipboard payload surfaces as
+/// an error rather than a panic inside the encoder.
+fn encode_rgba_to_png(rgba: &[u8], width: u32, height: u32) -> Result<Vec<u8>, String> {
+    if width == 0 || height == 0 {
+        return Err("empty clipboard image".into());
+    }
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .and_then(|p| p.checked_mul(4))
+        .ok_or("image dimensions overflow")?;
+    if rgba.len() != expected {
+        return Err(format!(
+            "rgba buffer is {} bytes, expected {expected} for {width}x{height}",
+            rgba.len()
+        ));
+    }
+    let mut out = Vec::new();
+    {
+        let mut enc = png::Encoder::new(&mut out, width, height);
+        enc.set_color(png::ColorType::Rgba);
+        enc.set_depth(png::BitDepth::Eight);
+        let mut writer = enc.write_header().map_err(|e| e.to_string())?;
+        writer.write_image_data(rgba).map_err(|e| e.to_string())?;
+    }
+    Ok(out)
+}
+
+/// Read an image from the system clipboard, re-encode it as PNG, and return
+/// it base64-encoded. `Ok(None)` when the clipboard holds no image (the
+/// common case — text, files, or empty) so the frontend can no-op quietly.
+#[tauri::command]
+pub(crate) async fn read_clipboard_image(
+    app: tauri::AppHandle,
+) -> Result<Option<ClipboardImageWire>, String> {
+    // arboard's clipboard read is blocking and, per the plugin's own warning,
+    // must not run on the main thread — `spawn_blocking` keeps it off both the
+    // UI thread and the async runtime's reactor.
+    let png = tokio::task::spawn_blocking(move || {
+        // `read_image` errors when there's no image on the clipboard; treat
+        // that as "nothing to attach" rather than a hard failure.
+        let Ok(image) = app.clipboard().read_image() else {
+            return Ok::<Option<Vec<u8>>, String>(None);
+        };
+        let png = encode_rgba_to_png(image.rgba(), image.width(), image.height())?;
+        Ok(Some(png))
+    })
+    .await
+    .map_err(|e| format!("clipboard task join error: {e}"))??;
+
+    Ok(png.map(|bytes| ClipboardImageWire {
+        mime: "image/png".to_string(),
+        data: base64::engine::general_purpose::STANDARD.encode(bytes),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_rgba_to_png_roundtrips_dimensions_and_pixels() {
+        // 2x1 RGBA: opaque red, opaque green.
+        let rgba = vec![255, 0, 0, 255, 0, 255, 0, 255];
+        let bytes = encode_rgba_to_png(&rgba, 2, 1).expect("encode");
+        // PNG magic header.
+        assert_eq!(
+            &bytes[..8],
+            &[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a]
+        );
+        // Decodes back to the same dimensions + pixels.
+        let decoder = png::Decoder::new(std::io::Cursor::new(&bytes));
+        let mut reader = decoder.read_info().expect("read_info");
+        let mut buf = vec![0; reader.output_buffer_size()];
+        let info = reader.next_frame(&mut buf).expect("frame");
+        assert_eq!((info.width, info.height), (2, 1));
+        assert_eq!(&buf[..info.buffer_size()], &rgba[..]);
+    }
+
+    #[test]
+    fn encode_rgba_to_png_rejects_size_mismatch() {
+        // Claims 4x4 (256 bytes) but only 8 provided.
+        let err = encode_rgba_to_png(&[0; 8], 4, 4).unwrap_err();
+        assert!(err.contains("expected"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn encode_rgba_to_png_rejects_empty_dims() {
+        assert!(encode_rgba_to_png(&[], 0, 0).is_err());
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -5,6 +5,7 @@ mod agent_keyring;
 mod agent_mcp;
 mod agent_native;
 mod agent_oauth;
+mod clipboard_image;
 mod commands;
 mod helm_install;
 mod kubectl_install;
@@ -104,6 +105,7 @@ fn main() {
         .manage(agent::AgentState::default())
         .invoke_handler(tauri::generate_handler![
             commands::ping,
+            clipboard_image::read_clipboard_image,
             commands::dev_memory_stats,
             commands::dev_compact_memory,
             commands::updater_info,

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -734,6 +734,24 @@ describe("AI agent + chat", () => {
     });
   });
 
+  it("chatSendMessage forwards image attachments when provided", async () => {
+    const cap = captureNext(undefined);
+    await api.chatSendMessage("c-1", "what is this?", undefined, [
+      { mime: "image/png", data: "AAAA" },
+      { mime: "image/jpeg", data: "Zm9v" },
+    ]);
+    expect(cap.calls[0]?.cmd).toBe("chat_send_message");
+    expect(cap.calls[0]?.args).toEqual({
+      chatId: "c-1",
+      content: "what is this?",
+      viewContext: undefined,
+      images: [
+        { mime: "image/png", data: "AAAA" },
+        { mime: "image/jpeg", data: "Zm9v" },
+      ],
+    });
+  });
+
   it("chatSendMessage forwards the view-context snapshot when provided", async () => {
     const cap = captureNext(undefined);
     await api.chatSendMessage("c-1", "fix this", {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -13,6 +13,7 @@ import type {
   ApprovalMode,
   ChatInitialMcp,
   ChatOpenResult,
+  ChatImageAttachment,
   ChatTool,
   ChatViewContext,
   KubectlDetection,
@@ -964,8 +965,15 @@ export const api = {
     chatId: string,
     content: string,
     viewContext?: ChatViewContext,
+    images?: ChatImageAttachment[],
   ) =>
-    invoke<void>("chat_send_message", { chatId, content, viewContext }),
+    invoke<void>("chat_send_message", { chatId, content, viewContext, images }),
+  // Read an image off the system clipboard as base64 PNG. The WebKitGTK
+  // webview doesn't surface clipboard images on the DOM paste event, so the
+  // composer falls back to this. Resolves `null` when the clipboard has no
+  // image (text, files, empty).
+  readClipboardImage: () =>
+    invoke<ChatImageAttachment | null>("read_clipboard_image"),
   chatCancelStreaming: (chatId: string) =>
     invoke<void>("chat_cancel_streaming", { chatId }),
   chatSetApprovalMode: (chatId: string, mode: ApprovalMode) =>

--- a/ui/src/components/chat/ChatInput.test.tsx
+++ b/ui/src/components/chat/ChatInput.test.tsx
@@ -1,0 +1,169 @@
+// ChatInput clipboard-image flow: pasting an image surfaces a thumbnail,
+// Send forwards it as a base64 {mime, data} attachment alongside the text,
+// and the remove badge drops it before send. Text-only paste is left to the
+// browser's default (we don't intercept it).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ChatInput } from "./ChatInput";
+import { setMockInvoke, resetMockInvoke } from "../../test/tauri-mock";
+import type { ChatImageAttachment } from "../../types";
+
+beforeEach(() => {
+  resetMockInvoke();
+  // Default: the native clipboard has no image. Tests that exercise the
+  // WebKitGTK fallback override this.
+  setMockInvoke((cmd) => (cmd === "read_clipboard_image" ? null : undefined));
+});
+
+function renderInput(
+  overrides: Partial<React.ComponentProps<typeof ChatInput>> = {},
+) {
+  const onSend = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <ChatInput
+      mode="dark"
+      disabled={false}
+      streaming={false}
+      approvalMode="approve_per_write"
+      onApprovalModeChange={() => {}}
+      {...overrides}
+      onSend={onSend}
+      onCancel={onCancel}
+    />,
+  );
+  return { onSend, onCancel };
+}
+
+// "hi" → base64 "aGk=", which is what jsdom's FileReader.readAsDataURL emits.
+function pngFile(name = "shot.png") {
+  return new File(["hi"], name, { type: "image/png" });
+}
+
+function pasteImage(file: File) {
+  const textarea = screen.getByRole("textbox");
+  fireEvent.paste(textarea, {
+    clipboardData: {
+      items: [{ kind: "file", type: file.type, getAsFile: () => file }],
+    },
+  });
+}
+
+describe("ChatInput — clipboard image attachments", () => {
+  it("pastes an image, shows a thumbnail, and sends it with the text", async () => {
+    const { onSend } = renderInput();
+    pasteImage(pngFile());
+
+    // Thumbnail appears once the FileReader resolves.
+    const thumb = await screen.findByAltText("shot.png");
+    expect(thumb.getAttribute("src")).toBe("data:image/png;base64,aGk=");
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "what is this?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [text, images] = onSend.mock.calls[0] as [
+      string,
+      ChatImageAttachment[],
+    ];
+    expect(text).toBe("what is this?");
+    expect(images).toEqual([{ mime: "image/png", data: "aGk=" }]);
+  });
+
+  it("allows sending an image with no text", async () => {
+    const { onSend } = renderInput();
+    pasteImage(pngFile());
+    await screen.findByAltText("shot.png");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [text, images] = onSend.mock.calls[0] as [
+      string,
+      ChatImageAttachment[],
+    ];
+    expect(text).toBe("");
+    expect(images).toHaveLength(1);
+  });
+
+  it("removes a pasted image before sending", async () => {
+    const { onSend } = renderInput();
+    pasteImage(pngFile());
+    await screen.findByAltText("shot.png");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove shot.png" }));
+    await waitFor(() =>
+      expect(screen.queryByAltText("shot.png")).toBeNull(),
+    );
+
+    // With no text and no images, Send is disabled — nothing to send.
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("ignores a text paste (no thumbnail, no native read)", () => {
+    const readImage = vi.fn(() => null);
+    setMockInvoke((cmd) =>
+      cmd === "read_clipboard_image" ? readImage() : undefined,
+    );
+    const { onSend } = renderInput();
+    fireEvent.paste(screen.getByRole("textbox"), {
+      clipboardData: {
+        items: [{ kind: "string", type: "text/plain", getAsFile: () => null }],
+        getData: (t: string) => (t === "text/plain" ? "kubectl get pods" : ""),
+      },
+    });
+    // Text present → default textarea paste, never the native image fallback.
+    expect(readImage).not.toHaveBeenCalled();
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("shows a Stop button while streaming and cancels on click", () => {
+    const { onCancel } = renderInput({ streaming: true });
+    // Nothing typed → no send/queue button, just Stop.
+    expect(screen.queryByRole("button", { name: "Send" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Stop the agent" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("queues a typed message while streaming", () => {
+    const { onSend } = renderInput({ streaming: true });
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "and also scale it" },
+    });
+    // Mid-stream the action button queues rather than sends.
+    fireEvent.click(
+      screen.getByRole("button", { name: "Queue for the next round" }),
+    );
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect((onSend.mock.calls[0] as [string])[0]).toBe("and also scale it");
+  });
+
+  it("disables Send when the composer is empty", () => {
+    renderInput();
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+  });
+
+  it("reads from the native clipboard when the webview hides the image (WebKitGTK)", async () => {
+    setMockInvoke((cmd) =>
+      cmd === "read_clipboard_image"
+        ? ({ mime: "image/png", data: "aGk=" } satisfies ChatImageAttachment)
+        : undefined,
+    );
+    const { onSend } = renderInput();
+    // The WebKitGTK shape: no image File on the event, and no text either.
+    fireEvent.paste(screen.getByRole("textbox"), {
+      clipboardData: { items: [], getData: () => "" },
+    });
+
+    const thumb = await screen.findByAltText("pasted image");
+    expect(thumb.getAttribute("src")).toBe("data:image/png;base64,aGk=");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    const [, images] = onSend.mock.calls[0] as [string, ChatImageAttachment[]];
+    expect(images).toEqual([{ mime: "image/png", data: "aGk=" }]);
+  });
+});

--- a/ui/src/components/chat/ChatInput.tsx
+++ b/ui/src/components/chat/ChatInput.tsx
@@ -1,8 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 import { useResolvedTheme } from "../../store";
-import { tokens, FONT_SANS, FF_MONO, type ThemeMode, R_MD, FS_MD, FS_XS } from "../../theme";
-import { Btn, Toggle } from "../ui";
-import type { ApprovalMode } from "../../types";
+import {
+  tokens,
+  FONT_SANS,
+  FF_MONO,
+  type ThemeMode,
+  R_SM,
+  R_MD,
+  R_LG,
+  FS_MD,
+  FS_XS,
+} from "../../theme";
+import { IconBtn, Icons, Toggle } from "../ui";
+import { api } from "../../api";
+import type { ApprovalMode, ChatImageAttachment } from "../../types";
 
 type Props = {
   mode: ThemeMode;
@@ -10,7 +21,7 @@ type Props = {
   streaming: boolean;
   approvalMode: ApprovalMode;
   onApprovalModeChange: (mode: ApprovalMode) => void;
-  onSend: (text: string) => void;
+  onSend: (text: string, images: ChatImageAttachment[]) => void;
   onCancel: () => void;
   /// Manual compaction trigger. Kicks off the same summarisation
   /// pipeline auto-compaction uses; folds older history into a
@@ -38,10 +49,62 @@ type Props = {
   usableContext?: number;
 };
 
-const MIN_HEIGHT = 84; // ~3 rows. Tall enough that the input reads as a
-// multiline composer at rest, not a one-line prompt — operators routinely
-// paste YAML / kubectl output / multi-step questions.
-const MAX_HEIGHT = 360;
+const MIN_HEIGHT = 56; // ~2 rows. The composer card + bottom toolbar give it
+// presence at rest; it auto-grows up to MAX_HEIGHT as the operator types or
+// pastes YAML / kubectl output.
+const MAX_HEIGHT = 320;
+
+// Attachment caps. Images round-trip as base64 on every subsequent turn, so
+// keep both the per-image size and the count bounded — a stray 30 MB
+// screenshot would balloon the context and the IPC payload. These are
+// generous for the screenshot/diagram use case; the apiserver enforces its
+// own hard limits beyond this.
+const MAX_ATTACHMENTS = 8;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+// In-composer attachment: keeps both the raw base64 (`data`, what we send)
+// and the full data URI (`dataUrl`, what the <img> preview renders) so we
+// don't reconstruct the prefix twice.
+type Attachment = {
+  id: string;
+  mime: string;
+  data: string;
+  dataUrl: string;
+  name: string;
+};
+
+// Read a clipboard / picked File into an Attachment. Resolves `null` on read
+// error or a non-data-URL result rather than throwing — the caller filters
+// nulls so one bad paste can't wedge the whole batch.
+function readImageAttachment(file: File): Promise<Attachment | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onerror = () => resolve(null);
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : "";
+      const comma = result.indexOf(",");
+      if (comma === -1) {
+        resolve(null);
+        return;
+      }
+      const header = result.slice(0, comma); // e.g. "data:image/png;base64"
+      const data = result.slice(comma + 1);
+      if (!data) {
+        resolve(null);
+        return;
+      }
+      const mime = /^data:([^;]+)/.exec(header)?.[1] || file.type || "image/png";
+      resolve({
+        id: `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        mime,
+        data,
+        dataUrl: result,
+        name: file.name || "pasted image",
+      });
+    };
+    reader.readAsDataURL(file);
+  });
+}
 
 // ChatInput — multiline composer. Enter sends; Shift+Enter inserts a
 // newline. Matches Slack / Discord / ChatGPT muscle memory — most
@@ -64,7 +127,11 @@ export function ChatInput({
 }: Props) {
   const t = useResolvedTheme().tokens;
   const [value, setValue] = useState("");
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [attachError, setAttachError] = useState<string | null>(null);
+  const [focused, setFocused] = useState(false);
   const ref = useRef<HTMLTextAreaElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const allowAllWrites = approvalMode === "allow_all_writes";
 
   useEffect(() => {
@@ -75,13 +142,120 @@ export function ChatInput({
     el.style.height = `${next}px`;
   }, [value]);
 
+  // Accept image files from paste / drop / picker. Non-images are ignored;
+  // over-size and over-count attempts surface an inline note rather than
+  // silently dropping. `accepted.length` is folded into the count check so a
+  // multi-image paste respects the cap within a single batch.
+  const addFiles = async (files: File[]) => {
+    const images = files.filter((f) => f.type.startsWith("image/"));
+    if (images.length === 0) return;
+    setAttachError(null);
+    const accepted: Attachment[] = [];
+    for (const f of images) {
+      if (attachments.length + accepted.length >= MAX_ATTACHMENTS) {
+        setAttachError(`At most ${MAX_ATTACHMENTS} images per message.`);
+        break;
+      }
+      if (f.size > MAX_IMAGE_BYTES) {
+        setAttachError(
+          `“${f.name || "image"}” is too large (max ${Math.round(
+            MAX_IMAGE_BYTES / (1024 * 1024),
+          )} MB).`,
+        );
+        continue;
+      }
+      const att = await readImageAttachment(f);
+      if (att) accepted.push(att);
+    }
+    if (accepted.length > 0) {
+      setAttachments((prev) => [...prev, ...accepted]);
+    }
+  };
+
+  // Add an image the webview only exposes on the native clipboard (the
+  // WebKitGTK case — see `onPaste`). Reconstructs the data URI for preview;
+  // size is bounded from the base64 length since there's no File here.
+  const addNativeClipboardImage = async () => {
+    let img: ChatImageAttachment | null;
+    try {
+      img = await api.readClipboardImage();
+    } catch {
+      return; // No native image / read failed — nothing to attach.
+    }
+    if (!img) return;
+    if (attachments.length >= MAX_ATTACHMENTS) {
+      setAttachError(`At most ${MAX_ATTACHMENTS} images per message.`);
+      return;
+    }
+    // base64 decodes to ~3/4 its length in bytes.
+    if (img.data.length * 0.75 > MAX_IMAGE_BYTES) {
+      setAttachError(
+        `Pasted image is too large (max ${Math.round(
+          MAX_IMAGE_BYTES / (1024 * 1024),
+        )} MB).`,
+      );
+      return;
+    }
+    setAttachError(null);
+    setAttachments((prev) => [
+      ...prev,
+      {
+        id: `att-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        mime: img.mime,
+        data: img.data,
+        dataUrl: `data:${img.mime};base64,${img.data}`,
+        name: "pasted image",
+      },
+    ]);
+  };
+
+  const onPaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const cd = e.clipboardData;
+    if (!cd) return;
+    const files: File[] = [];
+    for (let i = 0; i < cd.items.length; i++) {
+      const it = cd.items[i];
+      if (it && it.kind === "file" && it.type.startsWith("image/")) {
+        const f = it.getAsFile();
+        if (f) files.push(f);
+      }
+    }
+    // Standard path: the clipboard exposed image File(s) on the event.
+    if (files.length > 0) {
+      e.preventDefault();
+      void addFiles(files);
+      return;
+    }
+    // WebKitGTK path: the webview doesn't surface clipboard images as Files.
+    // If there's also no plain text to paste, the clipboard most likely holds
+    // an image — read it natively. (When text IS present we leave the default
+    // textarea paste alone so YAML / kubectl output still works.)
+    const text =
+      typeof cd.getData === "function" ? cd.getData("text/plain") : "";
+    if (!text) {
+      void addNativeClipboardImage();
+    }
+  };
+
+  const removeAttachment = (id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  };
+
   const submit = () => {
     if (disabled) return;
     const text = value;
-    if (!text.trim()) return;
+    const images: ChatImageAttachment[] = attachments.map((a) => ({
+      mime: a.mime,
+      data: a.data,
+    }));
+    if (!text.trim() && images.length === 0) return;
     setValue("");
-    onSend(text);
+    setAttachments([]);
+    setAttachError(null);
+    onSend(text, images);
   };
+
+  const canSend = !disabled && (!!value.trim() || attachments.length > 0);
 
   return (
     <div
@@ -95,16 +269,65 @@ export function ChatInput({
         gap: 6,
       }}
     >
-      <div style={{ display: "flex", alignItems: "flex-end", gap: 8 }}>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const files = e.target.files ? Array.from(e.target.files) : [];
+          // Reset so picking the same file twice in a row still fires change.
+          e.target.value = "";
+          if (files.length > 0) void addFiles(files);
+        }}
+      />
+      {attachError && (
+        <div style={{ color: t.warn, fontSize: FS_XS, fontFamily: FF_MONO }}>
+          {attachError}
+        </div>
+      )}
+
+      {/* Composer card: textarea + bottom toolbar in one rounded surface, with
+          a focus ring. Attach sits bottom-left, send/stop bottom-right — no
+          dead space beside a tall textarea. */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+          background: t.surface,
+          border: `1px solid ${focused ? t.accent : t.borderSoft}`,
+          borderRadius: R_LG,
+          padding: 8,
+          boxShadow: focused ? `0 0 0 3px ${t.accentSoft}` : "none",
+          transition: "border-color 120ms ease, box-shadow 120ms ease",
+        }}
+      >
+        {attachments.length > 0 && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {attachments.map((a) => (
+              <Thumbnail
+                key={a.id}
+                t={t}
+                att={a}
+                onRemove={() => removeAttachment(a.id)}
+              />
+            ))}
+          </div>
+        )}
+
         <textarea
           ref={ref}
           value={value}
           onChange={(e) => setValue(e.target.value)}
+          onPaste={onPaste}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
           onKeyDown={(e) => {
-            // Enter sends. Shift+Enter inserts a newline. IME
-            // composition (CJK, accents) routes Enter through the
-            // composer — `isComposing` / keyCode 229 lets that
-            // through so we don't fire mid-composition.
+            // Enter sends. Shift+Enter inserts a newline. IME composition
+            // (CJK, accents) routes Enter through the composer — `isComposing`
+            // / keyCode 229 lets that through so we don't fire mid-composition.
             if (
               e.key === "Enter" &&
               !e.shiftKey &&
@@ -119,49 +342,64 @@ export function ChatInput({
             disabled
               ? "chat unavailable…"
               : streaming
-                ? "agent is responding — your message will be queued for its next round (Enter to send)"
-                : "Ask about this cluster — Enter to send, Shift+Enter for newline"
+                ? "agent is responding — Enter to queue for its next round"
+                : "Ask about this cluster…"
           }
           disabled={disabled}
-          rows={3}
+          rows={2}
           style={{
-            flex: 1,
+            width: "100%",
             minHeight: MIN_HEIGHT,
             maxHeight: MAX_HEIGHT,
-            resize: "vertical",
+            resize: "none",
             fontFamily: FONT_SANS,
             fontSize: FS_MD,
             color: t.text,
-            background: t.surface,
-            border: `1px solid ${t.borderSoft}`,
-            borderRadius: R_MD,
-            padding: "8px 10px",
+            background: "transparent",
+            border: "none",
+            padding: "2px 4px",
             outline: "none",
             lineHeight: 1.5,
           }}
         />
-        <div style={{ display: "flex", gap: 6 }}>
-          {streaming && (
-            <Btn t={t} variant="secondary" size="sm" onClick={onCancel}>
-              Stop
-            </Btn>
-          )}
-          <Btn
+
+        {/* Bottom toolbar: attach (left) · send / stop (right). */}
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <IconBtn
             t={t}
-            variant="primary"
             size="sm"
-            onClick={submit}
-            disabled={disabled || !value.trim()}
-            title={
-              streaming
-                ? "Queue this message for the agent's next round"
-                : undefined
-            }
+            onClick={() => fileInputRef.current?.click()}
+            disabled={disabled || attachments.length >= MAX_ATTACHMENTS}
+            title="Attach image (or paste from clipboard)"
           >
-            {streaming ? "Queue" : "Send"}
-          </Btn>
+            {Icons.plus}
+          </IconBtn>
+          <span style={{ flex: 1 }} />
+          {streaming && (
+            <RoundAction
+              t={t}
+              variant="neutral"
+              onClick={onCancel}
+              title="Stop the agent"
+            >
+              {Icons.stop}
+            </RoundAction>
+          )}
+          {(!streaming || canSend) && (
+            <RoundAction
+              t={t}
+              variant="accent"
+              onClick={submit}
+              disabled={!canSend}
+              title={streaming ? "Queue for the next round" : "Send"}
+            >
+              {Icons.send}
+            </RoundAction>
+          )}
         </div>
       </div>
+
+      {/* Meta row: secondary controls + token usage, muted under the card. */}
       <div
         style={{
           display: "flex",
@@ -218,10 +456,68 @@ export function ChatInput({
               usableContext={usableContext}
             />
           ) : null}
-          Enter to send · Shift+Enter for newline
         </span>
       </div>
     </div>
+  );
+}
+
+// RoundAction — circular icon button for the composer's primary actions.
+// `accent` is the send/queue button (filled, lights up on hover, dims when
+// there's nothing to send); `neutral` is the stop button shown mid-stream.
+function RoundAction({
+  t,
+  variant,
+  onClick,
+  disabled,
+  title,
+  children,
+}: {
+  t: ReturnType<typeof tokens>;
+  variant: "accent" | "neutral";
+  onClick: () => void;
+  disabled?: boolean;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  const [hover, setHover] = useState(false);
+  const accent = variant === "accent";
+  const bg = disabled
+    ? t.surfaceAlt
+    : accent
+      ? hover
+        ? t.accentHover
+        : t.accent
+      : hover
+        ? t.btnHover
+        : t.surface;
+  const fg = disabled ? t.textMuted : accent ? "#ffffff" : t.text;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      aria-label={title}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      style={{
+        width: 30,
+        height: 30,
+        flexShrink: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        borderRadius: "50%",
+        border: `1px solid ${accent ? "transparent" : t.border}`,
+        background: bg,
+        color: fg,
+        cursor: disabled ? "not-allowed" : "pointer",
+        transition: "background 120ms ease, color 120ms ease",
+      }}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -229,6 +525,64 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
+}
+
+// Thumbnail — a single pending attachment in the composer strip. 48px square
+// preview with a hover-revealed remove badge in the top-right corner.
+function Thumbnail({
+  t,
+  att,
+  onRemove,
+}: {
+  t: ReturnType<typeof tokens>;
+  att: Attachment;
+  onRemove: () => void;
+}) {
+  return (
+    <div
+      style={{
+        position: "relative",
+        width: 48,
+        height: 48,
+        borderRadius: R_SM,
+        overflow: "hidden",
+        border: `1px solid ${t.border}`,
+        background: t.surface,
+      }}
+      title={att.name}
+    >
+      <img
+        src={att.dataUrl}
+        alt={att.name}
+        style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+      />
+      <button
+        type="button"
+        aria-label={`Remove ${att.name}`}
+        onClick={onRemove}
+        style={{
+          position: "absolute",
+          top: 1,
+          right: 1,
+          width: 16,
+          height: 16,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          padding: 0,
+          borderRadius: R_SM,
+          border: "none",
+          cursor: "pointer",
+          color: "#fff",
+          background: "rgba(15,20,30,0.65)",
+          lineHeight: 1,
+          fontSize: 12,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
 }
 
 // Compaction trigger fraction must mirror agent.rs::COMPACTION_TRIGGER_FRACTION.
@@ -283,7 +637,7 @@ function UsageChip({
       {formatTokens(total)}
       {contextLimit > 0 ? ` / ${formatTokens(contextLimit)}` : ""}
       {pct !== null ? ` · ${pct}%` : ""}
-      {" tok · "}
+      {" tok"}
     </span>
   );
 }

--- a/ui/src/components/chat/DockChat.tsx
+++ b/ui/src/components/chat/DockChat.tsx
@@ -7,6 +7,7 @@ import type {
   AgentChatMessage,
   AiSettingsWire,
   ChatEvent,
+  ChatImageAttachment,
   ChatTool,
   ModelInfo,
   ProviderKind,
@@ -508,9 +509,9 @@ export function DockChat({ mode, tab, visible }: Props) {
     setModels(null);
   }, [activeSessionId]);
 
-  const onSend = async (text: string) => {
+  const onSend = async (text: string, images: ChatImageAttachment[] = []) => {
     if (!activeChatId || !activeSessionId) return;
-    if (!text.trim()) return;
+    if (!text.trim() && images.length === 0) return;
     const sid = activeSessionId;
     // Optimistic append so the user's bubble appears immediately,
     // before the backend's first AssistantStart fires. The backend
@@ -531,6 +532,7 @@ export function DockChat({ mode, tab, visible }: Props) {
                 id: `local-${Date.now()}`,
                 role: "user",
                 content: text,
+                images: images.length > 0 ? images : undefined,
               } satisfies ChatViewMessage,
             ],
           },
@@ -538,7 +540,12 @@ export function DockChat({ mode, tab, visible }: Props) {
       };
     });
     try {
-      await api.chatSendMessage(activeChatId, text, snapshotViewContext());
+      await api.chatSendMessage(
+        activeChatId,
+        text,
+        snapshotViewContext(),
+        images.length > 0 ? images : undefined,
+      );
     } catch (e) {
       setStatus({ kind: "error", message: String(e) });
     }

--- a/ui/src/components/chat/MessageBubble.test.tsx
+++ b/ui/src/components/chat/MessageBubble.test.tsx
@@ -1,0 +1,50 @@
+// User bubbles render attached images as thumbnails, reconstructing the data
+// URI from the wire {mime, data} pair. Image-only messages (no text) still
+// render the grid.
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { MessageBubble } from "./MessageBubble";
+import type { ChatViewMessage } from "./chatStreaming";
+
+describe("MessageBubble — image attachments", () => {
+  it("renders attached images as data-URI thumbnails", () => {
+    const message: ChatViewMessage = {
+      id: "m1",
+      role: "user",
+      content: "what is this?",
+      images: [
+        { mime: "image/png", data: "AAAA" },
+        { mime: "image/jpeg", data: "Zm9v" },
+      ],
+    };
+    const { container } = render(<MessageBubble mode="dark" message={message} />);
+    const imgs = container.querySelectorAll("img");
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0]!.getAttribute("src")).toBe("data:image/png;base64,AAAA");
+    expect(imgs[1]!.getAttribute("src")).toBe("data:image/jpeg;base64,Zm9v");
+  });
+
+  it("renders an image-only user message (no text)", () => {
+    const message: ChatViewMessage = {
+      id: "m2",
+      role: "user",
+      content: "",
+      images: [{ mime: "image/webp", data: "YmFy" }],
+    };
+    const { container } = render(<MessageBubble mode="dark" message={message} />);
+    const imgs = container.querySelectorAll("img");
+    expect(imgs).toHaveLength(1);
+    expect(imgs[0]!.getAttribute("src")).toBe("data:image/webp;base64,YmFy");
+  });
+
+  it("renders no images for a plain user message", () => {
+    const message: ChatViewMessage = {
+      id: "m3",
+      role: "user",
+      content: "hello",
+    };
+    const { container } = render(<MessageBubble mode="dark" message={message} />);
+    expect(container.querySelectorAll("img")).toHaveLength(0);
+  });
+});

--- a/ui/src/components/chat/MessageBubble.tsx
+++ b/ui/src/components/chat/MessageBubble.tsx
@@ -1,6 +1,15 @@
 import { memo, useMemo } from "react";
 import { useResolvedTheme } from "../../store";
-import { tokens, FF_MONO, type ThemeMode, R_LG, FS_MD, FS_SM, FS_XS } from "../../theme";
+import {
+  tokens,
+  FF_MONO,
+  type ThemeMode,
+  R_MD,
+  R_LG,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+} from "../../theme";
 import type { ChatViewMessage } from "./chatStreaming";
 import { Markdown } from "./markdown";
 import { safePrefixLength } from "./safePrefix";
@@ -137,7 +146,7 @@ function MessageBubbleInner({ message }: Props) {
           <ThinkingIndicator t={t} />
         ) : (
           <>
-            <Markdown text={renderText} t={t} />
+            {hasContent && <Markdown text={renderText} t={t} />}
             {message.streaming && (
               <span
                 style={{
@@ -153,7 +162,49 @@ function MessageBubbleInner({ message }: Props) {
             )}
           </>
         )}
+        {message.images && message.images.length > 0 && (
+          <ImageGrid t={t} images={message.images} withGap={hasContent} />
+        )}
       </div>
+    </div>
+  );
+}
+
+// ImageGrid — attached-image previews inside a user bubble. Each renders a
+// capped-size thumbnail reconstructed from the wire `{mime, data}` pair.
+// `withGap` adds top margin only when there's text above it.
+function ImageGrid({
+  t,
+  images,
+  withGap,
+}: {
+  t: ReturnType<typeof tokens>;
+  images: NonNullable<ChatViewMessage["images"]>;
+  withGap: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: 6,
+        marginTop: withGap ? 8 : 0,
+      }}
+    >
+      {images.map((img, i) => (
+        <img
+          key={i}
+          src={`data:${img.mime};base64,${img.data}`}
+          alt="attachment"
+          style={{
+            maxWidth: 180,
+            maxHeight: 180,
+            borderRadius: R_MD,
+            border: `1px solid ${t.border}`,
+            display: "block",
+          }}
+        />
+      ))}
     </div>
   );
 }

--- a/ui/src/components/chat/chatStreaming.test.ts
+++ b/ui/src/components/chat/chatStreaming.test.ts
@@ -1,0 +1,44 @@
+// Image attachments must survive the wire→view reconstruction so a reopened
+// chat still shows the thumbnails the operator pasted, and so non-user roles
+// never accidentally carry them.
+
+import { describe, it, expect } from "vitest";
+import { chatStateFromMessages } from "./chatStreaming";
+import type { AgentChatMessage } from "../../types";
+
+describe("chatStateFromMessages — image attachments", () => {
+  it("carries user-message images through to the view message", () => {
+    const msgs: AgentChatMessage[] = [
+      {
+        role: "user",
+        content: "what is this?",
+        images: [{ mime: "image/png", data: "AAAA" }],
+      },
+    ];
+    const { messages } = chatStateFromMessages(msgs);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!.role).toBe("user");
+    expect(messages[0]!.images).toEqual([{ mime: "image/png", data: "AAAA" }]);
+  });
+
+  it("omits images for messages without attachments", () => {
+    const msgs: AgentChatMessage[] = [{ role: "user", content: "plain" }];
+    const { messages } = chatStateFromMessages(msgs);
+    expect(messages[0]!.images).toBeUndefined();
+  });
+
+  it("does not attach images to non-user roles", () => {
+    // Defensive: even if a stray assistant message arrived with images on the
+    // wire, the view reconstruction must not surface them as a user-style grid.
+    const msgs: AgentChatMessage[] = [
+      {
+        role: "assistant",
+        content: "here",
+        images: [{ mime: "image/png", data: "AAAA" }],
+      },
+    ];
+    const { messages } = chatStateFromMessages(msgs);
+    expect(messages[0]!.role).toBe("assistant");
+    expect(messages[0]!.images).toBeUndefined();
+  });
+});

--- a/ui/src/components/chat/chatStreaming.ts
+++ b/ui/src/components/chat/chatStreaming.ts
@@ -2,6 +2,7 @@ import type {
   AgentChatMessage,
   AgentToolCall,
   ChatEvent,
+  ChatImageAttachment,
   McpServerStatusWire,
 } from "../../types";
 
@@ -13,6 +14,10 @@ export type ChatViewMessage = {
   id: string;
   role: "user" | "assistant" | "tool";
   content: string;
+  // Image attachments on a user message — rendered as thumbnails in the
+  // bubble. Mirrors the wire `AgentChatMessage.images`. Empty / absent for
+  // every other message.
+  images?: ChatImageAttachment[];
   // Streaming flag — true while a TokenDelta stream is in flight. Cleared on
   // assistant_end / error. UI can render a blinking caret based on this.
   streaming?: boolean;
@@ -157,6 +162,10 @@ export function chatStateFromMessages(
         id: `hist-${i}`,
         role,
         content,
+        images:
+          role === "user" && m.images && m.images.length > 0
+            ? m.images
+            : undefined,
         toolCalls: m.tool_calls,
         toolCallId: m.tool_call_id ?? undefined,
         toolName: m.name ?? undefined,

--- a/ui/src/components/ui/icons.tsx
+++ b/ui/src/components/ui/icons.tsx
@@ -221,6 +221,16 @@ export const Icons = {
     14,
     <path d="M10 4h4v6h6v4h-6v6h-4v-6H4v-4h6z" />,
   ),
+  // Chat composer send — an upward arrow (modern composer convention).
+  send: filled(
+    16,
+    <path d="M12 3 21 12h-5v8h-8v-8H3z" />,
+  ),
+  // Stop / cancel an in-flight stream — a rounded filled square.
+  stop: filled(
+    14,
+    <rect x="6" y="6" width="12" height="12" rx="2" />,
+  ),
   pencil: filled(
     14,
     <path d="M3 17l11-11 4 4-11 11H3v-4zM16 4l2-2 4 4-2 2z" />,

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -2197,12 +2197,23 @@ export type AgentToolCall = {
   arguments: string;
 };
 
+// A single image attached to a user message. `data` is base64 WITHOUT the
+// `data:<mime>;base64,` prefix — matches the Rust `ImageAttachment` wire
+// shape. The frontend reconstructs a data URI for <img> previews.
+export type ChatImageAttachment = {
+  mime: string;
+  data: string;
+};
+
 export type AgentChatMessage = {
   role: MessageRole;
   content: string;
   tool_calls?: AgentToolCall[];
   tool_call_id?: string | null;
   name?: string | null;
+  // Image attachments on user messages (clipboard paste / file attach).
+  // Absent / empty on every other role.
+  images?: ChatImageAttachment[] | null;
 };
 
 export type SessionMeta = {


### PR DESCRIPTION
Add multimodal image support to the agent chat, end to end:

- Data model: `ImageAttachment { mime, data(base64) }` on `ChatMessage`, persisted in the session JSONL so reopened chats keep visual context.
- Providers: emit native image blocks for user messages — Anthropic `image`/base64, OpenAI-compat `image_url` data-URI, Codex `input_image`. Gated on a new models.dev `vision` capability (parsed from `modalities.input`); text-only models drop the image with a note instead of 400ing. Unknown models default to "try it".
- Frontend composer: Ctrl+V paste (with a native-clipboard fallback for WebKitGTK, which doesn't surface pasted images on the DOM paste event) plus a file picker, thumbnail strip with remove, and image rendering in the sent bubble.
- New `read_clipboard_image` Tauri command: reads the system clipboard via arboard, re-encodes RGBA → PNG → base64.
- Reimagined the composer layout: one rounded card holding the textarea + a bottom toolbar (attach left, circular icon send/stop right), with a focus ring and a muted meta row for allow-writes / compact / usage.

Tests: per-provider image-block + vision-drop, catalogue modalities parse, PNG encode roundtrip, api wire shape, history carry-through, MessageBubble render, and ChatInput paste/native-fallback/streaming interactions.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
