### PR TITLE
feat(detail): kubectl-edit-style YAML tab (merge patch, honest deletes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,9 @@ Every kind's detail panel composes the same kind-agnostic primitives in `ui/src/
 
 ## Inline editing (Server-Side Apply)
 
-Every editable surface goes through the **same edit kit** in `ui/src/components/detail/edit.tsx`. Don't fork — extend. Live precedents: ConfigMap / Secret / ResourceQuota / LimitRange data sections, and `MetaSection`'s Labels / Annotations rows (any kind can opt in).
+Every **structured** editable surface goes through the **same edit kit** in `ui/src/components/detail/edit.tsx`. Don't fork — extend. Live precedents: ConfigMap / Secret / ResourceQuota / LimitRange data sections, and `MetaSection`'s Labels / Annotations rows (any kind can opt in).
+
+> **The YAML tab is the deliberate exception.** The free-form manifest editor (`ui/src/components/detail/YamlTab.tsx`) follows the `kubectl edit` model, **not** SSA: it sends an RFC 7386 JSON merge patch via `merge_patch_resource_cmd` → `merge_patch_resource()`, computed by `lib/yamlEdit.ts::mergePatch`. This is on purpose — a partial-tree SSA apply can't express deletions (a removed key is omitted, not deleted) or empty values, which is why removals/blanks silently no-op'd under the old `diffPartial`. Merge patch emits `null` for removed keys (delete) and preserves `""` (empty string), and carries `metadata.resourceVersion` for optimistic concurrency (a stale 409 → `MergePatchResult::Stale`, surfaced as a Reload / Apply-anyway banner — there is no field-ownership "force takeover" here). **Don't "harmonize" the YAML tab back onto `apply_resource`/SSA**; the structured per-field editors keep SSA for its ownership tracking, the manifest editor keeps merge patch for honest deletes.
 
 ### Backend contract
 

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -36,10 +36,10 @@ use ferrisscope_kube_ext::{
     get_storage_class_detail, get_validating_webhook_configuration_detail, get_well_known_detail,
     helm_install_chart, helm_repo_update, helm_uninstall, helm_upgrade,
     list_config_maps_in_namespace, list_persistent_volume_claims_in_namespace, list_pods_on_node,
-    list_secrets_in_namespace, lookup, registry, restart_pod_owner, restart_pods_owners,
-    restart_workload, set_node_cordon, start_forward, ApplyResult, DrainReport, ForwardEntry,
-    ForwardStatus, HelmInstallResult, HelmUpgradeResult, ResourceKind, ResourceKindEntry,
-    RestartPodsReport,
+    list_secrets_in_namespace, lookup, merge_patch_resource, registry, restart_pod_owner,
+    restart_pods_owners, restart_workload, set_node_cordon, start_forward, ApplyResult,
+    DrainReport, ForwardEntry, ForwardStatus, HelmInstallResult, HelmUpgradeResult,
+    MergePatchResult, ResourceKind, ResourceKindEntry, RestartPodsReport,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -2229,6 +2229,37 @@ pub(crate) async fn apply_resource_cmd(
         &name,
         fields,
         force,
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// `kubectl edit`-style save for the YAML manifest tab. Applies an RFC 7386
+/// JSON merge patch (adds + edits + `null` deletions). Distinct from
+/// `apply_resource_cmd` (SSA): the free-form manifest editor wants explicit
+/// deletions and last-write-wins rather than per-field ownership tracking.
+///
+/// `resource_version = Some(rv)` enforces optimistic concurrency (returns
+/// `MergePatchResult::Stale` on a 409 if the object moved on); `None` is the
+/// UI's explicit "apply anyway" overwrite.
+#[tauri::command]
+pub(crate) async fn merge_patch_resource_cmd(
+    cluster_id: String,
+    kind_id: String,
+    namespace: Option<String>,
+    name: String,
+    patch: Value,
+    resource_version: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<MergePatchResult, String> {
+    let entry = state.entry(&cluster_id).await?;
+    merge_patch_resource(
+        entry.cluster.client(),
+        &kind_id,
+        namespace.as_deref(),
+        &name,
+        patch,
+        resource_version.as_deref(),
     )
     .await
     .map_err(|e| e.to_string())

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -174,6 +174,7 @@ fn main() {
             commands::get_validating_webhook_configuration_detail_cmd,
             commands::get_well_known_detail_cmd,
             commands::apply_resource_cmd,
+            commands::merge_patch_resource_cmd,
             commands::delete_resource_cmd,
             commands::cordon_node_cmd,
             commands::drain_node_cmd,

--- a/crates/kube-ext/src/fetch.rs
+++ b/crates/kube-ext/src/fetch.rs
@@ -1942,6 +1942,135 @@ fn extract_manager(msg: &str) -> Option<String> {
     Some(rest[..end].to_owned())
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MergePatchResult {
+    /// Patch landed. Carries the new `resourceVersion` so the UI knows the
+    /// watcher will catch up.
+    Applied { resource_version: Option<String> },
+    /// The object changed on the server since the operator opened it — the
+    /// `resourceVersion` they edited from is stale. The UI offers reload or
+    /// apply-anyway. This is the only conflict mode of the merge-patch path
+    /// (unlike SSA, there is no per-field ownership conflict).
+    Stale { message: String },
+}
+
+/// Build the JSON merge-patch body that actually goes on the wire. Injects
+/// `metadata.resourceVersion` when the caller supplies one so the apiserver
+/// enforces optimistic concurrency (rejecting the PATCH with a 409 if the
+/// object moved on). Pulled out as a pure function so the envelope handling
+/// is unit-testable without a cluster.
+fn build_merge_patch_body(patch: Value, resource_version: Option<&str>) -> Value {
+    let mut body = if patch.is_object() { patch } else { json!({}) };
+    if let Some(rv) = resource_version {
+        let obj = body.as_object_mut().expect("ensured object above");
+        let metadata_entry = obj.entry("metadata").or_insert_with(|| json!({}));
+        if !metadata_entry.is_object() {
+            *metadata_entry = json!({});
+        }
+        metadata_entry
+            .as_object_mut()
+            .expect("ensured object above")
+            .insert("resourceVersion".to_owned(), Value::String(rv.to_owned()));
+    }
+    body
+}
+
+/// `kubectl edit`-style save for the YAML manifest tab. Applies an RFC 7386
+/// JSON merge patch (adds + edits + `null` deletions) against any kind in the
+/// registry. This is deliberately *not* Server-Side Apply: a free-form
+/// manifest editor wants last-write-wins with explicit deletions, not
+/// per-field ownership tracking (which is what the structured editors use via
+/// [`apply_resource`]).
+///
+/// `resource_version` carries optimistic concurrency: `Some(rv)` makes the
+/// apiserver reject the patch with a 409 if the object changed since the
+/// operator opened it (surfaced as [`MergePatchResult::Stale`]); `None` skips
+/// the check (the UI's explicit "apply anyway" overwrite).
+pub async fn merge_patch_resource(
+    client: Client,
+    kind_id: &str,
+    namespace: Option<&str>,
+    name: &str,
+    patch: Value,
+    resource_version: Option<&str>,
+) -> Result<MergePatchResult, FetchError> {
+    let entry =
+        registry::lookup(kind_id).ok_or_else(|| FetchError::UnknownKind(kind_id.to_owned()))?;
+    let meta = &entry.meta;
+
+    let gvk = GroupVersionKind::gvk(meta.group, meta.version, meta.kind);
+    let ar = ApiResource::from_gvk_with_plural(&gvk, meta.plural);
+
+    let api: Api<DynamicObject> = if meta.namespaced {
+        let ns = namespace.ok_or_else(|| FetchError::NamespaceRequired(kind_id.to_owned()))?;
+        Api::namespaced_with(client, ns, &ar)
+    } else {
+        Api::all_with(client, &ar)
+    };
+
+    let body = build_merge_patch_body(patch, resource_version);
+
+    match api
+        .patch(name, &PatchParams::default(), &Patch::Merge(&body))
+        .await
+    {
+        Ok(obj) => Ok(MergePatchResult::Applied {
+            resource_version: obj.metadata.resource_version,
+        }),
+        // A resourceVersion mismatch comes back as 409 Conflict with a
+        // message like "the object has been modified; please apply your
+        // changes to the latest version and try again".
+        Err(kube::Error::Api(status)) if status.code == 409 => Ok(MergePatchResult::Stale {
+            message: status.message.clone(),
+        }),
+        Err(e) => Err(FetchError::Kube(e)),
+    }
+}
+
+#[cfg(test)]
+mod merge_patch_tests {
+    use super::build_merge_patch_body;
+    use serde_json::json;
+
+    #[test]
+    fn injects_resource_version_into_existing_metadata() {
+        let patch = json!({ "metadata": { "labels": { "a": "b" } }, "data": { "k": "v" } });
+        let body = build_merge_patch_body(patch, Some("42"));
+        assert_eq!(body["metadata"]["resourceVersion"], json!("42"));
+        // existing fields survive
+        assert_eq!(body["metadata"]["labels"]["a"], json!("b"));
+        assert_eq!(body["data"]["k"], json!("v"));
+    }
+
+    #[test]
+    fn creates_metadata_when_absent() {
+        let patch = json!({ "spec": { "replicas": 3 } });
+        let body = build_merge_patch_body(patch, Some("7"));
+        assert_eq!(body["metadata"]["resourceVersion"], json!("7"));
+        assert_eq!(body["spec"]["replicas"], json!(3));
+    }
+
+    #[test]
+    fn preserves_null_deletions_in_the_patch() {
+        // The merge-patch's whole point: a removed key arrives as null and
+        // must stay null through envelope assembly.
+        let patch = json!({ "data": { "gone": null, "kept": "x" } });
+        let body = build_merge_patch_body(patch, None);
+        assert!(body["data"].as_object().unwrap().contains_key("gone"));
+        assert_eq!(body["data"]["gone"], json!(null));
+        assert_eq!(body["data"]["kept"], json!("x"));
+        // No resourceVersion requested → no metadata injected.
+        assert!(body.get("metadata").is_none());
+    }
+
+    #[test]
+    fn non_object_patch_becomes_empty_object() {
+        let body = build_merge_patch_body(json!("oops"), Some("1"));
+        assert_eq!(body["metadata"]["resourceVersion"], json!("1"));
+    }
+}
+
 // ── Node operations: cordon / uncordon / drain / pods-on-node ──────────────
 //
 // `cordon` / `uncordon` flip `spec.unschedulable` via Server-Side Apply with

--- a/crates/kube-ext/src/lib.rs
+++ b/crates/kube-ext/src/lib.rs
@@ -29,11 +29,11 @@ pub use fetch::{
     get_storage_class_detail, get_validating_webhook_configuration_detail, get_well_known_detail,
     helm_available, helm_install_chart, helm_repo_update, helm_uninstall, helm_upgrade,
     list_config_maps_in_namespace, list_persistent_volume_claims_in_namespace, list_pods_on_node,
-    list_secrets_in_namespace, restart_pod_owner, restart_pods_owners, restart_workload,
-    set_node_cordon, ApplyConflict, ApplyOk, ApplyResult, DocApplyResult, DrainFailure,
-    DrainReport, DrainSkipped, FetchError, HelmInstallResult, HelmUpdateAvailable,
-    HelmUpgradeResult, RestartFailure, RestartPodsReport, RestartedWorkload, FIELD_MANAGER,
-    HELM_CLUSTER_SOURCE,
+    list_secrets_in_namespace, merge_patch_resource, restart_pod_owner, restart_pods_owners,
+    restart_workload, set_node_cordon, ApplyConflict, ApplyOk, ApplyResult, DocApplyResult,
+    DrainFailure, DrainReport, DrainSkipped, FetchError, HelmInstallResult, HelmUpdateAvailable,
+    HelmUpgradeResult, MergePatchResult, RestartFailure, RestartPodsReport, RestartedWorkload,
+    FIELD_MANAGER, HELM_CLUSTER_SOURCE,
 };
 pub use portforward::{
     new_status_channel, snapshot as forward_snapshot, start as start_forward, ForwardEntry,

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -117,6 +117,29 @@ describe("applyResource (SSA)", () => {
   });
 });
 
+describe("mergePatchResource (kubectl edit)", () => {
+  it("ships the merge patch + resourceVersion for the optimistic-lock path", async () => {
+    const cap = captureNext({ kind: "applied", resource_version: "43" });
+    const patch = { data: { KEY: "B", GONE: null } };
+    await api.mergePatchResource("ctx", "configmaps", "default", "cm", patch, "42");
+    expect(cap.calls[0]?.cmd).toBe("merge_patch_resource_cmd");
+    expect(cap.calls[0]?.args).toEqual({
+      clusterId: "ctx",
+      kindId: "configmaps",
+      namespace: "default",
+      name: "cm",
+      patch,
+      resourceVersion: "42",
+    });
+  });
+
+  it("resourceVersion=null is the overwrite (apply-anyway) path", async () => {
+    const cap = captureNext({ kind: "applied", resource_version: "44" });
+    await api.mergePatchResource("ctx", "configmaps", "default", "cm", {}, null);
+    expect(cap.calls[0]?.args?.resourceVersion).toBeNull();
+  });
+});
+
 describe("deleteResource", () => {
   it("force-delete sends gracePeriodSeconds: 0", async () => {
     const cap = captureNext(undefined);

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -34,6 +34,7 @@ import type {
   CompactMemoryResult,
   DevMemoryStats,
   DocApplyResult,
+  MergePatchResult,
   DrainReport,
   EndpointSliceDetail,
   EndpointsDetail,
@@ -541,6 +542,28 @@ export const api = {
       name,
       fields,
       force,
+    }),
+
+  // `kubectl edit`-style save for the YAML manifest tab: an RFC 7386 JSON
+  // merge patch (adds + edits + `null` deletions). `resourceVersion` carries
+  // optimistic concurrency — pass the version the operator opened to detect
+  // a concurrent change (`MergePatchResult.kind === "stale"`); pass null to
+  // overwrite regardless ("apply anyway").
+  mergePatchResource: (
+    clusterId: string,
+    kindId: string,
+    namespace: string | null,
+    name: string,
+    patch: Record<string, unknown>,
+    resourceVersion: string | null,
+  ) =>
+    invoke<MergePatchResult>("merge_patch_resource_cmd", {
+      clusterId,
+      kindId,
+      namespace,
+      name,
+      patch,
+      resourceVersion,
     }),
 
   // Cordon (cordon=true) or uncordon (false) a node. Patches

--- a/ui/src/components/DetailPanel.tsx
+++ b/ui/src/components/DetailPanel.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import Editor from "@monaco-editor/react";
 import { api, onResourceDelta } from "../api";
-import {
-  diffPartial,
-  parseYaml,
-  stripYaml,
-  type Json,
-} from "../lib/yamlEdit";
-import { installClipboardShortcuts } from "../lib/monacoClipboard";
+import { parseYaml, stripYaml, type Json } from "../lib/yamlEdit";
 import { useAppStore, useResolvedTheme } from "../store";
 import type {
   ContainerDetail,
@@ -20,7 +13,7 @@ import type {
   ResourceKind,
   ResourceRow,
 } from "../types";
-import { tokens, FF_MONO, type ThemeMode, type Tokens, R_LG, R_SM, FS_LG, FS_MD, FS_SM, FS_XS } from "../theme";
+import { tokens, FF_MONO, type ThemeMode, type Tokens, R_LG, FS_LG, FS_MD, FS_SM, FS_XS } from "../theme";
 import {
   Chip,
   ContainerDots,
@@ -75,8 +68,8 @@ import {
   NamespaceSummary,
   NodeSummary,
 } from "./detail/cluster";
-import { ConflictBanner, EditModeChrome } from "./detail/edit";
 import { InlineLogTab } from "./detail/InlineLogTab";
+import { YamlTab, type YamlStale } from "./detail/YamlTab";
 import { MetricsTab } from "./detail/MetricsTab";
 import {
   EndpointSliceSummary,
@@ -210,9 +203,31 @@ type LoadState =
       // Parsed JSON form of the same stripped doc — kept around so Save
       // can diff against it without re-parsing on every keystroke.
       original: Json;
+      // metadata.resourceVersion from the *unstripped* doc — threaded into
+      // the merge-patch save for optimistic concurrency. Null when absent or
+      // when the raw doc failed to parse.
+      resourceVersion: string | null;
       refreshedAt: number;
     }
   | { kind: "error"; message: string };
+
+// Pull `metadata.resourceVersion` out of the raw (unstripped) YAML so the
+// merge-patch save can use it for optimistic concurrency. Total — returns
+// null on any parse failure or shape drift rather than throwing.
+function resourceVersionFromYaml(rawYaml: string): string | null {
+  try {
+    const doc = parseYaml(rawYaml);
+    if (doc == null || typeof doc !== "object" || Array.isArray(doc)) return null;
+    const meta = (doc as Record<string, Json>).metadata;
+    if (meta == null || typeof meta !== "object" || Array.isArray(meta)) return null;
+    const rv = (meta as Record<string, Json>).resourceVersion;
+    if (typeof rv === "string") return rv;
+    if (typeof rv === "number") return String(rv);
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 type Tab = "summary" | "yaml" | "events" | "related" | "logs" | "metrics";
 
@@ -319,17 +334,14 @@ export function DetailPanel({
     hasSummary ? "summary" : hasYaml ? "yaml" : "summary",
   );
   const [load, setLoad] = useState<LoadState>({ kind: "loading" });
-  // YAML-tab edit state. `buffer` is the operator's in-flight edit; null
-  // when not editing. `saving` blocks the controls during the SSA round
-  // trip; `conflict` populates the ConflictBanner; `error` shows other
-  // failures (parse, network) above the editor.
+  // YAML-tab edit state. `buffer` is the operator's in-flight draft; null
+  // means "in sync with the server". `saving` blocks the controls during the
+  // merge-patch round trip; `stale` surfaces an optimistic-concurrency 409
+  // (the object changed under us); `error` shows other failures (parse,
+  // network) above the editor.
   const [yamlBuffer, setYamlBuffer] = useState<string | null>(null);
   const [yamlSaving, setYamlSaving] = useState(false);
-  const [yamlConflict, setYamlConflict] = useState<{
-    managers: string[];
-    fields: string[];
-    message: string;
-  } | null>(null);
+  const [yamlStale, setYamlStale] = useState<YamlStale | null>(null);
   const [yamlError, setYamlError] = useState<string | null>(null);
   // Bumped on every Upsert for this uid; the pod summary subtree refetches
   // its detail in response. The YAML tab still triggers via `refetch` below.
@@ -580,6 +592,7 @@ export function DetailPanel({
         yaml: "",
         yamlRaw: "",
         original: null,
+        resourceVersion: null,
         refreshedAt: Date.now(),
       });
       return;
@@ -597,6 +610,7 @@ export function DetailPanel({
             yaml: stripped,
             yamlRaw: yaml,
             original,
+            resourceVersion: resourceVersionFromYaml(yaml),
             refreshedAt: Date.now(),
           });
         } catch (e) {
@@ -608,6 +622,7 @@ export function DetailPanel({
             yaml,
             yamlRaw: yaml,
             original: null,
+            resourceVersion: resourceVersionFromYaml(yaml),
             refreshedAt: Date.now(),
           });
           console.warn("YAML strip failed", e);
@@ -658,7 +673,7 @@ export function DetailPanel({
     // buffer is keyed to the prior resource and would otherwise corrupt
     // the new one's apply payload.
     setYamlBuffer(null);
-    setYamlConflict(null);
+    setYamlStale(null);
     setYamlError(null);
     setYamlSaving(false);
 
@@ -1134,12 +1149,15 @@ export function DetailPanel({
             ) : load.kind === "loading" ? (
               <LoadingLine t={t} label="Fetching YAML…" />
             ) : (
-              <YamlPane
+              <YamlTab
                 mode={mode}
                 t={t}
                 yaml={load.kind === "ready" ? load.yaml : ""}
                 yamlRaw={load.kind === "ready" ? load.yamlRaw : ""}
                 original={load.kind === "ready" ? load.original : null}
+                resourceVersion={
+                  load.kind === "ready" ? load.resourceVersion : null
+                }
                 refreshedAt={load.kind === "ready" ? load.refreshedAt : null}
                 clusterId={clusterId}
                 kindId={kind.id}
@@ -1150,13 +1168,13 @@ export function DetailPanel({
                 setBuffer={setYamlBuffer}
                 saving={yamlSaving}
                 setSaving={setYamlSaving}
-                conflict={yamlConflict}
-                setConflict={setYamlConflict}
+                stale={yamlStale}
+                setStale={setYamlStale}
                 error={yamlError}
                 setError={setYamlError}
-                onSaved={() => {
+                onResync={() => {
                   setYamlBuffer(null);
-                  setYamlConflict(null);
+                  setYamlStale(null);
                   setYamlError(null);
                   refetch();
                   setDetailVersion((v) => v + 1);
@@ -1219,308 +1237,6 @@ export function DetailPanel({
   );
 }
 
-// Manifest editor — the YAML tab body. Read-only by default; the operator
-// flips into edit mode via the pencil chip in the chrome bar. Save sends
-// only the touched paths through `apply_resource_cmd` so SSA tracks
-// ownership at field-level granularity, not document-level.
-function YamlPane({
-  mode,
-  t,
-  yaml,
-  yamlRaw,
-  original,
-  refreshedAt,
-  clusterId,
-  kindId,
-  kindLabel,
-  namespace,
-  name,
-  buffer,
-  setBuffer,
-  saving,
-  setSaving,
-  conflict,
-  setConflict,
-  error,
-  setError,
-  onSaved,
-}: {
-  mode: ThemeMode;
-  t: Tokens;
-  yaml: string;
-  // Unstripped YAML — surfaced via the "HIDDEN" toggle in read mode so
-  // operators can inspect server-managed fields (managedFields, status,
-  // resourceVersion, …) without leaving the panel.
-  yamlRaw: string;
-  original: Json | null;
-  refreshedAt: number | null;
-  clusterId: string;
-  kindId: string;
-  kindLabel: string;
-  namespace: string | null;
-  name: string;
-  buffer: string | null;
-  setBuffer: (v: string | null) => void;
-  saving: boolean;
-  setSaving: (v: boolean) => void;
-  conflict: { managers: string[]; fields: string[]; message: string } | null;
-  setConflict: (
-    v: { managers: string[]; fields: string[]; message: string } | null,
-  ) => void;
-  error: string | null;
-  setError: (v: string | null) => void;
-  onSaved: () => void;
-}) {
-  // Monaco wants a literal font stack — pull the theme's mono so it
-  // tracks VS Code's Cascadia etc.
-  const monoFont = useResolvedTheme().typography.fontMono;
-  const editing = buffer !== null;
-  // Operator-facing toggle: when true, render the unstripped raw YAML
-  // (managedFields / status / etc visible). Forced false in edit mode so
-  // saves only ever diff against the stripped baseline — otherwise a
-  // toggle mid-edit would silently re-include server fields the apiserver
-  // would reject anyway. Reset to false whenever the document refetches.
-  const [showHidden, setShowHidden] = useState(false);
-  useEffect(() => {
-    if (editing) setShowHidden(false);
-  }, [editing]);
-  useEffect(() => {
-    setShowHidden(false);
-  }, [refreshedAt]);
-
-  // The editor's live text. When editing we render the operator's buffer;
-  // when in show-hidden read mode we render the raw YAML; otherwise the
-  // stripped YAML.
-  const value = editing ? buffer! : showHidden ? yamlRaw : yaml;
-
-  // 1s tick so the "fetched X ago" indicator in the toolbar refreshes.
-  const [, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (refreshedAt == null || editing) return;
-    const id = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, [refreshedAt, editing]);
-
-  // Diff metrics — only meaningful while editing. `count` drives the Save
-  // chip; `onlyDeletions` flips the warning so the operator isn't confused
-  // when key-removal edits don't take effect under our partial-tree apply.
-  const diff = useMemo(() => {
-    if (!editing || original == null) {
-      return { count: 0, partial: {}, empty: true, onlyDeletions: false };
-    }
-    try {
-      const edited = parseYaml(buffer!);
-      return diffPartial(original, edited);
-    } catch {
-      return { count: -1, partial: {}, empty: true, onlyDeletions: false };
-    }
-  }, [editing, buffer, original]);
-
-  const enter = () => {
-    setError(null);
-    setConflict(null);
-    setBuffer(yaml);
-  };
-  const cancel = () => {
-    setBuffer(null);
-    setConflict(null);
-    setError(null);
-  };
-
-  const apply = async (force: boolean) => {
-    if (original == null) {
-      setError("Cannot edit: original document failed to parse.");
-      return;
-    }
-    let edited: Json;
-    try {
-      edited = parseYaml(buffer ?? "");
-    } catch (e) {
-      setError(`YAML parse error: ${String(e)}`);
-      return;
-    }
-    const d = diffPartial(original, edited);
-    if (d.empty && !d.onlyDeletions) {
-      setError("Nothing changed.");
-      return;
-    }
-    setSaving(true);
-    setError(null);
-    try {
-      const result = await api.applyResource(
-        clusterId,
-        kindId,
-        namespace,
-        name,
-        d.partial,
-        force,
-      );
-      if (result.kind === "applied") {
-        setSaving(false);
-        onSaved();
-      } else {
-        setSaving(false);
-        setConflict({
-          managers: result.managers,
-          fields: result.fields,
-          message: result.message,
-        });
-      }
-    } catch (e) {
-      setSaving(false);
-      setError(String(e));
-    }
-  };
-
-  // The chrome bar above the editor — pencil → Save (N) / Cancel chips.
-  // Disabled when the original couldn't be parsed (e.g. malformed YAML
-  // returned from the apiserver, which shouldn't happen but isn't fatal).
-  const editable = original != null;
-  const dirtyForChrome = diff.count > 0 ? diff.count : 0;
-
-  return (
-    <div
-      style={{
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        minHeight: 0,
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          padding: "6px 14px",
-          borderBottom: `1px solid ${t.borderSoft}`,
-          background: t.headerAlt,
-          flexShrink: 0,
-        }}
-      >
-        <span
-          style={{
-            fontSize: FS_XS,
-            fontFamily: FF_MONO,
-            color: t.textMuted,
-            textTransform: "uppercase",
-            letterSpacing: 0.6,
-          }}
-        >
-          {editing
-            ? diff.count === -1
-              ? "YAML parse error"
-              : diff.onlyDeletions && diff.count === 0
-                ? "removals only — not applied"
-                : `editing · ${dirtyForChrome} change${dirtyForChrome === 1 ? "" : "s"}`
-            : refreshedAt != null
-              ? showHidden
-                ? `read-only · all fields shown · fetched ${timeAgo(refreshedAt)}`
-                : `read-only · status & managed fields hidden · fetched ${timeAgo(refreshedAt)}`
-              : showHidden
-                ? "read-only · all fields shown"
-                : "read-only · status & managed fields hidden"}
-        </span>
-        <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
-          {!editing && yamlRaw !== yaml && (
-            <button
-              type="button"
-              onClick={() => setShowHidden((v) => !v)}
-              title={
-                showHidden
-                  ? "Hide server-managed fields (managedFields, status, resourceVersion, …)"
-                  : "Show server-managed fields (managedFields, status, resourceVersion, …)"
-              }
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 6,
-                height: 22,
-                padding: "0 8px",
-                borderRadius: R_SM,
-                border: "none",
-                background: showHidden ? t.accentSoft : t.chip,
-                color: showHidden ? t.accent : t.textDim,
-                fontFamily: FF_MONO,
-                fontSize: FS_SM,
-                fontWeight: 700,
-                letterSpacing: 0.4,
-                cursor: "pointer",
-                textTransform: "uppercase",
-              }}
-            >
-              {showHidden ? "Unhide" : "Hidden"}
-            </button>
-          )}
-          {editable && (
-            <EditModeChrome
-              t={t}
-              editing={editing}
-              dirty={dirtyForChrome}
-              saving={saving}
-              onEnter={enter}
-              onCancel={cancel}
-              onSave={() => apply(false)}
-            />
-          )}
-        </span>
-      </div>
-      {error && (
-        <div
-          style={{
-            padding: "8px 14px",
-            background: "rgba(244,63,94,0.1)",
-            borderBottom: `1px solid ${t.borderSoft}`,
-            flexShrink: 0,
-          }}
-        >
-          <ErrorBlock
-            t={t}
-            message={error}
-            kindLabel={kindLabel}
-            verb="save"
-            inline
-          />
-        </div>
-      )}
-      {conflict && (
-        <div style={{ padding: "10px 14px 0", flexShrink: 0 }}>
-          <ConflictBanner
-            t={t}
-            conflict={conflict}
-            saving={saving}
-            onForce={() => apply(true)}
-            onDismiss={() => setConflict(null)}
-          />
-        </div>
-      )}
-      <div style={{ flex: 1, minHeight: 0 }}>
-        <Editor
-          height="100%"
-          language="yaml"
-          theme={mode === "dark" ? "vs-dark" : "light"}
-          value={value}
-          onChange={(next) => {
-            if (!editing) return;
-            setBuffer(next ?? "");
-          }}
-          onMount={installClipboardShortcuts}
-          options={{
-            readOnly: !editing || saving,
-            minimap: { enabled: false },
-            // Monaco wants a literal font + numeric size.
-            fontSize: 12.5,
-            fontFamily: monoFont,
-            wordWrap: "on",
-            scrollBeyondLastLine: false,
-            renderLineHighlight: "none",
-            folding: true,
-          }}
-        />
-      </div>
-    </div>
-  );
-}
 
 // Related-resources tab. Pure-frontend projection of fields the kind's
 // existing detail API already returns:
@@ -3323,15 +3039,6 @@ function formatAge(value: unknown, nowMs: number): string {
   if (h < 24) return `${h}h`;
   const d = Math.floor(h / 24);
   return `${d}d`;
-}
-
-function timeAgo(then: number): string {
-  const s = Math.max(0, Math.floor((Date.now() - then) / 1000));
-  if (s < 5) return "just now";
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  return `${Math.floor(m / 60)}h ago`;
 }
 
 // Routes the structured Summary tab to the right per-kind component for

--- a/ui/src/components/detail/YamlTab.test.tsx
+++ b/ui/src/components/detail/YamlTab.test.tsx
@@ -1,0 +1,227 @@
+// Component test for the YAML manifest tab. The merge-patch math is unit
+// tested in lib/yamlEdit.test.ts; this file pins the rendered behaviour the
+// operator actually touches: the editor is always editable, Save ships the
+// computed merge patch + resourceVersion, a stale 409 surfaces the banner,
+// and "apply anyway" re-sends without the version guard.
+//
+// Monaco is mocked to a plain <textarea> — we only care about value/onChange
+// and the readOnly flag, not the real editor.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { tokens } from "../../theme";
+import { parseYaml } from "../../lib/yamlEdit";
+import { YamlTab, type YamlStale } from "./YamlTab";
+
+const { mergePatchResourceMock } = vi.hoisted(() => ({
+  mergePatchResourceMock: vi.fn(),
+}));
+
+vi.mock("../../api", () => ({
+  api: { mergePatchResource: mergePatchResourceMock },
+}));
+
+// Monaco stand-in: a controlled textarea that forwards edits and honours
+// the readOnly option so we can assert the always-editable contract.
+vi.mock("@monaco-editor/react", () => ({
+  default: (props: {
+    value?: string;
+    onChange?: (v: string | undefined) => void;
+    options?: { readOnly?: boolean };
+  }) => (
+    <textarea
+      data-testid="editor"
+      readOnly={props.options?.readOnly}
+      value={props.value ?? ""}
+      onChange={(e) => props.onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+const t = tokens("dark");
+
+const BASE_YAML = "metadata:\n  name: cm\ndata:\n  KEY: A\n";
+const EDITED_YAML = "metadata:\n  name: cm\ndata:\n  KEY: B\n";
+
+// `serverYaml` / `serverRv` model the live object the detail panel feeds in.
+// Rerendering Host with new values simulates a watcher refetch while the
+// internally-held draft (buffer) persists across the rerender.
+function Host({
+  onResync = vi.fn(),
+  serverYaml = BASE_YAML,
+  serverRv = "42",
+  refreshedAt = 1000,
+}: {
+  onResync?: () => void;
+  serverYaml?: string;
+  serverRv?: string;
+  refreshedAt?: number;
+}) {
+  const [buffer, setBuffer] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [stale, setStale] = useState<YamlStale | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  return (
+    <YamlTab
+      mode="dark"
+      t={t}
+      yaml={serverYaml}
+      yamlRaw={`${serverYaml}  uid: abc\n`}
+      original={parseYaml(serverYaml)}
+      resourceVersion={serverRv}
+      refreshedAt={refreshedAt}
+      clusterId="c1"
+      kindId="configmaps"
+      kindLabel="configmap"
+      namespace="ns"
+      name="cm"
+      buffer={buffer}
+      setBuffer={setBuffer}
+      saving={saving}
+      setSaving={setSaving}
+      stale={stale}
+      setStale={setStale}
+      error={error}
+      setError={setError}
+      onResync={() => {
+        setBuffer(null);
+        onResync();
+      }}
+    />
+  );
+}
+
+beforeEach(() => {
+  mergePatchResourceMock.mockReset();
+});
+
+describe("YamlTab", () => {
+  it("is editable straight away — no pencil gate", () => {
+    render(<Host />);
+    const editor = screen.getByTestId("editor") as HTMLTextAreaElement;
+    expect(editor.readOnly).toBe(false);
+    // Save is present but inert until something changes.
+    const save = screen.getByRole("button", { name: /^save$/i });
+    expect(save).toBeDisabled();
+  });
+
+  it("Save ships the merge patch + resourceVersion once the doc diverges", async () => {
+    mergePatchResourceMock.mockResolvedValue({
+      kind: "applied",
+      resource_version: "43",
+    });
+    const onResync = vi.fn();
+    render(<Host onResync={onResync} />);
+
+    fireEvent.change(screen.getByTestId("editor"), {
+      target: { value: EDITED_YAML },
+    });
+
+    // The dirty Save chip shows the change count.
+    const save = await screen.findByRole("button", { name: /save \(1\)/i });
+    fireEvent.click(save);
+
+    await waitFor(() => expect(mergePatchResourceMock).toHaveBeenCalledTimes(1));
+    expect(mergePatchResourceMock).toHaveBeenCalledWith(
+      "c1",
+      "configmaps",
+      "ns",
+      "cm",
+      { data: { KEY: "B" } },
+      "42",
+    );
+    await waitFor(() => expect(onResync).toHaveBeenCalled());
+  });
+
+  it("freezes the baseline at edit time — a watcher refetch can't rebase or refresh the version", async () => {
+    mergePatchResourceMock.mockResolvedValue({
+      kind: "applied",
+      resource_version: "100",
+    });
+    const { rerender } = render(<Host serverRv="42" />);
+
+    // Operator starts editing.
+    fireEvent.change(screen.getByTestId("editor"), {
+      target: { value: EDITED_YAML },
+    });
+
+    // A watcher refetch lands a newer server copy mid-edit: a higher
+    // resourceVersion and an externally-added key.
+    rerender(
+      <Host
+        serverRv="99"
+        serverYaml={"metadata:\n  name: cm\ndata:\n  KEY: A\n  OTHER: x\n"}
+        refreshedAt={2000}
+      />,
+    );
+
+    // Still one change against the FROZEN baseline (not two — OTHER is not
+    // reverted), and Save sends the FROZEN resourceVersion 42, so the
+    // optimistic lock will correctly detect the concurrent change.
+    fireEvent.click(await screen.findByRole("button", { name: /save \(1\)/i }));
+    await waitFor(() => expect(mergePatchResourceMock).toHaveBeenCalledTimes(1));
+    expect(mergePatchResourceMock).toHaveBeenCalledWith(
+      "c1",
+      "configmaps",
+      "ns",
+      "cm",
+      { data: { KEY: "B" } },
+      "42",
+    );
+  });
+
+  it("a stale 409 surfaces the banner; Apply anyway drops the version guard", async () => {
+    mergePatchResourceMock
+      .mockResolvedValueOnce({ kind: "stale", message: "object was modified" })
+      .mockResolvedValueOnce({ kind: "applied", resource_version: "99" });
+    render(<Host />);
+
+    fireEvent.change(screen.getByTestId("editor"), {
+      target: { value: EDITED_YAML },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /save \(1\)/i }));
+
+    // Banner appears with the server message.
+    expect(await screen.findByText(/object changed/i)).toBeInTheDocument();
+    expect(screen.getByText(/object was modified/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /apply my changes anyway/i }),
+    );
+
+    await waitFor(() => expect(mergePatchResourceMock).toHaveBeenCalledTimes(2));
+    // Second call overwrites: resourceVersion is null.
+    expect(mergePatchResourceMock.mock.calls[1]).toEqual([
+      "c1",
+      "configmaps",
+      "ns",
+      "cm",
+      { data: { KEY: "B" } },
+      null,
+    ]);
+  });
+
+  it("Discard reverts the draft to the server copy", async () => {
+    render(<Host />);
+    const editor = screen.getByTestId("editor") as HTMLTextAreaElement;
+    fireEvent.change(editor, { target: { value: EDITED_YAML } });
+    expect(editor.value).toContain("KEY: B");
+
+    fireEvent.click(await screen.findByRole("button", { name: /discard/i }));
+
+    expect((screen.getByTestId("editor") as HTMLTextAreaElement).value).toBe(
+      BASE_YAML,
+    );
+    // Back to clean → Save inert again.
+    expect(screen.getByRole("button", { name: /^save$/i })).toBeDisabled();
+  });
+
+  it("the Server fields toggle shows raw YAML read-only", () => {
+    render(<Host />);
+    fireEvent.click(screen.getByRole("button", { name: /server fields/i }));
+    const editor = screen.getByTestId("editor") as HTMLTextAreaElement;
+    expect(editor.readOnly).toBe(true);
+    expect(editor.value).toContain("uid: abc");
+  });
+});

--- a/ui/src/components/detail/YamlTab.tsx
+++ b/ui/src/components/detail/YamlTab.tsx
@@ -1,0 +1,515 @@
+// The detail panel's YAML tab — a `kubectl edit`-style manifest editor.
+//
+// Design notes vs. the structured per-field editors:
+//   • Always editable. There is no pencil / read-mode gate; the operator
+//     types straight into the document and a Save/Discard pair appears the
+//     moment the buffer diverges from the server copy.
+//   • Saves via an RFC 7386 JSON merge patch (`api.mergePatchResource`), not
+//     SSA. That's what makes removals and blanked values actually apply —
+//     a removed key is sent as `null`. See `lib/yamlEdit.ts::mergePatch`.
+//   • Optimistic concurrency: the patch carries the `resourceVersion` the
+//     operator opened. If the object moved on, the apiserver rejects it and
+//     we surface a stale-conflict banner (Reload / Apply anyway) instead of
+//     silently clobbering the newer copy.
+//
+// The buffer + save/stale/error state is owned by the parent (`DetailPanel`)
+// so it survives tab switches and is reset on target change. `buffer === null`
+// means "in sync with the server" — the editor then tracks live refetches.
+
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import Editor from "@monaco-editor/react";
+import { api } from "../../api";
+import { installClipboardShortcuts } from "../../lib/monacoClipboard";
+import { mergePatch, parseYaml, type Json } from "../../lib/yamlEdit";
+import { useResolvedTheme } from "../../store";
+import {
+  FF_MONO,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  R_SM,
+  type ThemeMode,
+  type Tokens,
+} from "../../theme";
+import { ErrorBlock } from "../ui";
+
+export type YamlStale = { message: string };
+
+type Props = {
+  mode: ThemeMode;
+  t: Tokens;
+  // Stripped, source-like YAML — the editable baseline.
+  yaml: string;
+  // Unstripped YAML (managedFields / status / resourceVersion …) — shown
+  // read-only via the "Show server fields" toggle.
+  yamlRaw: string;
+  // Parsed form of the stripped doc; the merge-patch baseline. Null when the
+  // server YAML failed to parse, which disables saving.
+  original: Json | null;
+  // resourceVersion the operator opened — drives optimistic concurrency.
+  resourceVersion: string | null;
+  refreshedAt: number | null;
+  clusterId: string;
+  kindId: string;
+  kindLabel: string;
+  namespace: string | null;
+  name: string;
+  // Parent-owned draft. null = synced to server (editor tracks `yaml`).
+  buffer: string | null;
+  setBuffer: (v: string | null) => void;
+  saving: boolean;
+  setSaving: (v: boolean) => void;
+  stale: YamlStale | null;
+  setStale: (v: YamlStale | null) => void;
+  error: string | null;
+  setError: (v: string | null) => void;
+  // Clear local draft/stale/error and refetch the live object. Used after a
+  // successful save and on an explicit Reload.
+  onResync: () => void;
+};
+
+export function YamlTab({
+  mode,
+  t,
+  yaml,
+  yamlRaw,
+  original,
+  resourceVersion,
+  refreshedAt,
+  clusterId,
+  kindId,
+  kindLabel,
+  namespace,
+  name,
+  buffer,
+  setBuffer,
+  saving,
+  setSaving,
+  stale,
+  setStale,
+  error,
+  setError,
+  onResync,
+}: Props) {
+  const monoFont = useResolvedTheme().typography.fontMono;
+
+  // Operator-facing toggle: render the unstripped raw YAML read-only so
+  // server-managed fields can be inspected without leaving the panel. The
+  // draft is preserved underneath. Reset whenever the document refetches.
+  const [showRaw, setShowRaw] = useState(false);
+  useEffect(() => {
+    setShowRaw(false);
+  }, [refreshedAt]);
+
+  const hasRaw = yamlRaw !== yaml;
+
+  // Frozen merge-patch baseline. The detail panel refetches the live object
+  // every few hundred ms while the watcher is chatty — if we diffed against
+  // (and saved the resourceVersion of) that moving target, a concurrent
+  // external edit would be silently rebased away and the optimistic lock
+  // would never fire. So we snapshot {original, resourceVersion, yaml} at the
+  // instant editing begins and hold it until the operator is back in sync.
+  // While in sync (buffer null) the baseline tracks the latest server copy.
+  const [baseline, setBaseline] = useState({ original, resourceVersion, yaml });
+  useEffect(() => {
+    if (buffer === null) setBaseline({ original, resourceVersion, yaml });
+  }, [buffer, original, resourceVersion, yaml]);
+
+  // The text Monaco renders. When synced (buffer null) we track the live
+  // server copy so a watcher refetch keeps the view fresh.
+  const draft = buffer ?? yaml;
+  const value = showRaw ? yamlRaw : draft;
+
+  // Merge-patch metrics for the current draft against the frozen baseline.
+  // `count` drives the change chip; `parseError` flips Save + the status line.
+  const diff = useMemo(() => {
+    if (baseline.original == null)
+      return { count: 0, empty: true, parseError: false };
+    try {
+      const edited = parseYaml(draft);
+      const mp = mergePatch(baseline.original, edited);
+      return { count: mp.count, empty: mp.empty, parseError: false };
+    } catch {
+      return { count: 0, empty: true, parseError: true };
+    }
+  }, [baseline.original, draft]);
+
+  const editable = baseline.original != null;
+  const dirty = buffer !== null && !diff.empty && !diff.parseError;
+  const canSave = editable && dirty && !saving && !showRaw;
+
+  const save = async (ignoreVersion: boolean) => {
+    if (baseline.original == null) {
+      setError("Cannot edit: the server document failed to parse.");
+      return;
+    }
+    let edited: Json;
+    try {
+      edited = parseYaml(buffer ?? baseline.yaml);
+    } catch (e) {
+      setError(`YAML parse error: ${String(e)}`);
+      return;
+    }
+    const mp = mergePatch(baseline.original, edited);
+    if (mp.empty) {
+      setError("Nothing changed.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await api.mergePatchResource(
+        clusterId,
+        kindId,
+        namespace,
+        name,
+        mp.patch,
+        ignoreVersion ? null : baseline.resourceVersion,
+      );
+      setSaving(false);
+      if (res.kind === "applied") {
+        setStale(null);
+        onResync();
+      } else {
+        setStale({ message: res.message });
+      }
+    } catch (e) {
+      setSaving(false);
+      setError(String(e));
+    }
+  };
+
+  const discard = () => {
+    setBuffer(null);
+    setStale(null);
+    setError(null);
+  };
+
+  const reload = () => {
+    setStale(null);
+    setError(null);
+    onResync();
+  };
+
+  // ── Header status line ───────────────────────────────────────────────────
+  let statusText: string;
+  let statusTone: "muted" | "accent" | "bad" = "muted";
+  if (showRaw) {
+    statusText = "read-only · all server fields shown";
+  } else if (!editable) {
+    statusText = "read-only · server YAML could not be parsed";
+    statusTone = "bad";
+  } else if (diff.parseError) {
+    statusText = "YAML parse error · fix to enable Save";
+    statusTone = "bad";
+  } else if (dirty) {
+    statusText = `${diff.count} unsaved change${diff.count === 1 ? "" : "s"}`;
+    statusTone = "accent";
+  } else {
+    statusText =
+      refreshedAt != null
+        ? `in sync · fetched ${timeAgo(refreshedAt)}`
+        : "in sync";
+  }
+
+  return (
+    <div
+      style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        minHeight: 0,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 10,
+          padding: "6px 14px",
+          borderBottom: `1px solid ${t.borderSoft}`,
+          background: t.headerAlt,
+          flexShrink: 0,
+        }}
+      >
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 7,
+            fontSize: FS_XS,
+            fontFamily: FF_MONO,
+            color:
+              statusTone === "accent"
+                ? t.accent
+                : statusTone === "bad"
+                  ? t.bad
+                  : t.textMuted,
+            textTransform: "uppercase",
+            letterSpacing: 0.6,
+            minWidth: 0,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {dirty && !showRaw && !diff.parseError && (
+            <span
+              aria-hidden
+              style={{
+                width: 7,
+                height: 7,
+                borderRadius: 999,
+                background: t.accent,
+                flexShrink: 0,
+              }}
+            />
+          )}
+          {statusText}
+        </span>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 8,
+            flexShrink: 0,
+          }}
+        >
+          {hasRaw && (
+            <button
+              type="button"
+              onClick={() => setShowRaw((v) => !v)}
+              title={
+                showRaw
+                  ? "Hide server-managed fields (managedFields, status, resourceVersion, …)"
+                  : "Show server-managed fields (managedFields, status, resourceVersion, …)"
+              }
+              style={toggleBtnStyle(t, showRaw)}
+            >
+              {showRaw ? "Editing view" : "Server fields"}
+            </button>
+          )}
+          {buffer !== null && !showRaw && (
+            // Available whenever the draft has diverged — including when the
+            // YAML no longer parses, so a typo is always recoverable.
+            <button
+              type="button"
+              onClick={discard}
+              disabled={saving}
+              title="Discard your edits and return to the server copy"
+              style={chipBtnStyle(t, "ghost", saving)}
+            >
+              Discard
+            </button>
+          )}
+          {editable && !showRaw && (
+            <button
+              type="button"
+              onClick={() => save(false)}
+              disabled={!canSave}
+              title={
+                dirty
+                  ? "Apply your changes (kubectl edit-style merge patch)"
+                  : "No changes to save"
+              }
+              style={chipBtnStyle(t, "primary", !canSave)}
+            >
+              {saving
+                ? "Saving…"
+                : dirty
+                  ? `Save (${diff.count})`
+                  : "Save"}
+            </button>
+          )}
+        </span>
+      </div>
+
+      {error && (
+        <div
+          style={{
+            padding: "8px 14px",
+            background: "rgba(244,63,94,0.1)",
+            borderBottom: `1px solid ${t.borderSoft}`,
+            flexShrink: 0,
+          }}
+        >
+          <ErrorBlock
+            t={t}
+            message={error}
+            kindLabel={kindLabel}
+            verb="save"
+            inline
+          />
+        </div>
+      )}
+
+      {stale && (
+        <div style={{ padding: "10px 14px 0", flexShrink: 0 }}>
+          <StaleBanner
+            t={t}
+            message={stale.message}
+            saving={saving}
+            onReload={reload}
+            onApplyAnyway={() => save(true)}
+          />
+        </div>
+      )}
+
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <Editor
+          height="100%"
+          language="yaml"
+          theme={mode === "dark" ? "vs-dark" : "light"}
+          value={value}
+          onChange={(next) => {
+            if (showRaw || saving) return;
+            setBuffer(next ?? "");
+          }}
+          onMount={installClipboardShortcuts}
+          options={{
+            readOnly: showRaw || saving || !editable,
+            minimap: { enabled: false },
+            fontSize: 12.5,
+            fontFamily: monoFont,
+            wordWrap: "on",
+            scrollBeyondLastLine: false,
+            renderLineHighlight: "none",
+            folding: true,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// Stale-conflict surface: the object changed on the server since the operator
+// opened it. They either reload (discard their edits, take the new copy) or
+// apply anyway (re-send the merge patch without the resourceVersion guard —
+// only the fields they touched are overwritten, concurrent edits to other
+// fields survive).
+function StaleBanner({
+  t,
+  message,
+  saving,
+  onReload,
+  onApplyAnyway,
+}: {
+  t: Tokens;
+  message: string;
+  saving: boolean;
+  onReload: () => void;
+  onApplyAnyway: () => void;
+}) {
+  return (
+    <div
+      style={{
+        margin: "0 0 12px",
+        padding: "10px 12px",
+        background: "rgba(245,158,11,0.12)",
+        border: "1px solid rgba(245,158,11,0.4)",
+        borderRadius: R_SM,
+        color: t.text,
+        fontSize: FS_MD,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div style={{ display: "flex", gap: 8, alignItems: "baseline" }}>
+        <span style={{ color: t.warn, fontWeight: 700 }}>Object changed</span>
+        <span style={{ color: t.textDim }}>
+          since you opened it — saving would overwrite the newer copy
+        </span>
+      </div>
+      <div
+        style={{
+          fontSize: FS_SM,
+          color: t.textMuted,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+        }}
+      >
+        {message}
+      </div>
+      <div style={{ display: "flex", gap: 6 }}>
+        <button
+          type="button"
+          onClick={onReload}
+          disabled={saving}
+          style={chipBtnStyle(t, "ghost", saving)}
+        >
+          Reload
+        </button>
+        <button
+          type="button"
+          onClick={onApplyAnyway}
+          disabled={saving}
+          style={{
+            ...chipBtnStyle(t, "ghost", saving),
+            background: "rgba(244,63,94,0.16)",
+            color: t.bad,
+          }}
+        >
+          {saving ? "Applying…" : "Apply my changes anyway"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function toggleBtnStyle(t: Tokens, active: boolean): CSSProperties {
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: 6,
+    height: 22,
+    padding: "0 8px",
+    borderRadius: R_SM,
+    border: "none",
+    background: active ? t.accentSoft : t.chip,
+    color: active ? t.accent : t.textDim,
+    fontFamily: FF_MONO,
+    fontSize: FS_SM,
+    fontWeight: 700,
+    letterSpacing: 0.4,
+    cursor: "pointer",
+    textTransform: "uppercase",
+  };
+}
+
+function chipBtnStyle(
+  t: Tokens,
+  variant: "primary" | "ghost",
+  disabled: boolean,
+): CSSProperties {
+  const base: CSSProperties = {
+    height: 22,
+    padding: "0 10px",
+    borderRadius: R_SM,
+    border: "none",
+    fontFamily: FF_MONO,
+    fontSize: FS_SM,
+    fontWeight: 700,
+    letterSpacing: 0.4,
+    textTransform: "uppercase",
+    cursor: disabled ? "not-allowed" : "pointer",
+  };
+  if (variant === "primary") {
+    // Match the codebase's Save convention (soft-green `good` tone) so the
+    // YAML save reads the same as the structured editors' Save chips.
+    return disabled
+      ? { ...base, background: t.chip, color: t.textMuted }
+      : { ...base, background: "rgba(16,185,129,0.16)", color: t.good };
+  }
+  return { ...base, background: t.chip, color: t.textDim, opacity: disabled ? 0.5 : 1 };
+}
+
+function timeAgo(then: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (s < 5) return "just now";
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.floor(m / 60)}h ago`;
+}

--- a/ui/src/lib/yamlEdit.test.ts
+++ b/ui/src/lib/yamlEdit.test.ts
@@ -1,13 +1,13 @@
-// `stripServerFields` and `diffPartial` are the engine behind the YAML
-// editor's "save only what changed" behavior. Both have shape-sensitive
-// branches (metadata pruning, identity stripping, the
-// "only-deletions" warning path) — exactly the kind of thing that drifts
+// `stripServerFields` and `mergePatch` are the engine behind the YAML
+// editor's "edit and save like kubectl edit" behavior. Both have
+// shape-sensitive branches (metadata pruning, identity stripping, removals
+// becoming explicit `null`s) — exactly the kind of thing that drifts
 // silently when someone tweaks the implementation.
 
 import { describe, it, expect } from "vitest";
 import {
-  diffPartial,
   dumpYaml,
+  mergePatch,
   parseYaml,
   stripServerFields,
   stripYaml,
@@ -103,43 +103,39 @@ describe("parseYaml / dumpYaml / stripYaml", () => {
   });
 });
 
-describe("diffPartial — modifications", () => {
-  it("empty diff for identical inputs", () => {
+describe("mergePatch — modifications", () => {
+  it("empty patch for identical inputs", () => {
     const a = cm();
-    const r = diffPartial(a, a);
+    const r = mergePatch(a, a);
     expect(r.empty).toBe(true);
-    expect(r.onlyDeletions).toBe(false);
     expect(r.count).toBe(0);
-    expect(r.partial).toEqual({});
+    expect(r.patch).toEqual({});
   });
 
   it("changing a single nested scalar emits only the touched subtree", () => {
     const a = cm();
     const b = cm({ data: { KEY: "B" } });
-    const r = diffPartial(a, b);
+    const r = mergePatch(a, b);
     expect(r.empty).toBe(false);
-    expect(r.onlyDeletions).toBe(false);
     expect(r.count).toBe(1);
-    expect(r.partial).toEqual({ data: { KEY: "B" } });
+    expect(r.patch).toEqual({ data: { KEY: "B" } });
   });
 
   it("adding a new key under an existing object yields that key alone", () => {
     const a: Json = { spec: { replicas: 3 } };
     const b: Json = { spec: { replicas: 3, paused: true } };
-    const r = diffPartial(a, b);
-    expect(r.partial).toEqual({ spec: { paused: true } });
+    const r = mergePatch(a, b);
+    expect(r.patch).toEqual({ spec: { paused: true } });
     expect(r.count).toBe(1);
   });
 
-  it("array changes are replaced wholesale (we don't know the listType)", () => {
+  it("array changes are replaced wholesale (merge-patch has no list keys)", () => {
     const a: Json = { spec: { containers: [{ name: "c1" }] } };
     const b: Json = {
       spec: { containers: [{ name: "c1" }, { name: "c2" }] },
     };
-    const r = diffPartial(a, b);
-    // Whole containers array must appear in the partial — we can't express
-    // a per-element listType:map merge in this codepath.
-    expect(r.partial).toEqual({
+    const r = mergePatch(a, b);
+    expect(r.patch).toEqual({
       spec: { containers: [{ name: "c1" }, { name: "c2" }] },
     });
     expect(r.count).toBe(1);
@@ -148,16 +144,16 @@ describe("diffPartial — modifications", () => {
   it("type change (object → scalar) counts as a single change", () => {
     const a: Json = { spec: { replicas: 3 } };
     const b: Json = { spec: 3 };
-    const r = diffPartial(a, b);
-    expect(r.partial).toEqual({ spec: 3 });
+    const r = mergePatch(a, b);
+    expect(r.patch).toEqual({ spec: 3 });
     expect(r.count).toBe(1);
   });
 });
 
-describe("diffPartial — identity stripping", () => {
-  it("apiVersion / kind / metadata.name / metadata.namespace are never claimed", () => {
+describe("mergePatch — identity stripping", () => {
+  it("apiVersion / kind / metadata.name / metadata.namespace are never patched", () => {
     // Build inputs that differ ONLY in identity fields — anything else and
-    // the rest of the diff would show up.
+    // the rest of the patch would show up.
     const a: Json = {
       apiVersion: "v1",
       kind: "ConfigMap",
@@ -170,12 +166,10 @@ describe("diffPartial — identity stripping", () => {
       metadata: { name: "hello-renamed", namespace: "other" },
       data: { K: "V" },
     };
-    const r = diffPartial(a, b);
-    // None of the four identity fields appear in the partial.
-    expect("apiVersion" in r.partial).toBe(false);
-    expect("kind" in r.partial).toBe(false);
-    expect(r.partial.metadata).toBeUndefined();
-    // No spec changes → diff is empty (we don't claim identity).
+    const r = mergePatch(a, b);
+    expect("apiVersion" in r.patch).toBe(false);
+    expect("kind" in r.patch).toBe(false);
+    expect(r.patch.metadata).toBeUndefined();
     expect(r.empty).toBe(true);
   });
 
@@ -192,30 +186,71 @@ describe("diffPartial — identity stripping", () => {
       metadata: { name: "x", labels: { app: "b" } },
       data: { K: "V" },
     };
-    const r = diffPartial(a, b);
-    expect(r.partial).toEqual({ metadata: { labels: { app: "b" } } });
+    const r = mergePatch(a, b);
+    expect(r.patch).toEqual({ metadata: { labels: { app: "b" } } });
     expect(r.count).toBe(1);
   });
 });
 
-describe("diffPartial — deletions", () => {
-  it("only-deletions case is flagged but produces an empty partial", () => {
+describe("mergePatch — deletions and empty values", () => {
+  it("removing a key emits an explicit null so merge-patch deletes it", () => {
     const a: Json = { data: { KEEP: "yes", DROP: "drop-me" } };
     const b: Json = { data: { KEEP: "yes" } };
-    const r = diffPartial(a, b);
+    const r = mergePatch(a, b);
     expect(r.empty).toBe(false);
-    expect(r.onlyDeletions).toBe(true);
-    expect(r.count).toBe(0);
-    expect(r.partial).toEqual({});
+    expect(r.count).toBe(1);
+    expect(r.patch).toEqual({ data: { DROP: null } });
   });
 
-  it("mixed add + remove still emits the add and is NOT flagged as only-deletions", () => {
+  it("mixed add + remove emits both the add and the null deletion", () => {
     const a: Json = { data: { KEEP: "yes", DROP: "old" } };
     const b: Json = { data: { KEEP: "yes", ADDED: "new" } };
-    const r = diffPartial(a, b);
-    expect(r.onlyDeletions).toBe(false);
+    const r = mergePatch(a, b);
     expect(r.empty).toBe(false);
-    expect(r.partial).toEqual({ data: { ADDED: "new" } });
+    expect(r.patch).toEqual({ data: { ADDED: "new", DROP: null } });
+    expect(r.count).toBe(2);
+  });
+
+  it("blanking a value to YAML null deletes the field", () => {
+    // `replicas:` with nothing after it parses to null.
+    const a: Json = { spec: { replicas: 3 } };
+    const b: Json = { spec: { replicas: null } };
+    const r = mergePatch(a, b);
+    expect(r.patch).toEqual({ spec: { replicas: null } });
+    expect(r.count).toBe(1);
+  });
+
+  it("an explicit empty string is preserved, distinct from deletion", () => {
+    const a: Json = { data: { KEY: "value" } };
+    const b: Json = { data: { KEY: "" } };
+    const r = mergePatch(a, b);
+    expect(r.patch).toEqual({ data: { KEY: "" } });
+    expect(r.count).toBe(1);
+  });
+
+  it("never nulls the top-level metadata block even if the editor drops it", () => {
+    const a: Json = {
+      apiVersion: "v1",
+      kind: "ConfigMap",
+      metadata: { name: "x", labels: { app: "a" } },
+      data: { K: "V" },
+    };
+    // Operator deleted the whole metadata block; only data remains.
+    const b: Json = { apiVersion: "v1", kind: "ConfigMap", data: { K: "V2" } };
+    const r = mergePatch(a, b);
+    // metadata must not appear as a null — that would be a destructive,
+    // rejected patch. Only the real data change is emitted.
+    expect("metadata" in r.patch).toBe(false);
+    expect(r.patch).toEqual({ data: { K: "V2" } });
+  });
+
+  it("removing a single metadata child (a label) still nulls it", () => {
+    const a: Json = {
+      metadata: { name: "x", labels: { app: "a", team: "x" } },
+    };
+    const b: Json = { metadata: { name: "x", labels: { app: "a" } } };
+    const r = mergePatch(a, b);
+    expect(r.patch).toEqual({ metadata: { labels: { team: null } } });
     expect(r.count).toBe(1);
   });
 });

--- a/ui/src/lib/yamlEdit.ts
+++ b/ui/src/lib/yamlEdit.ts
@@ -3,13 +3,20 @@
 // Two responsibilities:
 //   • `stripServerFields` — remove fields the apiserver writes back so the
 //     operator sees source-like YAML (no managedFields noise, no status).
-//   • `diffPartial` — compute the minimal partial-object subtree the user
-//     actually changed, so SSA only takes ownership of touched fields.
+//   • `mergePatch` — compute an RFC 7386 JSON merge patch from the original
+//     vs the edited document, so a single PATCH expresses adds, edits *and*
+//     removals. The YAML tab follows the `kubectl edit` model rather than
+//     Server-Side Apply (which the structured per-field editors use).
 //
-// SSA caveat: dropping a key from the edited document does NOT request
-// deletion — it just declines ownership. Adds and modifications work as
-// expected; explicit removal is out of scope for v1 of this editor and
-// surfaced via `diffHasOnlyDeletions` so the UI can warn.
+// Merge-patch semantics the operator gets from this:
+//   • changed scalar / array → new value replaces the old wholesale.
+//   • added key → set.
+//   • removed key → emitted as `null`, which deletes the field server-side.
+//   • blanked value (`key:` → YAML null) → also `null` → deletes the field.
+//     Use `key: ""` for an explicit empty string (preserved as-is).
+// This is the deliberate divergence from the SSA path: SSA partial trees
+// can't express deletion by omission, which is why removals and empties
+// silently no-op'd under the old `diffPartial`.
 
 import jsYaml from "js-yaml";
 
@@ -90,24 +97,24 @@ export function stripYaml(text: string): string {
 }
 
 // Result of diffing original vs edited stripped JSON.
-export type DiffResult = {
-  // Minimal partial-object subtree containing only modified or added paths.
-  // Suitable as `fields` for apply_resource_cmd. Empty object if nothing
-  // changed.
-  partial: Record<string, Json>;
-  // True if the diff is a no-op (semantically equal documents).
+export type MergePatch = {
+  // RFC 7386 merge patch: object fields are merged recursively, `null`
+  // values delete the field, everything else replaces. Ready to hand to
+  // `merge_patch_resource_cmd`. Empty object when nothing changed.
+  patch: Record<string, Json>;
+  // True if the patch is a no-op (semantically equal documents).
   empty: boolean;
-  // True if the operator's only changes are key removals — none of which
-  // can be expressed via this SSA partial-tree approach. The UI surfaces a
-  // warning so the operator isn't confused when Save appears to do nothing.
-  onlyDeletions: boolean;
-  // Number of touched paths — drives the "Save (N)" chip.
+  // Number of touched leaf paths (adds + edits + removals) — drives the
+  // "Save (N)" chip. Unlike the old partial-diff, removals count here
+  // because they actually apply.
   count: number;
 };
 
-// Strip identity fields the backend re-attaches itself — we don't want to
-// claim ownership of `apiVersion`, `kind`, `metadata.name`,
-// `metadata.namespace` even if Monaco round-trips them unchanged.
+// Strip identity fields the backend re-attaches itself — we never want to
+// patch `apiVersion`, `kind`, `metadata.name`, `metadata.namespace`. A merge
+// patch that nulled `metadata.name` (operator deleted the line) would be a
+// rename attempt the apiserver rejects; dropping them keeps edits focused on
+// spec / data / labels.
 const IDENTITY_KEYS = new Set(["apiVersion", "kind"]);
 const META_IDENTITY_KEYS = new Set(["name", "namespace"]);
 
@@ -130,67 +137,70 @@ function stripIdentity(doc: Json): Json {
   return out;
 }
 
-export function diffPartial(originalRaw: Json, editedRaw: Json): DiffResult {
+export function mergePatch(originalRaw: Json, editedRaw: Json): MergePatch {
   const original = stripIdentity(originalRaw);
   const edited = stripIdentity(editedRaw);
 
-  const stats = { changed: 0, deletions: 0 };
-  const partial = walkDiff(original, edited, stats);
+  const stats = { count: 0 };
+  const patch = walkMerge(original, edited, stats, true);
   const obj: Record<string, Json> =
-    partial !== UNCHANGED && isObject(partial) ? partial : {};
-  const empty = stats.changed === 0 && stats.deletions === 0;
-  const onlyDeletions = stats.changed === 0 && stats.deletions > 0;
-  return {
-    partial: obj,
-    empty,
-    onlyDeletions,
-    count: stats.changed,
-  };
+    patch !== UNCHANGED && isObject(patch) ? patch : {};
+  return { patch: obj, empty: stats.count === 0, count: stats.count };
 }
 
-// Walk both trees together. Returns the minimal subtree of `edited` that
-// represents adds + modifications relative to `original`. Returns the
-// sentinel `UNCHANGED` when nothing changed in this subtree.
+// Walk both trees together, producing the RFC 7386 merge patch from
+// `original` → `edited`. Returns the sentinel `UNCHANGED` when nothing
+// changed in this subtree so unchanged branches drop out of the patch.
 const UNCHANGED: unique symbol = Symbol("unchanged");
 type WalkResult = Json | typeof UNCHANGED;
 
-function walkDiff(
+function walkMerge(
   original: Json,
   edited: Json,
-  stats: { changed: number; deletions: number },
+  stats: { count: number },
+  topLevel: boolean,
 ): WalkResult {
   if (deepEqual(original, edited)) return UNCHANGED;
 
-  // Object × object → per-key diff.
+  // Object × object → per-key merge.
   if (isObject(original) && isObject(edited)) {
     const out: Record<string, Json> = {};
     let touched = 0;
     for (const [k, v] of Object.entries(edited)) {
       if (!(k in original)) {
-        // New key.
+        // New key — set it.
         out[k] = v;
-        stats.changed += 1;
+        stats.count += 1;
         touched += 1;
         continue;
       }
-      const sub = walkDiff(original[k]!, v, stats);
+      const sub = walkMerge(original[k]!, v, stats, false);
       if (sub !== UNCHANGED) {
         out[k] = sub;
         touched += 1;
       }
     }
-    // Track removed keys for the "only deletions" warning. They don't go
-    // into `out` — SSA partial trees can't express deletion this way.
+    // Removed keys → explicit `null` so merge-patch deletes them. We refuse
+    // to null the top-level `metadata` block: it carries identity + the
+    // resourceVersion the backend injects, so deleting it wholesale is never
+    // what the operator means (and the apiserver would reject it). Removing
+    // individual metadata children (labels, annotations, a finalizer) still
+    // works because that recurses one level deeper.
     for (const k of Object.keys(original)) {
-      if (!(k in edited)) stats.deletions += 1;
+      if (k in edited) continue;
+      if (topLevel && k === "metadata") continue;
+      out[k] = null;
+      stats.count += 1;
+      touched += 1;
     }
     return touched === 0 ? UNCHANGED : out;
   }
 
-  // Anything else (scalar change, array change, type change): the leaf is
-  // the new value as-is. Arrays are replaced wholesale because we don't
-  // know each list's `listType` (map / set / atomic) without the schema.
-  stats.changed += 1;
+  // Anything else (scalar change, array change, type change): the leaf
+  // replaces wholesale. Arrays are replaced rather than element-merged —
+  // merge-patch has no concept of list keys, matching the operator's mental
+  // model of "what I typed is what gets stored".
+  stats.count += 1;
   return edited;
 }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -1926,6 +1926,15 @@ export type ApplyResult =
   | { kind: "applied"; resource_version: string | null }
   | ({ kind: "conflict" } & Omit<ApplyConflict, "conflict">);
 
+// ── Merge-patch (kubectl edit) result ──────────────────────────────────────
+//
+// The YAML manifest tab saves via an RFC 7386 JSON merge patch rather than
+// SSA, so its conflict mode is different: not per-field ownership, but a
+// stale `resourceVersion` (the object changed since the operator opened it).
+export type MergePatchResult =
+  | { kind: "applied"; resource_version: string | null }
+  | { kind: "stale"; message: string };
+
 // Per-doc result from the multi-doc YAML apply path. Tagged on `status`.
 export type DocApplyResult =
   | {


### PR DESCRIPTION
The YAML tab used a partial-diff SSA model (`diffPartial` -> `apply_resource`) that couldn't express deletions or empty values and required a pencil click to edit. Removing a field silently no-op'd, blanking a value mis-saved, and the "force takeover" path re-applied an empty patch.

Switch the manifest editor to the `kubectl edit` model:

- `lib/yamlEdit.ts`: replace `diffPartial` with `mergePatch` — an RFC 7386 merge patch that emits `null` for removed keys (delete) and preserves `""` (empty string). Never nulls the top-level metadata block.
- Backend `merge_patch_resource` / `merge_patch_resource_cmd`: `Patch::Merge` carrying `metadata.resourceVersion` for optimistic concurrency -> `Applied` or `Stale`. Pure body-builder helper is unit-tested.
- New `detail/YamlTab.tsx`: always-editable, Save (N) / Discard chrome, a stale-conflict banner (Reload / Apply anyway) replacing the broken force prompt, and a frozen edit baseline so live watcher refetches can't rebase the diff or refresh the version out from under the lock.

Tests: merge-patch engine (deletions/empties/identity/metadata guard), api command shape, backend envelope builder, and 6 YamlTab interaction tests (always-editable, save wiring, baseline freeze, stale->apply-anyway, discard, server-fields toggle). Documents the deliberate SSA divergence in CLAUDE.md.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
