### PR TITLE
feat(watcher): always-on namespaces pin + relist reconcile

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -533,6 +533,12 @@ pub(crate) async fn connect_context(
             // subscribe before connect_context). Cheap no-op if already
             // claimed by an earlier command.
             wire_cluster_health(&app, &name, entry.clone());
+            // Hold one internal subscriber on `(cluster, "namespaces", All)`
+            // for the entry's lifetime so the top-right namespace dropdown
+            // stays live across cluster reconnects and React lifecycle
+            // races. CAS-gated; no-op on a StrictMode double-fire. See
+            // `pin_cluster_namespaces`.
+            pin_cluster_namespaces(&app, &name);
             // Connect-time probes (cluster.info background fetch + bench)
             // run exactly once per cluster. The CAS in `claim_connect_probes`
             // guarantees that even if `connect_context` fires twice (React
@@ -677,6 +683,57 @@ fn wire_cluster_health(app: &AppHandle, cluster_id: &str, entry: Arc<crate::stat
             old.abort();
         }
     }
+}
+
+/// Install an always-on internal subscriber on `(cluster, "namespaces", All)`
+/// so the reflector stays alive for the lifetime of the entry. The top-right
+/// namespace dropdown (and any other UI that wants a live namespace list)
+/// then sees deltas immediately without depending on the frontend keeping
+/// its own subscription alive across cluster reconnects / React lifecycle
+/// quirks / 60 s linger windows. The internal subscriber count is released
+/// implicitly when `drop_cluster_watchers` / `tear_down_unhealthy` force-
+/// abort every watcher and the entry is removed; a fresh `connect_context`
+/// re-fires this on the rebuilt entry.
+///
+/// CAS-gated so a duplicate `connect_context` (StrictMode double-fire, fast
+/// operator click) doesn't add a second pin and leak one subscriber count
+/// past teardown. The actual subscribe runs in a spawned task so this
+/// helper stays non-async and the caller (a connect path that already paid
+/// for client / TLS / probe round trips) doesn't have to wait on the
+/// slot-bump round trip.
+fn pin_cluster_namespaces(app: &AppHandle, cluster_id: &str) {
+    let app = app.clone();
+    let cluster_id = cluster_id.to_owned();
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<AppState>();
+        // Capture the entry Arc here and reuse it for the subscribe.
+        // Going through `subscribe_resource_inner` (which calls
+        // `state.entry()`) would lazy-reconnect if the operator
+        // disconnected between our spawn and this point — leaking a
+        // new entry whose `namespaces_pinned` we can't claim (we
+        // already claimed on the now-gone entry) and whose watcher
+        // would run forever with no UI consumer.
+        let Some(entry) = state.get_existing(&cluster_id).await else {
+            return;
+        };
+        if !entry.claim_namespaces_pinning() {
+            return;
+        }
+        if let Err(e) =
+            subscribe_resource_with_entry(&cluster_id, "namespaces", None, &app, &state, entry)
+                .await
+        {
+            // Lazy-failure rather than hard-failure: the frontend's
+            // belt-and-braces App.tsx subscribe will still try its own
+            // path. Worth a warn so the operator can correlate the
+            // top-right going stale with the underlying cluster issue.
+            tracing::warn!(
+                error = %e,
+                cluster_id = %cluster_id,
+                "pin_cluster_namespaces: internal subscribe failed"
+            );
+        }
+    });
 }
 
 /// Update the fleet cache entry for `cluster_id` with the latest
@@ -841,14 +898,51 @@ pub(crate) async fn subscribe_resource(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> Result<SubscribeResult, String> {
+    subscribe_resource_inner(&cluster_id, &kind_id, namespaces.as_deref(), &app, &state).await
+}
+
+/// Body of `subscribe_resource` parameterised over borrowed types so
+/// internal callers (the always-on namespaces pin) can share the
+/// slot-bump / forwarder-spawn logic without going through Tauri's
+/// command dispatch. The `#[tauri::command]` wrapper above is a thin
+/// adapter — no logic of its own. Lazy-resolves the entry (this is
+/// the eager App.tsx-subscribe path that fires before
+/// `connect_context`); callers that already hold the entry and
+/// must NOT lazy-reconnect (the namespaces pin, racing against a
+/// cluster disconnect) should use `subscribe_resource_with_entry`.
+pub(crate) async fn subscribe_resource_inner(
+    cluster_id: &str,
+    kind_id: &str,
+    namespaces: Option<&[String]>,
+    app: &AppHandle,
+    state: &AppState,
+) -> Result<SubscribeResult, String> {
+    let entry = state.entry(cluster_id).await?;
+    subscribe_resource_with_entry(cluster_id, kind_id, namespaces, app, state, entry).await
+}
+
+/// Slot-bump / forwarder-spawn for an already-resolved
+/// `Arc<ClusterEntry>`. Use this when you've non-creatingly looked
+/// up the entry (via `state.get_existing`) and want to *avoid* the
+/// lazy-reconnect path inside `state.entry()` — typically because
+/// you're racing a teardown and a reconnect would leak the new
+/// entry. The Tauri-facing `subscribe_resource_inner` is a thin
+/// lazy-resolve wrapper over this.
+pub(crate) async fn subscribe_resource_with_entry(
+    cluster_id: &str,
+    kind_id: &str,
+    namespaces: Option<&[String]>,
+    app: &AppHandle,
+    state: &AppState,
+    entry: Arc<crate::state::ClusterEntry>,
+) -> Result<SubscribeResult, String> {
     let started = std::time::Instant::now();
-    let kind = lookup(&kind_id).ok_or_else(|| format!("unknown kind: {kind_id}"))?;
-    let entry = state.entry(&cluster_id).await?;
+    let kind = lookup(kind_id).ok_or_else(|| format!("unknown kind: {kind_id}"))?;
     // Lazy-connect callers (App's eager namespaces subscribe runs
     // before connect_context) need the health forwarder wired here so
     // probe events reach the UI. CAS-guarded — cheap no-op when
     // connect_context has already wired it.
-    wire_cluster_health(&app, &cluster_id, entry.clone());
+    wire_cluster_health(app, cluster_id, entry.clone());
     if entry.unavailable.load(Ordering::SeqCst) {
         // Cluster has been declared unavailable by the health probe and
         // its watchers + metrics service have been torn down. Refuse to
@@ -863,13 +957,13 @@ pub(crate) async fn subscribe_resource(
     // Cluster-scoped kinds ignore the selection upstream (the registry
     // coerces to `All`), so it doesn't hurt to pass the raw scope here
     // — the registry's `from_*_spec` closures do the right thing.
-    let scope = match namespaces.as_deref() {
+    let scope = match namespaces {
         Some(list) if kind.meta.namespaced => ferrisscope_kube_ext::NsScope::from_selection(list),
         _ => ferrisscope_kube_ext::NsScope::All,
     };
     let after_entry = started.elapsed().as_millis() as u64;
     let mut slots = entry.kinds.lock().await;
-    let slot_key = (kind_id.clone(), scope.clone());
+    let slot_key = (kind_id.to_owned(), scope.clone());
     let slot = slots
         .entry(slot_key.clone())
         .or_insert_with(KindSlot::empty);
@@ -899,11 +993,11 @@ pub(crate) async fn subscribe_resource(
         // fully-browsed UI. The pool is the middle ground.
         let client = entry.cluster.watcher_client();
         let w = (kind.start)(client, scope.clone(), strategy);
-        let search_index = state.search_index_for(&cluster_id).await;
+        let search_index = state.search_index_for(cluster_id).await;
         spawn_resource_forwarder(
             app.clone(),
-            cluster_id.clone(),
-            kind_id.clone(),
+            cluster_id.to_owned(),
+            kind_id.to_owned(),
             scope.clone(),
             w.clone(),
             search_index,

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -69,6 +69,17 @@ pub(crate) struct ClusterEntry {
     /// by `state.entry()` rather than `connect_context`). Same CAS
     /// pattern: true on first claim, false thereafter.
     health_wired: AtomicBool,
+    /// One-shot guard for the always-on namespaces subscription. Holds
+    /// a single internal subscriber on `(cluster, "namespaces", All)`
+    /// for the lifetime of the entry so the reflector survives across
+    /// modal-open / kind-flip cycles — the top-right namespace dropdown
+    /// would otherwise go stale whenever the frontend's eager subscribe
+    /// lost the watcher (transient unavailable, React lifecycle race,
+    /// linger expiry). The subscription is released implicitly when
+    /// `drop_cluster_watchers` / `tear_down_unhealthy` force-abort all
+    /// watchers and the entry is removed; a fresh `connect_context`
+    /// re-fires this on the new entry.
+    namespaces_pinned: AtomicBool,
     /// JoinHandle for the health-event forwarder task spawned by
     /// `spawn_health_forwarder`. Stored here so `drop_cluster_watchers`
     /// / `tear_down_unhealthy` can abort it explicitly on teardown.
@@ -118,6 +129,16 @@ impl ClusterEntry {
     /// the lazy-connect path too (App's eager namespaces subscribe).
     pub(crate) fn claim_health_wiring(&self) -> bool {
         self.health_wired
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    /// Atomically claim the right to install the always-on namespaces
+    /// subscription. Returns `true` exactly once per `ClusterEntry`
+    /// lifetime; subsequent callers no-op. See `namespaces_pinned` for
+    /// the rationale.
+    pub(crate) fn claim_namespaces_pinning(&self) -> bool {
+        self.namespaces_pinned
             .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
             .is_ok()
     }
@@ -270,6 +291,7 @@ impl AppState {
             unavailable: AtomicBool::new(false),
             connect_probes_done: AtomicBool::new(false),
             health_wired: AtomicBool::new(false),
+            namespaces_pinned: AtomicBool::new(false),
             health_forwarder: std::sync::Mutex::new(None),
             metrics_forwarder: std::sync::Mutex::new(None),
         });
@@ -309,6 +331,7 @@ impl AppState {
             unavailable: AtomicBool::new(false),
             connect_probes_done: AtomicBool::new(false),
             health_wired: AtomicBool::new(false),
+            namespaces_pinned: AtomicBool::new(false),
             health_forwarder: std::sync::Mutex::new(None),
             metrics_forwarder: std::sync::Mutex::new(None),
         });
@@ -367,5 +390,52 @@ impl AppState {
     /// deltas, the Tauri search command) must handle this gracefully.
     pub(crate) async fn search_index_for(&self, id: &str) -> Option<Arc<SearchIndex>> {
         self.search_indices.lock().await.get(id).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// Mirrors the CAS used by every `ClusterEntry::claim_*` method
+    /// (`claim_connect_probes`, `claim_health_wiring`,
+    /// `claim_namespaces_pinning`). Synthetic because constructing a real
+    /// `ClusterEntry` requires a live `Cluster` + `ClusterHealth` (real
+    /// kube `Client`) — that path is exercised end-to-end by the
+    /// kind-backed integration suite. This test pins the *contract* the
+    /// claim methods rely on: first caller wins, every subsequent caller
+    /// observes the flag set and no-ops. Catches future regressions like
+    /// accidentally weakening the `Ordering` or swapping the expected
+    /// value.
+    fn cas_one_shot(flag: &AtomicBool) -> bool {
+        flag.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+    }
+
+    #[test]
+    fn claim_pattern_is_one_shot() {
+        let f = AtomicBool::new(false);
+        assert!(cas_one_shot(&f), "first claim must succeed");
+        assert!(!cas_one_shot(&f), "second claim must observe set + fail");
+        assert!(!cas_one_shot(&f), "third claim still fails");
+    }
+
+    #[test]
+    fn claim_pattern_concurrent_claims_pick_exactly_one_winner() {
+        // Two claims racing on the same flag — exactly one must win.
+        // Models a `StrictMode` double-fire or a fast `connect_context`
+        // followed by an `App.tsx` lazy-connect arriving on a parallel
+        // task.
+        let f = std::sync::Arc::new(AtomicBool::new(false));
+        let f1 = f.clone();
+        let f2 = f.clone();
+        let h1 = std::thread::spawn(move || cas_one_shot(&f1));
+        let h2 = std::thread::spawn(move || cas_one_shot(&f2));
+        let r1 = h1.join().unwrap();
+        let r2 = h2.join().unwrap();
+        assert!(
+            r1 ^ r2,
+            "exactly one caller must win (xor): r1={r1} r2={r2}"
+        );
     }
 }

--- a/crates/kube-ext/src/watcher.rs
+++ b/crates/kube-ext/src/watcher.rs
@@ -366,51 +366,18 @@ impl ResourceWatcher {
             let mut applied = 0u64;
             let mut suppressed = 0u64;
             let mut first_apply_logged = false;
+            // Uids observed during the current Init→InitDone window. Allocated
+            // when Init fires, drained on InitDone to reconcile the cache:
+            // anything present locally but absent from the new LIST is a
+            // delete-while-disconnected (sleep/wake, 410 Gone resync). kube-rs
+            // never replays Delete for missing items — it just LISTs current
+            // state — so without this we'd carry ghost rows until the next
+            // teardown.
+            let mut init_seen: Option<HashSet<String>> = None;
             while let Some(event) = stream.next().await {
-                match event {
-                    Ok(watcher::Event::Apply(obj) | watcher::Event::InitApply(obj)) => {
-                        let Some(uid) = obj.uid() else { continue };
-                        let row = with_uid(uid.clone(), S::project(&obj));
-                        // Drop the typed object as soon as projection is done.
-                        drop(obj);
-                        // No-op suppression: if the projected row is byte-
-                        // identical to the last one we cached for this uid,
-                        // skip the broadcast. Catches kube-rs resync after a
-                        // 410 Gone (re-emits every object as InitApply, most
-                        // unchanged) and the steady-state churn from server-
-                        // side fields the projection deliberately drops
-                        // (managedFields, resourceVersion, lastTransitionTime
-                        // bumps that don't move any column). One Value::eq
-                        // walk is orders of magnitude cheaper than the IPC
-                        // emit + JSON-decode + React reconciliation we'd
-                        // otherwise pay downstream.
-                        let mut cache = cache_task.lock().expect("watcher cache poisoned");
-                        let unchanged = cache.get(&uid).is_some_and(|prev| prev == &row);
-                        if unchanged {
-                            suppressed += 1;
-                        } else {
-                            cache.insert(uid.clone(), row.clone());
-                            drop(cache);
-                            dirty_task.record_upsert(uid, row);
-                        }
-                        applied += 1;
-                        if !first_apply_logged {
-                            first_apply_logged = true;
-                            tracing::info!(
-                                kind = S::meta().id,
-                                elapsed_ms = started.elapsed().as_millis() as u64,
-                                "watcher: first apply (apiserver returned first object)"
-                            );
-                        } else if applied.is_multiple_of(50) {
-                            tracing::debug!(
-                                kind = S::meta().id,
-                                elapsed_ms = started.elapsed().as_millis() as u64,
-                                applied,
-                                suppressed,
-                                "watcher: apply progress"
-                            );
-                        }
-                    }
+                let (obj, is_init_apply) = match event {
+                    Ok(watcher::Event::Apply(o)) => (o, false),
+                    Ok(watcher::Event::InitApply(o)) => (o, true),
                     Ok(watcher::Event::Delete(obj)) => {
                         if let Some(uid) = obj.uid() {
                             tracing::debug!(
@@ -424,24 +391,78 @@ impl ResourceWatcher {
                                 .remove(&uid);
                             dirty_task.record_delete(uid);
                         }
+                        continue;
                     }
                     Ok(watcher::Event::Init) => {
                         tracing::debug!(kind = S::meta().id, "watcher: init");
+                        init_seen = Some(HashSet::new());
+                        continue;
                     }
                     Ok(watcher::Event::InitDone) => {
                         init_done_task.store(true, Ordering::SeqCst);
+                        let reconciled =
+                            reconcile_init_seen(&mut init_seen, &cache_task, &dirty_task);
                         tracing::info!(
                             kind = S::meta().id,
                             elapsed_ms = started.elapsed().as_millis() as u64,
                             applied,
                             suppressed,
+                            reconciled_deletes = reconciled,
                             "watcher: init done (initial sync complete)"
                         );
                         dirty_task.mark_init_done();
+                        continue;
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, kind = S::meta().id, "watcher: stream error");
+                        continue;
                     }
+                };
+                let Some(uid) = obj.uid() else { continue };
+                if is_init_apply {
+                    if let Some(seen) = init_seen.as_mut() {
+                        seen.insert(uid.clone());
+                    }
+                }
+                let row = with_uid(uid.clone(), S::project(&obj));
+                // Drop the typed object as soon as projection is done.
+                drop(obj);
+                // No-op suppression: if the projected row is byte-
+                // identical to the last one we cached for this uid,
+                // skip the broadcast. Catches kube-rs resync after a
+                // 410 Gone (re-emits every object as InitApply, most
+                // unchanged) and the steady-state churn from server-
+                // side fields the projection deliberately drops
+                // (managedFields, resourceVersion, lastTransitionTime
+                // bumps that don't move any column). One Value::eq
+                // walk is orders of magnitude cheaper than the IPC
+                // emit + JSON-decode + React reconciliation we'd
+                // otherwise pay downstream.
+                let mut cache = cache_task.lock().expect("watcher cache poisoned");
+                let unchanged = cache.get(&uid).is_some_and(|prev| prev == &row);
+                if unchanged {
+                    suppressed += 1;
+                } else {
+                    cache.insert(uid.clone(), row.clone());
+                    drop(cache);
+                    dirty_task.record_upsert(uid, row);
+                }
+                applied += 1;
+                if !first_apply_logged {
+                    first_apply_logged = true;
+                    tracing::info!(
+                        kind = S::meta().id,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "watcher: first apply (apiserver returned first object)"
+                    );
+                } else if applied.is_multiple_of(50) {
+                    tracing::debug!(
+                        kind = S::meta().id,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        applied,
+                        suppressed,
+                        "watcher: apply progress"
+                    );
                 }
             }
             tracing::info!(
@@ -519,45 +540,13 @@ impl ResourceWatcher {
             let mut suppressed = 0u64;
             let mut skipped_no_uid = 0u64;
             let mut first_apply_logged = false;
+            // See `start_with_api` for the rationale — same reconcile
+            // applies to CRD watches.
+            let mut init_seen: Option<HashSet<String>> = None;
             while let Some(event) = stream.next().await {
-                match event {
-                    Ok(watcher::Event::Apply(obj) | watcher::Event::InitApply(obj)) => {
-                        let Some(uid) = obj.uid() else {
-                            skipped_no_uid += 1;
-                            continue;
-                        };
-                        let row = with_uid(uid.clone(), project_task(&obj));
-                        // No-op suppression — see typed-watcher branch above
-                        // for the rationale. Same behaviour: cheap structural
-                        // equality on the projected row; on miss, update the
-                        // cache and broadcast; on hit, drop silently.
-                        let mut cache = cache_task.lock().expect("dynamic watcher cache poisoned");
-                        let unchanged = cache.get(&uid).is_some_and(|prev| prev == &row);
-                        if unchanged {
-                            suppressed += 1;
-                        } else {
-                            cache.insert(uid.clone(), row.clone());
-                            drop(cache);
-                            dirty_task.record_upsert(uid, row);
-                        }
-                        applied += 1;
-                        if !first_apply_logged {
-                            first_apply_logged = true;
-                            tracing::info!(
-                                kind = %log_id_task,
-                                elapsed_ms = started.elapsed().as_millis() as u64,
-                                "dynamic watcher: first apply"
-                            );
-                        } else if applied.is_multiple_of(50) {
-                            tracing::debug!(
-                                kind = %log_id_task,
-                                elapsed_ms = started.elapsed().as_millis() as u64,
-                                applied,
-                                suppressed,
-                                "dynamic watcher: apply progress"
-                            );
-                        }
-                    }
+                let (obj, is_init_apply) = match event {
+                    Ok(watcher::Event::Apply(o)) => (o, false),
+                    Ok(watcher::Event::InitApply(o)) => (o, true),
                     Ok(watcher::Event::Delete(obj)) => {
                         if let Some(uid) = obj.uid() {
                             cache_task
@@ -566,21 +555,28 @@ impl ResourceWatcher {
                                 .remove(&uid);
                             dirty_task.record_delete(uid);
                         }
+                        continue;
                     }
                     Ok(watcher::Event::Init) => {
                         tracing::debug!(kind = %log_id_task, "dynamic watcher: init");
+                        init_seen = Some(HashSet::new());
+                        continue;
                     }
                     Ok(watcher::Event::InitDone) => {
+                        let reconciled =
+                            reconcile_init_seen(&mut init_seen, &cache_task, &dirty_task);
                         tracing::info!(
                             kind = %log_id_task,
                             elapsed_ms = started.elapsed().as_millis() as u64,
                             applied,
                             suppressed,
                             skipped_no_uid,
+                            reconciled_deletes = reconciled,
                             "dynamic watcher: init done"
                         );
                         init_done_task.store(true, Ordering::SeqCst);
                         dirty_task.mark_init_done();
+                        continue;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -588,7 +584,48 @@ impl ResourceWatcher {
                             kind = %log_id_task,
                             "dynamic watcher: stream error"
                         );
+                        continue;
                     }
+                };
+                let Some(uid) = obj.uid() else {
+                    skipped_no_uid += 1;
+                    continue;
+                };
+                if is_init_apply {
+                    if let Some(seen) = init_seen.as_mut() {
+                        seen.insert(uid.clone());
+                    }
+                }
+                let row = with_uid(uid.clone(), project_task(&obj));
+                // No-op suppression — see typed-watcher branch above
+                // for the rationale. Same behaviour: cheap structural
+                // equality on the projected row; on miss, update the
+                // cache and broadcast; on hit, drop silently.
+                let mut cache = cache_task.lock().expect("dynamic watcher cache poisoned");
+                let unchanged = cache.get(&uid).is_some_and(|prev| prev == &row);
+                if unchanged {
+                    suppressed += 1;
+                } else {
+                    cache.insert(uid.clone(), row.clone());
+                    drop(cache);
+                    dirty_task.record_upsert(uid, row);
+                }
+                applied += 1;
+                if !first_apply_logged {
+                    first_apply_logged = true;
+                    tracing::info!(
+                        kind = %log_id_task,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "dynamic watcher: first apply"
+                    );
+                } else if applied.is_multiple_of(50) {
+                    tracing::debug!(
+                        kind = %log_id_task,
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        applied,
+                        suppressed,
+                        "dynamic watcher: apply progress"
+                    );
                 }
             }
             tracing::info!(
@@ -676,46 +713,17 @@ impl ResourceWatcher {
             let mut applied = 0u64;
             let mut decode_errors = 0u64;
             let mut first_apply_logged = false;
+            // Secret uids replayed during the current Init→InitDone window.
+            // On InitDone we diff against the per-release secret_uids maps
+            // and prune anything missing — same sleep/wake reconcile as the
+            // typed/dynamic watchers, but the aggregator shape (one row per
+            // logical release, multiple secrets per row) means we have to
+            // walk the store inline instead of using `reconcile_init_seen`.
+            let mut init_seen: Option<HashSet<String>> = None;
             while let Some(event) = stream.next().await {
-                match event {
-                    Ok(watcher::Event::Apply(obj) | watcher::Event::InitApply(obj)) => {
-                        let Some(secret_uid) = obj.uid() else {
-                            continue;
-                        };
-                        let release = match decode_release(&obj) {
-                            Ok(r) => r,
-                            Err(e) => {
-                                decode_errors += 1;
-                                tracing::debug!(
-                                    error = %e,
-                                    secret = %obj.name_any(),
-                                    namespace = ?obj.namespace(),
-                                    "helm watcher: decode failed"
-                                );
-                                continue;
-                            }
-                        };
-                        let ns = release.namespace.clone().unwrap_or_default();
-                        let name = release.name.clone();
-                        let key = (ns.clone(), name.clone());
-                        let mut g = store_task.lock().expect("helm store poisoned");
-                        let entry = g.entry(key.clone()).or_default();
-                        entry.insert(secret_uid, release);
-                        if let Some(latest) = entry.values().max_by_key(|r| r.version) {
-                            let uid = synthetic_uid(&ns, &name);
-                            let row = with_uid(uid.clone(), project_row(latest));
-                            dirty_task.record_upsert(uid, row);
-                        }
-                        applied += 1;
-                        if !first_apply_logged {
-                            first_apply_logged = true;
-                            tracing::info!(
-                                kind = "helm_releases",
-                                elapsed_ms = started.elapsed().as_millis() as u64,
-                                "helm watcher: first apply"
-                            );
-                        }
-                    }
+                let (obj, is_init_apply) = match event {
+                    Ok(watcher::Event::Apply(o)) => (o, false),
+                    Ok(watcher::Event::InitApply(o)) => (o, true),
                     Ok(watcher::Event::Delete(obj)) => {
                         let Some(secret_uid) = obj.uid() else {
                             continue;
@@ -747,24 +755,104 @@ impl ResourceWatcher {
                             let row = with_uid(uid.clone(), project_row(latest));
                             dirty_task.record_upsert(uid, row);
                         }
+                        continue;
                     }
                     Ok(watcher::Event::Init) => {
                         tracing::debug!(kind = "helm_releases", "helm watcher: init");
+                        init_seen = Some(HashSet::new());
+                        continue;
                     }
                     Ok(watcher::Event::InitDone) => {
                         init_done_task.store(true, Ordering::SeqCst);
+                        let reconciled = if let Some(seen) = init_seen.take() {
+                            let mut g = store_task.lock().expect("helm store poisoned");
+                            // Snapshot (key, missing_secret_uid) pairs while
+                            // holding the lock; can't mutate `g` while a
+                            // borrow into it is alive.
+                            let stale: Vec<((String, String), String)> = g
+                                .iter()
+                                .flat_map(|(key, revs)| {
+                                    revs.keys()
+                                        .filter(|u| !seen.contains(u.as_str()))
+                                        .map(|u| (key.clone(), u.clone()))
+                                        .collect::<Vec<_>>()
+                                })
+                                .collect();
+                            for (key, secret_uid) in &stale {
+                                let Some(revs) = g.get_mut(key) else {
+                                    continue;
+                                };
+                                revs.remove(secret_uid);
+                                if revs.is_empty() {
+                                    g.remove(key);
+                                    dirty_task.record_delete(synthetic_uid(&key.0, &key.1));
+                                } else if let Some(latest) = revs.values().max_by_key(|r| r.version)
+                                {
+                                    let uid = synthetic_uid(&key.0, &key.1);
+                                    let row = with_uid(uid.clone(), project_row(latest));
+                                    dirty_task.record_upsert(uid, row);
+                                }
+                            }
+                            stale.len()
+                        } else {
+                            0
+                        };
                         tracing::info!(
                             kind = "helm_releases",
                             elapsed_ms = started.elapsed().as_millis() as u64,
                             applied,
                             decode_errors,
+                            reconciled_secret_uids = reconciled,
                             "helm watcher: init done"
                         );
                         dirty_task.mark_init_done();
+                        continue;
                     }
                     Err(e) => {
                         tracing::warn!(error = %e, kind = "helm_releases", "helm watcher: stream error");
+                        continue;
                     }
+                };
+                let Some(secret_uid) = obj.uid() else {
+                    continue;
+                };
+                if is_init_apply {
+                    if let Some(seen) = init_seen.as_mut() {
+                        seen.insert(secret_uid.clone());
+                    }
+                }
+                let release = match decode_release(&obj) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        decode_errors += 1;
+                        tracing::debug!(
+                            error = %e,
+                            secret = %obj.name_any(),
+                            namespace = ?obj.namespace(),
+                            "helm watcher: decode failed"
+                        );
+                        continue;
+                    }
+                };
+                let ns = release.namespace.clone().unwrap_or_default();
+                let name = release.name.clone();
+                let key = (ns.clone(), name.clone());
+                let mut g = store_task.lock().expect("helm store poisoned");
+                let entry = g.entry(key.clone()).or_default();
+                entry.insert(secret_uid, release);
+                if let Some(latest) = entry.values().max_by_key(|r| r.version) {
+                    let uid = synthetic_uid(&ns, &name);
+                    let row = with_uid(uid.clone(), project_row(latest));
+                    dirty_task.record_upsert(uid, row);
+                }
+                applied += 1;
+                if !first_apply_logged {
+                    first_apply_logged = true;
+                    tracing::info!(
+                        kind = "helm_releases",
+                        elapsed_ms = started.elapsed().as_millis() as u64,
+                        "helm watcher: first apply"
+                    );
                 }
             }
             tracing::info!(
@@ -895,72 +983,16 @@ impl ResourceWatcher {
             tokio::pin!(stream);
             let mut applied = 0u64;
             let mut decode_errors = 0u64;
+            // Secret uids replayed during the current Init→InitDone window.
+            // On InitDone we drop secret_to_chart entries for missing uids
+            // and demote the affected ChartEntry — same sleep/wake reconcile
+            // as the typed/dynamic watchers; the secret→chart reverse map
+            // means we don't have to scan cluster_charts here.
+            let mut init_seen: Option<HashSet<String>> = None;
             while let Some(event) = stream.next().await {
-                match event {
-                    Ok(watcher::Event::Apply(obj) | watcher::Event::InitApply(obj)) => {
-                        let Some(secret_uid) = obj.uid() else {
-                            continue;
-                        };
-                        let release = match decode_release(&obj) {
-                            Ok(r) => r,
-                            Err(e) => {
-                                decode_errors += 1;
-                                tracing::debug!(
-                                    error = %e,
-                                    "helm-chart watcher: decode failed"
-                                );
-                                continue;
-                            }
-                        };
-                        let Some(name) = release.chart_meta_str("name") else {
-                            continue;
-                        };
-                        let Some(version) = release.chart_meta_str("version") else {
-                            continue;
-                        };
-                        let new_key: ClusterKey = (name.clone(), version.clone());
-
-                        // Demote a prior chart-key for this same secret
-                        // uid (rare in-place version change) before
-                        // promoting into the new key.
-                        let prior_key = secret_map_task
-                            .lock()
-                            .expect("helm-chart secret map poisoned")
-                            .get(&secret_uid)
-                            .cloned();
-                        if let Some(old_key) = prior_key {
-                            if old_key != new_key {
-                                demote_cluster_chart(
-                                    &cluster_charts_task,
-                                    &old_key,
-                                    &secret_uid,
-                                    &dirty_task,
-                                );
-                            }
-                        }
-
-                        {
-                            let mut g =
-                                cluster_charts_task.lock().expect("helm-chart map poisoned");
-                            let entry = g.entry(new_key.clone()).or_insert_with(|| ChartEntry {
-                                sample: release.clone(),
-                                secret_uids: HashSet::new(),
-                            });
-                            entry.secret_uids.insert(secret_uid.clone());
-                            let uid = synthetic_uid(HELM_CLUSTER_SOURCE, &name, &version);
-                            let row = with_uid(
-                                uid.clone(),
-                                project_cluster_row(&entry.sample, entry.secret_uids.len()),
-                            );
-                            dirty_task.record_upsert(uid, row);
-                        }
-                        secret_map_task
-                            .lock()
-                            .expect("helm-chart secret map poisoned")
-                            .insert(secret_uid, new_key);
-
-                        applied += 1;
-                    }
+                let (obj, is_init_apply) = match event {
+                    Ok(watcher::Event::Apply(o)) => (o, false),
+                    Ok(watcher::Event::InitApply(o)) => (o, true),
                     Ok(watcher::Event::Delete(obj)) => {
                         let Some(secret_uid) = obj.uid() else {
                             continue;
@@ -977,20 +1009,54 @@ impl ResourceWatcher {
                                 &dirty_task,
                             );
                         }
+                        continue;
                     }
                     Ok(watcher::Event::Init) => {
                         tracing::debug!(kind = "helm_charts", "helm-chart watcher: init");
+                        init_seen = Some(HashSet::new());
+                        continue;
                     }
                     Ok(watcher::Event::InitDone) => {
                         init_done_task.store(true, Ordering::SeqCst);
+                        let reconciled = if let Some(seen) = init_seen.take() {
+                            // Snapshot (secret_uid, key) for any tracked
+                            // secret missing from the new LIST, drop from
+                            // the reverse map, then demote each owning
+                            // chart entry (which may delete the row or
+                            // re-emit with a lower used_by count).
+                            let stale: Vec<(String, ClusterKey)> = secret_map_task
+                                .lock()
+                                .expect("helm-chart secret map poisoned")
+                                .iter()
+                                .filter(|(u, _)| !seen.contains(u.as_str()))
+                                .map(|(u, k)| (u.clone(), k.clone()))
+                                .collect();
+                            for (secret_uid, key) in &stale {
+                                secret_map_task
+                                    .lock()
+                                    .expect("helm-chart secret map poisoned")
+                                    .remove(secret_uid);
+                                demote_cluster_chart(
+                                    &cluster_charts_task,
+                                    key,
+                                    secret_uid,
+                                    &dirty_task,
+                                );
+                            }
+                            stale.len()
+                        } else {
+                            0
+                        };
                         tracing::info!(
                             kind = "helm_charts",
                             elapsed_ms = started.elapsed().as_millis() as u64,
                             applied,
                             decode_errors,
+                            reconciled_secret_uids = reconciled,
                             "helm-chart watcher: init done"
                         );
                         dirty_task.mark_init_done();
+                        continue;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -998,8 +1064,75 @@ impl ResourceWatcher {
                             kind = "helm_charts",
                             "helm-chart watcher: stream error"
                         );
+                        continue;
+                    }
+                };
+                let Some(secret_uid) = obj.uid() else {
+                    continue;
+                };
+                if is_init_apply {
+                    if let Some(seen) = init_seen.as_mut() {
+                        seen.insert(secret_uid.clone());
                     }
                 }
+                let release = match decode_release(&obj) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        decode_errors += 1;
+                        tracing::debug!(
+                            error = %e,
+                            "helm-chart watcher: decode failed"
+                        );
+                        continue;
+                    }
+                };
+                let Some(name) = release.chart_meta_str("name") else {
+                    continue;
+                };
+                let Some(version) = release.chart_meta_str("version") else {
+                    continue;
+                };
+                let new_key: ClusterKey = (name.clone(), version.clone());
+
+                // Demote a prior chart-key for this same secret
+                // uid (rare in-place version change) before
+                // promoting into the new key.
+                let prior_key = secret_map_task
+                    .lock()
+                    .expect("helm-chart secret map poisoned")
+                    .get(&secret_uid)
+                    .cloned();
+                if let Some(old_key) = prior_key {
+                    if old_key != new_key {
+                        demote_cluster_chart(
+                            &cluster_charts_task,
+                            &old_key,
+                            &secret_uid,
+                            &dirty_task,
+                        );
+                    }
+                }
+
+                {
+                    let mut g = cluster_charts_task.lock().expect("helm-chart map poisoned");
+                    let entry = g.entry(new_key.clone()).or_insert_with(|| ChartEntry {
+                        sample: release.clone(),
+                        secret_uids: HashSet::new(),
+                    });
+                    entry.secret_uids.insert(secret_uid.clone());
+                    let uid = synthetic_uid(HELM_CLUSTER_SOURCE, &name, &version);
+                    let row = with_uid(
+                        uid.clone(),
+                        project_cluster_row(&entry.sample, entry.secret_uids.len()),
+                    );
+                    dirty_task.record_upsert(uid, row);
+                }
+                secret_map_task
+                    .lock()
+                    .expect("helm-chart secret map poisoned")
+                    .insert(secret_uid, new_key);
+
+                applied += 1;
             }
         });
 
@@ -1103,6 +1236,43 @@ impl Drop for ResourceWatcher {
         // — small leak per cluster-switch, but accumulating.
         self.dirty.close();
     }
+}
+
+/// Diff the watcher cache against the uids replayed during an
+/// `Event::Init` → `Event::InitDone` window and emit a synthetic
+/// `Delete` for any uid present in the cache but absent from the
+/// replayed set. This is how we catch deletes that happened while
+/// the watcher was disconnected (sleep/wake, 410 Gone resync) —
+/// kube-rs only emits `Event::Delete` when the apiserver streams
+/// the deletion live; a resync is a plain LIST and never tells us
+/// "this item is gone." Returns the number of reconciled deletions.
+///
+/// Used by the typed and dynamic watchers (same `Mutex<HashMap<uid, row>>`
+/// cache shape). The helm aggregators carry a richer per-release /
+/// per-chart store and reconcile inline.
+fn reconcile_init_seen(
+    init_seen: &mut Option<HashSet<String>>,
+    cache: &Mutex<HashMap<String, Value>>,
+    dirty: &DirtyChannel,
+) -> usize {
+    let Some(seen) = init_seen.take() else {
+        return 0;
+    };
+    let mut cache = cache.lock().expect("watcher cache poisoned");
+    let stale: Vec<String> = cache
+        .keys()
+        .filter(|uid| !seen.contains(uid.as_str()))
+        .cloned()
+        .collect();
+    for uid in &stale {
+        cache.remove(uid);
+    }
+    drop(cache);
+    let n = stale.len();
+    for uid in stale {
+        dirty.record_delete(uid);
+    }
+    n
 }
 
 /// Inject `uid` into a projected row. If the projection produced something
@@ -1262,5 +1432,66 @@ mod tests {
         assert!(batch.init_done);
         // Second wait sees empty + closed.
         assert!(!chan.wait_for_change().await);
+    }
+
+    #[test]
+    fn reconcile_init_seen_none_is_noop() {
+        // If Init/InitDone never fired (e.g. an Apply-only stream), the
+        // reconcile must not touch the cache and must return 0.
+        let cache = Mutex::new(HashMap::from([("u1".to_owned(), row("a"))]));
+        let chan = DirtyChannel::new();
+        let mut seen: Option<HashSet<String>> = None;
+        let n = reconcile_init_seen(&mut seen, &cache, &chan);
+        assert_eq!(n, 0);
+        assert_eq!(cache.lock().unwrap().len(), 1);
+        assert!(chan.drain().is_empty());
+    }
+
+    #[test]
+    fn reconcile_init_seen_drops_missing_uids() {
+        // The reflector relist after sleep/wake / 410 Gone replays the
+        // current state via Init→InitApply→InitDone but never tells us
+        // what disappeared. `init_seen` carries the uids replayed in this
+        // window; anything in the cache that's missing is a ghost.
+        let cache = Mutex::new(HashMap::from([
+            ("kept".to_owned(), row("k")),
+            ("gone-1".to_owned(), row("g1")),
+            ("gone-2".to_owned(), row("g2")),
+        ]));
+        let chan = DirtyChannel::new();
+        let mut seen: Option<HashSet<String>> = Some(HashSet::from(["kept".to_owned()]));
+        let n = reconcile_init_seen(&mut seen, &cache, &chan);
+        assert_eq!(n, 2);
+        assert!(seen.is_none(), "init_seen consumed");
+        let c = cache.lock().unwrap();
+        assert!(c.contains_key("kept"));
+        assert!(!c.contains_key("gone-1"));
+        assert!(!c.contains_key("gone-2"));
+        let batch = chan.drain();
+        assert!(batch.deletes.contains("gone-1"));
+        assert!(batch.deletes.contains("gone-2"));
+        assert!(batch.upserts.is_empty());
+    }
+
+    #[test]
+    fn reconcile_init_seen_full_overlap_is_noop() {
+        // Steady-state resync (apiserver still has every object we knew
+        // about) must emit zero Deletes.
+        let cache = Mutex::new(HashMap::from([
+            ("a".to_owned(), row("a")),
+            ("b".to_owned(), row("b")),
+        ]));
+        let chan = DirtyChannel::new();
+        let mut seen: Option<HashSet<String>> = Some(HashSet::from([
+            "a".to_owned(),
+            "b".to_owned(),
+            "c".to_owned(),
+        ]));
+        // Extra "c" in seen (live object we don't yet have cached) is
+        // fine — InitApply for c would have already record_upsert'd it.
+        let n = reconcile_init_seen(&mut seen, &cache, &chan);
+        assert_eq!(n, 0);
+        assert_eq!(cache.lock().unwrap().len(), 2);
+        assert!(chan.drain().is_empty());
     }
 }


### PR DESCRIPTION
Two related fixes for the top-right namespace dropdown going stale.

Backend always-on namespaces watcher per connected cluster. Hold one internal subscriber on (cluster, "namespaces", All) from connect_context so the reflector survives React lifecycle races / 60s linger expiry — the dropdown no longer depends on the frontend keeping a phantom subscribe alive. CAS-gated on a new ClusterEntry.namespaces_pinned; released implicitly by drop_cluster_watchers / tear_down_unhealthy. Uses a new subscribe_resource_with_entry path that takes a pre-resolved Arc<ClusterEntry> so the pin task can't lazy-reconnect a torn-down cluster mid-flight (would leak a watcher with no UI consumer).

Cache reconcile on Event::InitDone. kube-rs relist after 410 Gone / sleep-wake replays Init → InitApply → InitDone but never emits Delete for items missing from the new LIST — our cache was carrying ghost rows until the next teardown. Now we track replayed uids between Init and InitDone and emit synthetic Delete for any uid in the cache that wasn't replayed. Applied to typed, dynamic, and both helm aggregator paths; the helm paths walk their per-release / per-chart stores inline since the generic helper doesn't fit their shape.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
