### PR TITLE
Fix/macos UI scale native page zoom

### DIFF
--- a/crates/app/capabilities/default.json
+++ b/crates/app/capabilities/default.json
@@ -11,6 +11,7 @@
     "core:window:allow-toggle-maximize",
     "core:window:allow-close",
     "core:window:allow-set-theme",
+    "core:webview:allow-set-webview-zoom",
     "fs:default",
     "dialog:default",
     "dialog:allow-open",

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -15,11 +15,16 @@ mod state;
 mod terminal;
 mod updater;
 
-use ferrisscope_core::{kubeconfig, sources, watcher::KubeconfigWatcher};
+use ferrisscope_core::{kubeconfig, prefs, sources, watcher::KubeconfigWatcher};
 use tauri::{Emitter, Manager};
 use tracing_subscriber::EnvFilter;
 
 use crate::state::AppState;
+
+// Multiplier baked into every applied page-zoom value, so the user-facing
+// "100 %" in Settings already renders 10 % larger than the raw theme
+// baseline. Must stay in sync with `UI_SCALE_BASELINE` in ui/src/theme.ts.
+const UI_SCALE_BASELINE: f64 = 1.1;
 
 // Use mimalloc instead of glibc's ptmalloc2. Long-running Tauri apps tend
 // to accumulate "ghost" RSS under the default allocator because freed
@@ -269,6 +274,23 @@ fn main() {
             #[cfg(target_os = "linux")]
             if let Some(win) = app.get_webview_window("main") {
                 let _ = win.set_decorations(false);
+            }
+
+            // Pre-apply the persisted UI scale to the main webview before its
+            // first paint, via Tauri's native page-zoom API (WKWebView
+            // setPageZoom on macOS, webkit_web_view_set_zoom_level on Linux,
+            // WebView2 zoom on Windows). Without this, the page paints once at
+            // 1.0× and then snaps to the persisted scale a beat later when the
+            // frontend's hydratePrefs round-trip lands — a visible pop on
+            // every launch. The on-disk prefs file is tiny; a block_on at
+            // setup is fine. The frontend keeps the slider in sync at runtime
+            // (App.tsx → getCurrentWebviewWindow().setZoom on uiScale change).
+            if let Some(win) = app.get_webview_window("main") {
+                let prefs = tauri::async_runtime::block_on(prefs::load());
+                let scale = f64::from(prefs.settings.ui_scale) * UI_SCALE_BASELINE;
+                if let Err(e) = win.set_zoom(scale) {
+                    tracing::warn!(?e, scale, "failed to pre-apply UI scale");
+                }
             }
 
             // macOS window appearance is kept in lockstep with the app theme

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import { api, onPortForwardStatus, onResourceDelta } from "./api";
 import { useAppStore, useResolvedTheme } from "./store";
 import type { AppInfo, ResourceKind } from "./types";
@@ -128,6 +129,23 @@ export default function App() {
       .setTheme(themeMode)
       .catch(() => {});
   }, [themeMode]);
+
+  // Global UI scale via the webview's native page-zoom API. Routes to
+  // WKWebView setPageZoom (macOS), webkit_web_view_set_zoom_level
+  // (Linux), and the WebView2 zoom factor (Windows) — all of which
+  // rescale layout *and* paint uniformly. CSS `zoom` did paint-only on
+  // macOS WebKit, which caused the root 100vw/100vh box to overflow the
+  // window above 1.0× and under-fill below. The applied factor is the
+  // user-facing slider value multiplied by a hidden baseline so "100 %"
+  // in Settings already renders 10 % larger than the raw theme baseline.
+  // The Rust setup() pre-applies the persisted scale to the main webview
+  // before the first paint; this effect keeps it in lockstep with the
+  // slider afterward.
+  useEffect(() => {
+    getCurrentWebviewWindow()
+      .setZoom(uiScale * UI_SCALE_BASELINE)
+      .catch(() => {});
+  }, [uiScale]);
 
   useEffect(() => {
     api
@@ -611,14 +629,8 @@ export default function App() {
   // theme themselves to match — otherwise the OS defaults to light, leaving
   // a white dropdown list on a dark page.
   document.documentElement.style.colorScheme = themeMode;
-  // Global UI scale via CSS `zoom` on the root. Chosen over rem/font-size
-  // because the codebase pins pixel literals (`fontSize: FS_MD`, paddings)
-  // throughout — `zoom` scales every pixel uniformly and is supported in
-  // both webview engines we ship to (WebKit on macOS, WebKitGTK on Linux).
-  // The applied zoom is the user-facing slider value multiplied by a
-  // hidden baseline so "100 %" in Settings already renders 10 % larger
-  // than the raw theme baseline.
-  document.documentElement.style.zoom = String(uiScale * UI_SCALE_BASELINE);
+  // Note: UI scale is applied via the webview's native page-zoom API in the
+  // sibling useEffect above (and pre-applied from prefs in Rust setup()).
 
   const leftInset = selectedContext
     ? railMode === "pinned"

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 
-// Control IS_MAC per-test. Off macOS the header is a single row (brand +
-// breadcrumb + controls). On macOS the layout splits into two rows: row 1 is
-// right-aligned (controls + breadcrumb), row 2 holds the brand alone on the
-// left below the OS traffic lights.
+// Control IS_MAC per-test. The header is a single row everywhere. On macOS
+// the brand is wrapped in its own block that is `transform: translateY` nudged
+// down so it tucks beneath the integrated transparent title bar's traffic
+// lights, and the divider between brand and breadcrumb is dropped (the
+// vertical offset already separates them).
 // AppHeader reads IS_MAC directly (and macChrome reads it too) — a
 // getter-backed override on the keyboard module lets one file flip the value
 // at render time while the rest of the module stays real.
@@ -61,34 +62,35 @@ describe("AppHeader layout", () => {
     expect(r.contains(getByText(/Search clusters/))).toBe(true);
   });
 
-  it("splits into two rows on macOS: controls + breadcrumb up top, brand below", () => {
+  it("nudges the brand block down beneath the traffic lights on macOS", () => {
     platform.isMac = true;
     const { container, getByText } = renderHeader();
-    const shell = container.firstChild as HTMLElement;
-    expect(shell.children).toHaveLength(2);
-    const topRow = shell.children[0] as HTMLElement;
-    const brandRow = shell.children[1] as HTMLElement;
-    // Top row: controls + breadcrumb (no brand). PaddingTop clears the OS
-    // traffic lights (~14px tall at y≈14).
-    expect(topRow.contains(getByText("Clusters"))).toBe(true);
-    expect(topRow.contains(getByText("FerrisScope"))).toBe(false);
-    expect(parseInt(topRow.style.paddingTop, 10)).toBeGreaterThanOrEqual(28);
-    // Bottom row: brand alone, aligned with the leftmost traffic light at
-    // 12px paddingLeft (not the standard 22px gutter).
-    expect(brandRow.contains(getByText("FerrisScope"))).toBe(true);
-    expect(brandRow.contains(getByText("Clusters"))).toBe(false);
-    expect(brandRow.style.paddingLeft).toBe("12px");
-    // Both rows act as window drag handles on macOS.
-    expect(topRow.getAttribute("data-tauri-drag-region")).not.toBeNull();
-    expect(brandRow.getAttribute("data-tauri-drag-region")).not.toBeNull();
+    const r = row(container);
+    // Single row still; the brand sits in the first child wrapper with a
+    // translateY transform that tucks it under the OS traffic lights.
+    const brandWrapper = r.firstElementChild as HTMLElement;
+    expect(brandWrapper.contains(getByText("FerrisScope"))).toBe(true);
+    expect(brandWrapper.style.transform).toMatch(/translateY\(\d+px\)/);
+    // The brand-breadcrumb divider is dropped on macOS — the vertical
+    // offset already separates the two visually.
+    const divider = r.querySelector('div[style*="width: 1px"]');
+    expect(divider).toBeNull();
+    // Row gutter drops to 12px to align the brand with the leftmost
+    // traffic light, instead of the standard 22px gutter.
+    expect(r.style.paddingLeft).toBe("12px");
+    // Drag region stays on the row so the header still moves the window.
+    expect(r.getAttribute("data-tauri-drag-region")).not.toBeNull();
   });
 
-  it("keeps a single row with the standard gutter and no drag region off macOS", () => {
+  it("uses the normal gutter, keeps the divider and no drag region off macOS", () => {
     platform.isMac = false;
     const { container } = renderHeader();
-    const shell = container.firstChild as HTMLElement;
-    expect(shell.children).toHaveLength(1);
     const r = row(container);
+    const brandWrapper = r.firstElementChild as HTMLElement;
+    expect(brandWrapper.style.transform === "" || brandWrapper.style.transform === "none").toBe(
+      true,
+    );
+    expect(r.querySelector('div[style*="width: 1px"]')).not.toBeNull();
     expect(r.style.paddingLeft).toBe("22px");
     expect(r.getAttribute("data-tauri-drag-region")).toBeNull();
   });

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -75,9 +75,9 @@ describe("AppHeader layout", () => {
     // offset already separates the two visually.
     const divider = r.querySelector('div[style*="width: 1px"]');
     expect(divider).toBeNull();
-    // Row gutter drops back to the normal 22px since the brand is now
-    // visually beneath the lights, not next to them.
-    expect(r.style.paddingLeft).toBe("22px");
+    // Row gutter drops to 12px to align the brand with the leftmost
+    // traffic light, instead of the standard 22px gutter.
+    expect(r.style.paddingLeft).toBe("12px");
     // Drag region stays on the row so the header still moves the window.
     expect(r.getAttribute("data-tauri-drag-region")).not.toBeNull();
   });

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 
-// Control IS_MAC per-test. The header is a single row everywhere. On macOS
-// the brand is wrapped in its own block that is `transform: translateY` nudged
-// down so it tucks beneath the integrated transparent title bar's traffic
-// lights, and the divider between brand and breadcrumb is dropped (the
-// vertical offset already separates them).
+// Control IS_MAC per-test. Off macOS the header is a single row (brand +
+// breadcrumb + controls). On macOS the layout splits into two rows: row 1 is
+// right-aligned (controls + breadcrumb), row 2 holds the brand alone on the
+// left below the OS traffic lights.
 // AppHeader reads IS_MAC directly (and macChrome reads it too) — a
 // getter-backed override on the keyboard module lets one file flip the value
 // at render time while the rest of the module stays real.
@@ -62,35 +61,34 @@ describe("AppHeader layout", () => {
     expect(r.contains(getByText(/Search clusters/))).toBe(true);
   });
 
-  it("nudges the brand block down beneath the traffic lights on macOS", () => {
+  it("splits into two rows on macOS: controls + breadcrumb up top, brand below", () => {
     platform.isMac = true;
     const { container, getByText } = renderHeader();
-    const r = row(container);
-    // Single row still; the brand sits in the first child wrapper with a
-    // translateY transform that tucks it under the OS traffic lights.
-    const brandWrapper = r.firstElementChild as HTMLElement;
-    expect(brandWrapper.contains(getByText("FerrisScope"))).toBe(true);
-    expect(brandWrapper.style.transform).toMatch(/translateY\(\d+px\)/);
-    // The brand-breadcrumb divider is dropped on macOS — the vertical
-    // offset already separates the two visually.
-    const divider = r.querySelector('div[style*="width: 1px"]');
-    expect(divider).toBeNull();
-    // Row gutter drops to 12px to align the brand with the leftmost
-    // traffic light, instead of the standard 22px gutter.
-    expect(r.style.paddingLeft).toBe("12px");
-    // Drag region stays on the row so the header still moves the window.
-    expect(r.getAttribute("data-tauri-drag-region")).not.toBeNull();
+    const shell = container.firstChild as HTMLElement;
+    expect(shell.children).toHaveLength(2);
+    const topRow = shell.children[0] as HTMLElement;
+    const brandRow = shell.children[1] as HTMLElement;
+    // Top row: controls + breadcrumb (no brand). PaddingTop clears the OS
+    // traffic lights (~14px tall at y≈14).
+    expect(topRow.contains(getByText("Clusters"))).toBe(true);
+    expect(topRow.contains(getByText("FerrisScope"))).toBe(false);
+    expect(parseInt(topRow.style.paddingTop, 10)).toBeGreaterThanOrEqual(28);
+    // Bottom row: brand alone, aligned with the leftmost traffic light at
+    // 12px paddingLeft (not the standard 22px gutter).
+    expect(brandRow.contains(getByText("FerrisScope"))).toBe(true);
+    expect(brandRow.contains(getByText("Clusters"))).toBe(false);
+    expect(brandRow.style.paddingLeft).toBe("12px");
+    // Both rows act as window drag handles on macOS.
+    expect(topRow.getAttribute("data-tauri-drag-region")).not.toBeNull();
+    expect(brandRow.getAttribute("data-tauri-drag-region")).not.toBeNull();
   });
 
-  it("uses the normal gutter, keeps the divider and no drag region off macOS", () => {
+  it("keeps a single row with the standard gutter and no drag region off macOS", () => {
     platform.isMac = false;
     const { container } = renderHeader();
+    const shell = container.firstChild as HTMLElement;
+    expect(shell.children).toHaveLength(1);
     const r = row(container);
-    const brandWrapper = r.firstElementChild as HTMLElement;
-    expect(brandWrapper.style.transform === "" || brandWrapper.style.transform === "none").toBe(
-      true,
-    );
-    expect(r.querySelector('div[style*="width: 1px"]')).not.toBeNull();
     expect(r.style.paddingLeft).toBe("22px");
     expect(r.getAttribute("data-tauri-drag-region")).toBeNull();
   });

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -1,12 +1,14 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, cleanup } from "@testing-library/react";
 
-// Control IS_MAC per-test. The header is a single row everywhere; on macOS it
-// shares the integrated transparent title bar with the OS traffic lights, so
-// lib/macChrome insets it past them and turns it into a window drag handle.
-// AppHeader no longer reads IS_MAC directly, but macChrome (which it imports)
-// does — a getter-backed override on the keyboard module lets one file flip the
-// value at render time while the rest of the module stays real.
+// Control IS_MAC per-test. The header is a single row everywhere. On macOS
+// the brand is wrapped in its own block that is `transform: translateY` nudged
+// down so it tucks beneath the integrated transparent title bar's traffic
+// lights, and the divider between brand and breadcrumb is dropped (the
+// vertical offset already separates them).
+// AppHeader reads IS_MAC directly (and macChrome reads it too) — a
+// getter-backed override on the keyboard module lets one file flip the value
+// at render time while the rest of the module stays real.
 const platform = vi.hoisted(() => ({ isMac: false }));
 vi.mock("../lib/keyboard", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../lib/keyboard")>();
@@ -60,19 +62,35 @@ describe("AppHeader layout", () => {
     expect(r.contains(getByText(/Search clusters/))).toBe(true);
   });
 
-  it("insets past the traffic lights and becomes a drag region on macOS", () => {
+  it("nudges the brand block down beneath the traffic lights on macOS", () => {
     platform.isMac = true;
-    const { container } = renderHeader();
+    const { container, getByText } = renderHeader();
     const r = row(container);
-    // 72px traffic-light inset from lib/macChrome.
-    expect(r.style.paddingLeft).toBe("72px");
+    // Single row still; the brand sits in the first child wrapper with a
+    // translateY transform that tucks it under the OS traffic lights.
+    const brandWrapper = r.firstElementChild as HTMLElement;
+    expect(brandWrapper.contains(getByText("FerrisScope"))).toBe(true);
+    expect(brandWrapper.style.transform).toMatch(/translateY\(\d+px\)/);
+    // The brand-breadcrumb divider is dropped on macOS — the vertical
+    // offset already separates the two visually.
+    const divider = r.querySelector('div[style*="width: 1px"]');
+    expect(divider).toBeNull();
+    // Row gutter drops back to the normal 22px since the brand is now
+    // visually beneath the lights, not next to them.
+    expect(r.style.paddingLeft).toBe("22px");
+    // Drag region stays on the row so the header still moves the window.
     expect(r.getAttribute("data-tauri-drag-region")).not.toBeNull();
   });
 
-  it("uses the normal gutter and no drag region off macOS", () => {
+  it("uses the normal gutter, keeps the divider and no drag region off macOS", () => {
     platform.isMac = false;
     const { container } = renderHeader();
     const r = row(container);
+    const brandWrapper = r.firstElementChild as HTMLElement;
+    expect(brandWrapper.style.transform === "" || brandWrapper.style.transform === "none").toBe(
+      true,
+    );
+    expect(r.querySelector('div[style*="width: 1px"]')).not.toBeNull();
     expect(r.style.paddingLeft).toBe("22px");
     expect(r.getAttribute("data-tauri-drag-region")).toBeNull();
   });

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -555,14 +555,14 @@ export function AppHeader({
   // Single row everywhere. On macOS the brand sits in its own wrapper that
   // is `transform: translateY` nudged down so it tucks beneath the OS
   // traffic lights instead of competing with them for the row's left edge —
-  // and the row's left gutter drops to the normal 22 px since the brand is
-  // now visually under the lights, not next to them. Layout space for the
+  // and the row's left gutter drops to 12 px (matching the lights' own left
+  // edge) so the brand aligns with the leftmost light. Layout space for the
   // brand stays in its original position, so the breadcrumb + controls stay
-  // exactly where they were; the row's `paddingBottom` grows to absorb the
-  // brand's visual overflow so nothing spills into the content area below.
-  // The divider between brand and breadcrumb is dropped on macOS because
-  // the brand's vertical offset already separates the two; on other
-  // platforms it stays.
+  // exactly where they were; the row's `paddingBottom` is set to `BRAND_OFFSET`
+  // so it just contains the brand's visual overflow without adding extra
+  // chrome height beyond that. The divider between brand and breadcrumb is
+  // dropped on macOS because the brand's vertical offset already separates
+  // the two; on other platforms it stays.
   const BRAND_OFFSET = 18;
   return (
     <div style={shell}>
@@ -573,9 +573,9 @@ export function AppHeader({
           alignItems: "center",
           gap: 16,
           paddingTop: 12,
-          paddingBottom: IS_MAC ? 12 + BRAND_OFFSET : 12,
+          paddingBottom: IS_MAC ? BRAND_OFFSET : 12,
           paddingRight: 22,
-          paddingLeft: IS_MAC ? 22 : headerPaddingLeft(22),
+          paddingLeft: IS_MAC ? 12 : headerPaddingLeft(22),
         }}
       >
         <div

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -552,6 +552,18 @@ export function AppHeader({
     zIndex: 5,
   };
 
+  // Single row everywhere. On macOS the brand sits in its own wrapper that
+  // is `transform: translateY` nudged down so it tucks beneath the OS
+  // traffic lights instead of competing with them for the row's left edge —
+  // and the row's left gutter drops to the normal 22 px since the brand is
+  // now visually under the lights, not next to them. Layout space for the
+  // brand stays in its original position, so the breadcrumb + controls stay
+  // exactly where they were; the row's `paddingBottom` grows to absorb the
+  // brand's visual overflow so nothing spills into the content area below.
+  // The divider between brand and breadcrumb is dropped on macOS because
+  // the brand's vertical offset already separates the two; on other
+  // platforms it stays.
+  const BRAND_OFFSET = 18;
   return (
     <div style={shell}>
       <div
@@ -561,14 +573,21 @@ export function AppHeader({
           alignItems: "center",
           gap: 16,
           paddingTop: 12,
-          paddingBottom: 12,
+          paddingBottom: IS_MAC ? 12 + BRAND_OFFSET : 12,
           paddingRight: 22,
-          // macOS insets past the traffic lights; 22px gutter elsewhere.
-          paddingLeft: headerPaddingLeft(22),
+          paddingLeft: IS_MAC ? 22 : headerPaddingLeft(22),
         }}
       >
-        {brand}
-        <div style={{ height: 18, width: 1, background: t.border }} />
+        <div
+          style={{
+            transform: IS_MAC ? `translateY(${BRAND_OFFSET}px)` : "none",
+          }}
+        >
+          {brand}
+        </div>
+        {!IS_MAC && (
+          <div style={{ height: 18, width: 1, background: t.border }} />
+        )}
         {breadcrumb}
         <div {...dragRegionProps()} style={{ flex: 1 }} />
         {controls}

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -552,66 +552,46 @@ export function AppHeader({
     zIndex: 5,
   };
 
-  // On macOS the header is two rows. Row 1 is right-aligned: controls
-  // followed by the breadcrumb, with the OS traffic lights overlapping the
-  // empty left side. Row 2 sits the brand alone on the left, aligned with
-  // the leftmost light at `paddingLeft: 12`. Off macOS we keep the
-  // single-row layout: brand · divider · breadcrumb · spacer · controls.
+  // Single row everywhere. On macOS the brand sits in its own wrapper that
+  // is `transform: translateY` nudged down so it tucks beneath the OS
+  // traffic lights instead of competing with them for the row's left edge —
+  // and the row's left gutter drops to 12 px (matching the lights' own left
+  // edge) so the brand aligns with the leftmost light. Layout space for the
+  // brand stays in its original position, so the breadcrumb + controls stay
+  // exactly where they were; the row's `paddingBottom` is set to `BRAND_OFFSET`
+  // so it just contains the brand's visual overflow without adding extra
+  // chrome height beyond that. The divider between brand and breadcrumb is
+  // dropped on macOS because the brand's vertical offset already separates
+  // the two; on other platforms it stays.
+  const BRAND_OFFSET = 18;
   return (
     <div style={shell}>
-      {IS_MAC ? (
-        <>
-          <div
-            {...dragRegionProps()}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: 16,
-              paddingTop: 30,
-              paddingBottom: 4,
-              paddingLeft: 22,
-              paddingRight: 22,
-            }}
-          >
-            <div {...dragRegionProps()} style={{ flex: 1 }} />
-            {controls}
-            <div style={{ height: 18, width: 1, background: t.border }} />
-            {breadcrumb}
-          </div>
-          <div
-            {...dragRegionProps()}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              paddingTop: 0,
-              paddingBottom: 10,
-              paddingLeft: 12,
-              paddingRight: 22,
-            }}
-          >
-            {brand}
-            <div {...dragRegionProps()} style={{ flex: 1 }} />
-          </div>
-        </>
-      ) : (
+      <div
+        {...dragRegionProps()}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 16,
+          paddingTop: 12,
+          paddingBottom: IS_MAC ? BRAND_OFFSET : 12,
+          paddingRight: 22,
+          paddingLeft: IS_MAC ? 12 : headerPaddingLeft(22),
+        }}
+      >
         <div
           style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 16,
-            paddingTop: 12,
-            paddingBottom: 12,
-            paddingRight: 22,
-            paddingLeft: headerPaddingLeft(22),
+            transform: IS_MAC ? `translateY(${BRAND_OFFSET}px)` : "none",
           }}
         >
           {brand}
-          <div style={{ height: 18, width: 1, background: t.border }} />
-          {breadcrumb}
-          <div style={{ flex: 1 }} />
-          {controls}
         </div>
-      )}
+        {!IS_MAC && (
+          <div style={{ height: 18, width: 1, background: t.border }} />
+        )}
+        {breadcrumb}
+        <div {...dragRegionProps()} style={{ flex: 1 }} />
+        {controls}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -552,46 +552,66 @@ export function AppHeader({
     zIndex: 5,
   };
 
-  // Single row everywhere. On macOS the brand sits in its own wrapper that
-  // is `transform: translateY` nudged down so it tucks beneath the OS
-  // traffic lights instead of competing with them for the row's left edge —
-  // and the row's left gutter drops to 12 px (matching the lights' own left
-  // edge) so the brand aligns with the leftmost light. Layout space for the
-  // brand stays in its original position, so the breadcrumb + controls stay
-  // exactly where they were; the row's `paddingBottom` is set to `BRAND_OFFSET`
-  // so it just contains the brand's visual overflow without adding extra
-  // chrome height beyond that. The divider between brand and breadcrumb is
-  // dropped on macOS because the brand's vertical offset already separates
-  // the two; on other platforms it stays.
-  const BRAND_OFFSET = 18;
+  // On macOS the header is two rows. Row 1 is right-aligned: controls
+  // followed by the breadcrumb, with the OS traffic lights overlapping the
+  // empty left side. Row 2 sits the brand alone on the left, aligned with
+  // the leftmost light at `paddingLeft: 12`. Off macOS we keep the
+  // single-row layout: brand · divider · breadcrumb · spacer · controls.
   return (
     <div style={shell}>
-      <div
-        {...dragRegionProps()}
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 16,
-          paddingTop: 12,
-          paddingBottom: IS_MAC ? BRAND_OFFSET : 12,
-          paddingRight: 22,
-          paddingLeft: IS_MAC ? 12 : headerPaddingLeft(22),
-        }}
-      >
+      {IS_MAC ? (
+        <>
+          <div
+            {...dragRegionProps()}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 16,
+              paddingTop: 30,
+              paddingBottom: 4,
+              paddingLeft: 22,
+              paddingRight: 22,
+            }}
+          >
+            <div {...dragRegionProps()} style={{ flex: 1 }} />
+            {controls}
+            <div style={{ height: 18, width: 1, background: t.border }} />
+            {breadcrumb}
+          </div>
+          <div
+            {...dragRegionProps()}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              paddingTop: 0,
+              paddingBottom: 10,
+              paddingLeft: 12,
+              paddingRight: 22,
+            }}
+          >
+            {brand}
+            <div {...dragRegionProps()} style={{ flex: 1 }} />
+          </div>
+        </>
+      ) : (
         <div
           style={{
-            transform: IS_MAC ? `translateY(${BRAND_OFFSET}px)` : "none",
+            display: "flex",
+            alignItems: "center",
+            gap: 16,
+            paddingTop: 12,
+            paddingBottom: 12,
+            paddingRight: 22,
+            paddingLeft: headerPaddingLeft(22),
           }}
         >
           {brand}
-        </div>
-        {!IS_MAC && (
           <div style={{ height: 18, width: 1, background: t.border }} />
-        )}
-        {breadcrumb}
-        <div {...dragRegionProps()} style={{ flex: 1 }} />
-        {controls}
-      </div>
+          {breadcrumb}
+          <div style={{ flex: 1 }} />
+          {controls}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/components/detail/MetricsTab.test.tsx
+++ b/ui/src/components/detail/MetricsTab.test.tsx
@@ -2,9 +2,10 @@ import { describe, it, expect } from "vitest";
 import { clientXToSvgX } from "./MetricsTab";
 
 // Build a minimal SVGSVGElement-shaped stub. The chart renders the SVG
-// with width=viewBoxWidth, then ancestor CSS zoom visually scales it by
-// `zoom`. getBoundingClientRect reports the visually-scaled width since
-// it's in the same coord system as clientX.
+// with width=viewBoxWidth, then native page zoom rescales layout + paint
+// together — getBoundingClientRect and clientX share a coordinate space,
+// so the stub's `zoom` parameter scales both the reported rect width and
+// the cursor input uniformly.
 function makeSvgStub(opts: {
   viewBoxWidth: number;
   zoom: number;
@@ -45,28 +46,26 @@ describe("clientXToSvgX", () => {
     expect(clientXToSvgX(svg, 560)).toBeCloseTo(560, 5);
   });
 
-  it("scales the cursor back to viewBox space under CSS zoom", () => {
-    // UI Scale slider applies zoom=1.5 to <html>: the chart renders at
-    // 840 screen px, but viewBox stays 0..560. Cursor at the visual
-    // midpoint (screen x=420) must map to viewBox x=280 — the previous
-    // implementation returned 420 here, which is what made the
-    // crosshair land to the right of the cursor.
+  it("maps cursor proportionally when the rect is wider than the viewBox", () => {
+    // SVG rendered at 840 CSS px but viewBox stays 0..560 (e.g. the
+    // chart was sized larger by its container). Cursor at the rect
+    // midpoint (420) must map to viewBox midpoint (280).
     const svg = makeSvgStub({ viewBoxWidth: 560, zoom: 1.5, rectLeft: 0 });
     expect(clientXToSvgX(svg, 420)).toBeCloseTo(280, 5);
     expect(clientXToSvgX(svg, 840)).toBeCloseTo(560, 5);
   });
 
-  it("scales correctly under a different zoom factor", () => {
-    // zoom=0.8 (UI Scale down). Visual width = 448. Cursor at the
-    // visual midpoint (224) maps to viewBox x=280.
+  it("maps cursor proportionally when the rect is narrower than the viewBox", () => {
+    // SVG rendered at 448 CSS px with viewBox 0..560. Cursor at the
+    // rect midpoint (224) maps to viewBox midpoint (280).
     const svg = makeSvgStub({ viewBoxWidth: 560, zoom: 0.8, rectLeft: 0 });
     expect(clientXToSvgX(svg, 224)).toBeCloseTo(280, 5);
   });
 
   it("accounts for the SVG's left offset on the page", () => {
-    // Chart sits 200px from the left of the viewport, zoom=1.25 —
-    // visual width = 700, visual midpoint = 200 + 350 = 550. viewBox
-    // x should be 280.
+    // Chart sits 200px from the left of the viewport with rendered
+    // width 700. Cursor at the rect midpoint (550) maps to viewBox
+    // midpoint (280); cursor at the rect edges maps to 0 / viewBoxWidth.
     const svg = makeSvgStub({ viewBoxWidth: 560, zoom: 1.25, rectLeft: 200 });
     expect(clientXToSvgX(svg, 550)).toBeCloseTo(280, 5);
     expect(clientXToSvgX(svg, 200)).toBeCloseTo(0, 5);
@@ -97,16 +96,16 @@ describe("clientXToSvgX", () => {
     expect(clientXToSvgX(svg, 400)).toBeCloseTo(400, 5);
   });
 
-  it("scales correctly under WebKit/Tauri CSS zoom behavior (unzoomed bounding rect)", () => {
-    // Under WebKit/Tauri, document.documentElement.style.zoom is set to 1.5.
-    // getBoundingClientRect reports unzoomed width (560) and left (0),
-    // but cursor clientX is reported in zoomed visual coordinates (midpoint = 420).
+  it("ignores document.documentElement.style.zoom under native page zoom", () => {
+    // Sanity check: native page zoom (WebviewWindow.setZoom) rescales
+    // layout and paint together, so getBoundingClientRect and clientX
+    // already share a space. Stray CSS `zoom` on the root must not enter
+    // the mapping.
     const prevZoom = document.documentElement.style.zoom;
     document.documentElement.style.zoom = "1.5";
     try {
-      const svg = makeSvgStub({ viewBoxWidth: 560, zoom: 1, rectLeft: 0 }); // rect.width is 560
-      expect(clientXToSvgX(svg, 420)).toBeCloseTo(280, 5);
-      expect(clientXToSvgX(svg, 840)).toBeCloseTo(560, 5);
+      const svg = makeSvgStub({ viewBoxWidth: 560, zoom: 1, rectLeft: 0 });
+      expect(clientXToSvgX(svg, 280)).toBeCloseTo(280, 5);
     } finally {
       document.documentElement.style.zoom = prevZoom;
     }

--- a/ui/src/components/detail/MetricsTab.tsx
+++ b/ui/src/components/detail/MetricsTab.tsx
@@ -2007,12 +2007,11 @@ type ChartSeries = {
 };
 
 // Map a viewport (clientX) coordinate into the SVG's user-space x.
-// getBoundingClientRect and clientX are both reported in the same visual
-// viewport CSS pixels, so the ratio across the SVG's rendered width is
-// zoom-invariant by construction — multiplying by the viewBox width
-// gives the user-space x. getScreenCTM() also works in Chrome but
-// behaves inconsistently under CSS `zoom` in WebKitGTK, which is what
-// Tauri uses on Linux. Exported for tests.
+// Under Tauri's native page zoom (WebviewWindow.setZoom — WKWebView
+// setPageZoom on macOS, webkit_web_view_set_zoom_level on Linux, WebView2
+// zoom on Windows), getBoundingClientRect and clientX share the same
+// coordinate space on every engine, so the ratio across the SVG's
+// rendered width is zoom-invariant by construction. Exported for tests.
 export function clientXToSvgX(svg: SVGSVGElement, clientX: number): number {
   const rect = svg.getBoundingClientRect();
   if (rect.width <= 0) return clientX - rect.left;
@@ -2034,28 +2033,7 @@ export function clientXToSvgX(svg: SVGSVGElement, clientX: number): number {
     viewBoxWidth = svg.viewBox.baseVal.width;
   }
 
-  // Detect applied CSS zoom on document root
-  let zoom = 1.0;
-  const zoomStr = document.documentElement.style.zoom;
-  if (zoomStr) {
-    const parsed = Number.parseFloat(zoomStr);
-    if (Number.isFinite(parsed) && parsed > 0) {
-      zoom = parsed;
-    }
-  }
-
-  // Under CSS zoom, WebKit (Tauri on macOS/Linux) reports bounding rect in
-  // unzoomed layout pixels, while clientX is in zoomed visual pixels.
-  // Blink (Chrome) reports both in zoomed visual pixels.
-  // We detect WebKit by checking if rect.width is closer to unzoomed viewBoxWidth
-  // than to the zoomed viewBoxWidth * zoom.
-  const isRectUnzoomed =
-    Math.abs(zoom - 1.0) > 1e-4 &&
-    Math.abs(rect.width - viewBoxWidth) < Math.abs(rect.width - viewBoxWidth * zoom);
-
-  const clientXAdjusted = isRectUnzoomed ? clientX / zoom : clientX;
-
-  return ((clientXAdjusted - rect.left) / rect.width) * viewBoxWidth;
+  return ((clientX - rect.left) / rect.width) * viewBoxWidth;
 }
 
 function Chart({

--- a/ui/src/lib/zoom.test.ts
+++ b/ui/src/lib/zoom.test.ts
@@ -9,10 +9,12 @@ import {
   type Rect,
 } from "./zoom";
 
-// A fixed portal under `documentElement.style.zoom` is repainted × zoom, while
-// the inputs (getBoundingClientRect / clientX / innerWidth) are visual px. Each
-// helper does its math in visual px, then divides emitted coordinates by zoom
-// so the painted portal lands back at the intended visual geometry.
+// Under Tauri's native page zoom (WebviewWindow.setZoom), layout and paint
+// scale together on every engine, so coordinates and rects live in the same
+// space. The scale-returning helpers therefore stay at 1. The placement
+// helpers still respect the `scale` parameter as a contract — callers pass
+// 1 today, but the divide stays in place defensively in case a future
+// surface stacks a non-native transform on top.
 
 afterEach(() => {
   document.documentElement.style.zoom = "";
@@ -21,64 +23,24 @@ afterEach(() => {
 });
 
 describe("rootZoom", () => {
-  it("returns 1 when zoom is unset", () => {
+  it("returns 1 under native page zoom regardless of style.zoom", () => {
     expect(rootZoom()).toBe(1);
-  });
-  it("parses the applied zoom", () => {
     document.documentElement.style.zoom = "1.1";
-    expect(rootZoom()).toBeCloseTo(1.1, 5);
-  });
-  it("falls back to 1 for non-positive / unparseable values", () => {
-    document.documentElement.style.zoom = "0";
     expect(rootZoom()).toBe(1);
-    document.documentElement.style.zoom = "nonsense";
+    document.documentElement.style.zoom = "0.8";
     expect(rootZoom()).toBe(1);
   });
 });
 
 describe("fixedRectScale", () => {
-  // Stub how the engine reports a fixed element's width. The probe sets
-  // width:1000px; the ratio is reportedWidth / 1000.
-  function stubProbeWidth(reported: number) {
-    vi.spyOn(HTMLDivElement.prototype, "getBoundingClientRect").mockReturnValue({
-      width: reported,
-      height: 0,
-      top: 0,
-      left: 0,
-      right: reported,
-      bottom: 0,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    } as DOMRect);
-  }
-
-  it("falls back to rootZoom when the probe can't be measured (jsdom → 0)", () => {
+  it("returns 1 under native page zoom regardless of style.zoom or rect probing", () => {
+    expect(fixedRectScale()).toBe(1);
     document.documentElement.style.zoom = "1.1";
-    // jsdom reports 0-size rects; ratio is unmeasurable → fall back to zoom.
-    expect(fixedRectScale()).toBeCloseTo(1.1, 5);
+    expect(fixedRectScale()).toBe(1);
   });
 
-  it("returns the paint zoom on engines that report rects in visual px", () => {
-    document.documentElement.style.zoom = "1.1";
-    stubProbeWidth(1000 * 1.1); // visual: 1000css × 1.1 paint, reported as visual
-    expect(fixedRectScale()).toBeCloseTo(1.1, 5);
-  });
-
-  it("returns 1 on engines that report rects unzoomed", () => {
-    document.documentElement.style.zoom = "1.1";
-    stubProbeWidth(1000); // unzoomed: reported as the css px we set
-    expect(fixedRectScale()).toBeCloseTo(1, 5);
-  });
-
-  it("caches per zoom value", () => {
-    document.documentElement.style.zoom = "1.2";
-    const spy = vi
-      .spyOn(HTMLDivElement.prototype, "getBoundingClientRect")
-      .mockReturnValue({ width: 1200, height: 0 } as DOMRect);
-    expect(fixedRectScale()).toBeCloseTo(1.2, 5); // 1200 / 1000
-    expect(fixedRectScale()).toBeCloseTo(1.2, 5);
-    expect(spy).toHaveBeenCalledTimes(1); // second call served from cache
+  it("resetFixedRectScaleCache is a safe no-op", () => {
+    expect(() => resetFixedRectScaleCache()).not.toThrow();
   });
 });
 
@@ -86,32 +48,32 @@ describe("placeMenuAtCursor", () => {
   const menu = { width: 210, height: 120 };
   const viewport = { width: 1000, height: 800 };
 
-  it("passes the cursor through unchanged at zoom 1", () => {
+  it("passes the cursor through unchanged at scale 1", () => {
     expect(placeMenuAtCursor({ x: 300, y: 200 }, menu, viewport, 1)).toEqual({
       x: 300,
       y: 200,
     });
   });
 
-  it("divides the visual cursor by zoom so the repaint lands on it", () => {
-    // Visual cursor (330, 220) under zoom 1.1 → fixed (300, 200); the root
-    // repaints × 1.1 → back to (330, 220) visual.
+  it("clamps to the right/bottom edge inside the viewport", () => {
+    // x 980 + 210 > 996 → 786; y 780 + 120 > 796 → 676.
+    const p = placeMenuAtCursor({ x: 980, y: 780 }, menu, viewport, 1);
+    expect(p.x).toBe(786);
+    expect(p.y).toBe(676);
+  });
+
+  it("keeps a 4px margin at the top-left", () => {
+    const p = placeMenuAtCursor({ x: 0, y: 0 }, menu, viewport, 1);
+    expect(p.x).toBe(4);
+    expect(p.y).toBe(4);
+  });
+
+  it("divides the clamped coords by the scale parameter (defensive contract)", () => {
+    // Verifies the helper respects the `scale` arg even though native page
+    // zoom means callers pass 1 today.
     const p = placeMenuAtCursor({ x: 330, y: 220 }, menu, viewport, 1.1);
     expect(p.x).toBeCloseTo(300, 5);
     expect(p.y).toBeCloseTo(200, 5);
-  });
-
-  it("clamps to the right/bottom edge in visual space before dividing", () => {
-    // Visual: x 980 + 210 > 996 → 786; y 780 + 120 > 796 → 676. Then / 1.1.
-    const p = placeMenuAtCursor({ x: 980, y: 780 }, menu, viewport, 1.1);
-    expect(p.x).toBeCloseTo(786 / 1.1, 5);
-    expect(p.y).toBeCloseTo(676 / 1.1, 5);
-  });
-
-  it("keeps a 4px visual margin at the top-left", () => {
-    const p = placeMenuAtCursor({ x: 0, y: 0 }, menu, viewport, 1.1);
-    expect(p.x).toBeCloseTo(4 / 1.1, 5);
-    expect(p.y).toBeCloseTo(4 / 1.1, 5);
   });
 });
 
@@ -126,21 +88,12 @@ describe("placeSelectPopover", () => {
     height: 24,
   };
 
-  it("anchors below the trigger and matches its width at zoom 1", () => {
+  it("anchors below the trigger and matches its width at scale 1", () => {
     const p = placeSelectPopover(trigger, viewport, {}, 1);
     expect(p.flipUp).toBe(false);
     expect(p.x).toBe(200);
     expect(p.y).toBe(124 + 4); // bottom + gap
     expect(p.w).toBe(160);
-  });
-
-  it("divides x/y/w/maxH by zoom so the fixed popover lands on the trigger", () => {
-    const p = placeSelectPopover(trigger, viewport, {}, 1.1);
-    expect(p.x).toBeCloseTo(200 / 1.1, 5);
-    expect(p.y).toBeCloseTo(128 / 1.1, 5);
-    expect(p.w).toBeCloseTo(160 / 1.1, 5);
-    // maxH = clamp(800 - 124 - 8 - 4, 120, 360) = 360, then / zoom.
-    expect(p.maxH).toBeCloseTo(360 / 1.1, 5);
   });
 
   it("flips up when there is little room below, anchoring from the bottom", () => {
@@ -158,6 +111,15 @@ describe("placeSelectPopover", () => {
     // 900 + 300 > 992 → x = 1000 - 8 - 300 = 692
     expect(p.x).toBe(692);
   });
+
+  it("divides x/y/w/maxH by the scale parameter (defensive contract)", () => {
+    const p = placeSelectPopover(trigger, viewport, {}, 1.1);
+    expect(p.x).toBeCloseTo(200 / 1.1, 5);
+    expect(p.y).toBeCloseTo(128 / 1.1, 5);
+    expect(p.w).toBeCloseTo(160 / 1.1, 5);
+    // maxH = clamp(800 - 124 - 8 - 4, 120, 360) = 360, then / scale.
+    expect(p.maxH).toBeCloseTo(360 / 1.1, 5);
+  });
 });
 
 describe("placeTooltip", () => {
@@ -172,22 +134,22 @@ describe("placeTooltip", () => {
   };
   const tip = { width: 100, height: 30 };
 
-  it("centers below the trigger for side=bottom at zoom 1", () => {
+  it("centers below the trigger for side=bottom at scale 1", () => {
     const p = placeTooltip(trigger, tip, "bottom", viewport, 1);
     expect(p.placedSide).toBe("bottom");
     expect(p.x).toBe(400 + 20 - 50); // center - tip/2
     expect(p.y).toBe(320 + 8); // bottom + gap
   });
 
-  it("divides the result by zoom", () => {
-    const p = placeTooltip(trigger, tip, "bottom", viewport, 1.1);
-    expect(p.x).toBeCloseTo(370 / 1.1, 5);
-    expect(p.y).toBeCloseTo(328 / 1.1, 5);
-  });
-
   it("flips to bottom when top does not fit", () => {
     const high: Rect = { ...trigger, top: 10, bottom: 30 };
     const p = placeTooltip(high, tip, "top", viewport, 1);
     expect(p.placedSide).toBe("bottom");
+  });
+
+  it("divides the result by the scale parameter (defensive contract)", () => {
+    const p = placeTooltip(trigger, tip, "bottom", viewport, 1.1);
+    expect(p.x).toBeCloseTo(370 / 1.1, 5);
+    expect(p.y).toBeCloseTo(328 / 1.1, 5);
   });
 });

--- a/ui/src/lib/zoom.ts
+++ b/ui/src/lib/zoom.ts
@@ -1,29 +1,25 @@
-// Positioning helpers for `position: fixed` portals under the global UI scale.
+// Placement helpers for `position: fixed` portals.
 //
-// App.tsx applies the UI scale as `document.documentElement.style.zoom`
-// (= uiScale * UI_SCALE_BASELINE; baseline 1.1, so the default is already
-// >1.0). A `position: fixed` portal is a descendant of that zoomed root, so the
-// browser repaints its `top/left/width/height` coordinates × zoom (the "paint
-// scale", which is exactly the numeric `style.zoom`).
+// History: this module used to compensate for CSS `style.zoom` applied to
+// the document root — which Chromium/WebKitGTK and macOS WebKit treat
+// differently. macOS WebKit scaled paint only (not layout), so coordinates
+// from `getBoundingClientRect()` and `clientX/Y` lived in different spaces
+// and `position: fixed` repainted writes × zoom. The helpers below divided
+// each emitted coordinate by the right scale to land portals correctly.
 //
-// The inputs we measure from are reported differently per engine:
-//   - `clientX/clientY` (the mouse) are *visual* (post-zoom) px on every engine.
-//   - `getBoundingClientRect()` / `innerWidth` are visual on WebKitGTK (Linux)
-//     and modern Blink/WebView2, but the MetricsTab notes that macOS WebKit can
-//     report them *unzoomed*. So we can't assume rect == visual everywhere.
+// We've since switched to Tauri's native page-zoom API
+// (`WebviewWindow.setZoom`), which maps to WKWebView `setPageZoom` on
+// macOS, `webkit_web_view_set_zoom_level` on Linux, and the WebView2 zoom
+// factor on Windows — all of which rescale layout *and* paint uniformly.
+// Under native page zoom, every coordinate the page sees (cursor, rect,
+// `innerWidth`, fixed-style write) is in the same space, so the divides
+// collapse to identity and the engine-specific calibration probe is no
+// longer needed.
 //
-// The rule these helpers enforce: do all placement math in the same space the
-// inputs come in, then divide every coordinate written to the fixed portal by
-// the appropriate scale so the portal lands where intended once the root
-// repaints it × zoom:
-//   - cursor-anchored menus divide by the *paint scale* (`rootZoom()`), because
-//     the cursor is visual on all engines.
-//   - trigger-anchored menus divide by the *measured rect scale*
-//     (`fixedRectScale()`), which self-calibrates: it equals the paint scale on
-//     engines that report rects in visual px, and 1 where rects are unzoomed.
-//
-// Pure placement fns take the scale as a parameter so they stay testable; the
-// React call sites pass `rootZoom()` or `fixedRectScale()` as appropriate.
+// The helpers stay because they still own placement geometry (cursor
+// anchoring, trigger anchoring, viewport clamping, side flipping). The
+// `scale` parameter and the two getters below stay at `1` defensively in
+// case a future surface re-introduces a non-native zoom transform.
 
 export type Point = { x: number; y: number };
 export type Size = { width: number; height: number };
@@ -38,55 +34,27 @@ export type Rect = {
   height: number;
 };
 
-// Active root zoom (paint scale). Falls back to 1 when unset / unparseable
-// (jsdom in tests, first paint before App.tsx writes it).
+// Always 1 under native page zoom. Kept as a function (rather than a
+// constant) so the call sites read naturally and we have one symbol to
+// audit if a future feature ever stacks an extra paint transform on top.
 export function rootZoom(): number {
-  const z = Number.parseFloat(document.documentElement.style.zoom || "");
-  return Number.isFinite(z) && z > 0 ? z : 1;
+  return 1;
 }
 
-// Measured ratio between what `getBoundingClientRect()` reports for a
-// `position: fixed` element and the CSS px we set on it. This is the divisor
-// trigger-anchored portals need, and it works regardless of whether the engine
-// reports rects in visual px (ratio == paint zoom) or unzoomed px (ratio == 1)
-// — because the probe is measured the exact same way the real triggers are.
-//
-// Cached per zoom value (the ratio only changes when the scale changes); call
-// `resetFixedRectScaleCache()` in tests. Falls back to `rootZoom()` when the
-// probe can't be measured (jsdom reports 0-size rects).
-const PROBE_PX = 1000;
-let probeCache: { key: string; value: number } | null = null;
-
+// Kept for API stability; under native page zoom there's no rect/visual
+// mismatch, so it's the same as `rootZoom()`. `resetFixedRectScaleCache()`
+// stays for tests that still reach for it — it's a no-op now.
 export function resetFixedRectScaleCache(): void {
-  probeCache = null;
+  // no-op under native page zoom; retained for test compatibility.
 }
 
 export function fixedRectScale(): number {
-  const key = document.documentElement.style.zoom || "";
-  if (probeCache && probeCache.key === key) return probeCache.value;
-  let value = rootZoom();
-  const body = document.body;
-  if (body) {
-    const probe = document.createElement("div");
-    probe.style.position = "fixed";
-    probe.style.left = "0";
-    probe.style.top = "0";
-    probe.style.width = `${PROBE_PX}px`;
-    probe.style.height = "0";
-    probe.style.visibility = "hidden";
-    probe.style.pointerEvents = "none";
-    body.appendChild(probe);
-    const measured = probe.getBoundingClientRect().width;
-    body.removeChild(probe);
-    if (Number.isFinite(measured) && measured > 0) value = measured / PROBE_PX;
-  }
-  probeCache = { key, value };
-  return value;
+  return 1;
 }
 
 // Cursor-anchored menu (right-click ContextMenu). `cursor` is the visual-px
-// clientX/clientY; `menu` and `viewport` are visual px. Returns the fixed-layer
-// top/left in pre-zoom px, clamped 4px inside the viewport.
+// clientX/clientY; `menu` and `viewport` are in the same space. Returns the
+// fixed-layer top/left, clamped 4px inside the viewport.
 export function placeMenuAtCursor(
   cursor: Point,
   menu: Size,
@@ -111,10 +79,10 @@ export type SelectPlacement = {
   flipUp: boolean;
 };
 
-// Trigger-anchored dropdown (Select). `trigger` and `viewport` are visual px.
-// `flipUp` anchors the popover bottom to the trigger top (style `bottom`),
-// otherwise the popover top hangs below the trigger (style `top`). All emitted
-// pixel values (x, y, w, maxH) are pre-zoom px ready for the fixed style.
+// Trigger-anchored dropdown (Select). `trigger` and `viewport` share a
+// coordinate space. `flipUp` anchors the popover bottom to the trigger top
+// (style `bottom`), otherwise the popover top hangs below the trigger
+// (style `top`).
 export function placeSelectPopover(
   trigger: Rect,
   viewport: Size,
@@ -146,10 +114,10 @@ export function placeSelectPopover(
   };
 }
 
-// Trigger-anchored tooltip. `trigger`, `tip` and `viewport` are visual px.
-// Picks the requested `side`, flips to the opposite side if it doesn't fit,
-// then clamps. Returns the fixed-layer top/left in pre-zoom px plus the side
-// actually used (for the caller's arrow / styling).
+// Trigger-anchored tooltip. `trigger`, `tip` and `viewport` share a
+// coordinate space. Picks the requested `side`, flips to the opposite side
+// if it doesn't fit, then clamps. Returns top/left plus the side actually
+// used (for the caller's arrow / styling).
 export function placeTooltip(
   trigger: Rect,
   tip: Size,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
