### PR TITLE
feat(detail): collapsible containers, expandable annotations/tolerati…

### DIFF
--- a/crates/kube-ext/src/kinds/pod_template.rs
+++ b/crates/kube-ext/src/kinds/pod_template.rs
@@ -250,11 +250,14 @@ pub fn project_pod_template_summary(template: &PodTemplateSpec) -> Value {
         .and_then(|m| m.labels.as_ref())
         .map(|m| m.iter().map(|(k, v)| json!([k, v])).collect())
         .unwrap_or_default();
-    let annotations_count = template
-        .metadata
-        .as_ref()
-        .and_then(|m| m.annotations.as_ref())
-        .map_or(0, std::collections::BTreeMap::len);
+    // Elide the last-applied-configuration blob the same way project_meta
+    // does — a pod template can carry it too, and it's pure noise here.
+    let annotations = project_annotations(
+        template
+            .metadata
+            .as_ref()
+            .and_then(|m| m.annotations.as_ref()),
+    );
 
     let spec = template.spec.as_ref();
     let containers: Vec<Value> = spec
@@ -284,9 +287,22 @@ pub fn project_pod_template_summary(template: &PodTemplateSpec) -> Value {
         .map(|m| m.iter().map(|(k, v)| json!([k, v])).collect())
         .unwrap_or_default();
 
-    let tolerations_count = spec
+    let tolerations: Vec<Value> = spec
         .and_then(|s| s.tolerations.as_ref())
-        .map_or(0, std::vec::Vec::len);
+        .map(|ts| {
+            ts.iter()
+                .map(|t| {
+                    json!({
+                        "key": t.key.clone(),
+                        "operator": t.operator.clone(),
+                        "value": t.value.clone(),
+                        "effect": t.effect.clone(),
+                        "toleration_seconds": t.toleration_seconds,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
     let volumes: Vec<Value> = spec
         .and_then(|s| s.volumes.as_ref())
         .map(|vs| vs.iter().map(volume_value).collect())
@@ -298,12 +314,12 @@ pub fn project_pod_template_summary(template: &PodTemplateSpec) -> Value {
 
     json!({
         "labels": labels,
-        "annotations_count": annotations_count,
+        "annotations": annotations,
         "containers": containers,
         "service_account": spec.and_then(|s| s.service_account_name.clone()),
         "restart_policy": spec.and_then(|s| s.restart_policy.clone()),
         "node_selector": node_selector,
-        "tolerations_count": tolerations_count,
+        "tolerations": tolerations,
         "volumes": volumes,
         "image_pull_secrets": image_pull_secrets,
         "priority_class": spec.and_then(|s| s.priority_class_name.clone()),
@@ -440,4 +456,59 @@ pub fn project_managers(
             })
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::core::v1::{PodSpec, Toleration};
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn template_summary_carries_annotations_and_tolerations() {
+        let mut annotations = BTreeMap::new();
+        annotations.insert("team".to_string(), "platform".to_string());
+        // The last-applied-configuration blob must be elided, same as meta.
+        annotations.insert(
+            "kubectl.kubernetes.io/last-applied-configuration".to_string(),
+            "{\"huge\":\"blob\"}".to_string(),
+        );
+
+        let template = PodTemplateSpec {
+            metadata: Some(ObjectMeta {
+                annotations: Some(annotations),
+                ..Default::default()
+            }),
+            spec: Some(PodSpec {
+                tolerations: Some(vec![Toleration {
+                    key: Some("node.kubernetes.io/not-ready".to_string()),
+                    operator: Some("Exists".to_string()),
+                    effect: Some("NoExecute".to_string()),
+                    toleration_seconds: Some(300),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+        };
+
+        let v = project_pod_template_summary(&template);
+
+        // Annotations project as [k, v] pairs, with the hidden blob dropped.
+        let anns = v["annotations"].as_array().expect("annotations array");
+        assert_eq!(anns.len(), 1, "last-applied-configuration must be elided");
+        assert_eq!(anns[0], json!(["team", "platform"]));
+
+        // Tolerations project with full fields (no longer a bare count).
+        let tols = v["tolerations"].as_array().expect("tolerations array");
+        assert_eq!(tols.len(), 1);
+        assert_eq!(tols[0]["key"], "node.kubernetes.io/not-ready");
+        assert_eq!(tols[0]["operator"], "Exists");
+        assert_eq!(tols[0]["effect"], "NoExecute");
+        assert_eq!(tols[0]["toleration_seconds"], 300);
+
+        // The old count keys must be gone so the FE type stays honest.
+        assert!(v.get("annotations_count").is_none());
+        assert!(v.get("tolerations_count").is_none());
+    }
 }

--- a/crates/kube-ext/tests/snapshots/projections__cronjob_detail.snap
+++ b/crates/kube-ext/tests/snapshots/projections__cronjob_detail.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/kube-ext/tests/projections.rs
-assertion_line: 39
 expression: value
 ---
 {
@@ -28,7 +27,7 @@ expression: value
     "uid": "cj-uid"
   },
   "pod_template": {
-    "annotations_count": 0,
+    "annotations": [],
     "containers": [
       {
         "args": null,
@@ -54,7 +53,7 @@ expression: value
     "priority_class": null,
     "restart_policy": "OnFailure",
     "service_account": null,
-    "tolerations_count": 0,
+    "tolerations": [],
     "volumes": []
   },
   "schedule": "0 2 * * *",

--- a/crates/kube-ext/tests/snapshots/projections__daemonset_detail.snap
+++ b/crates/kube-ext/tests/snapshots/projections__daemonset_detail.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/kube-ext/tests/projections.rs
-assertion_line: 39
 expression: value
 ---
 {
@@ -20,7 +19,7 @@ expression: value
   "min_ready_seconds": null,
   "observed_generation": 1,
   "pod_template": {
-    "annotations_count": 0,
+    "annotations": [],
     "containers": [
       {
         "args": null,
@@ -51,7 +50,7 @@ expression: value
     "priority_class": null,
     "restart_policy": null,
     "service_account": null,
-    "tolerations_count": 0,
+    "tolerations": [],
     "volumes": []
   },
   "replicas": {

--- a/crates/kube-ext/tests/snapshots/projections__deployment_detail.snap
+++ b/crates/kube-ext/tests/snapshots/projections__deployment_detail.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/kube-ext/tests/projections.rs
-assertion_line: 39
 expression: value
 ---
 {
@@ -40,7 +39,7 @@ expression: value
   "observed_generation": 4,
   "paused": false,
   "pod_template": {
-    "annotations_count": 0,
+    "annotations": [],
     "containers": [
       {
         "args": null,
@@ -71,7 +70,7 @@ expression: value
     "priority_class": null,
     "restart_policy": null,
     "service_account": null,
-    "tolerations_count": 0,
+    "tolerations": [],
     "volumes": []
   },
   "progress_deadline_seconds": 600,

--- a/crates/kube-ext/tests/snapshots/projections__job_succeeded_detail.snap
+++ b/crates/kube-ext/tests/snapshots/projections__job_succeeded_detail.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/kube-ext/tests/projections.rs
-assertion_line: 39
 expression: value
 ---
 {
@@ -33,7 +32,7 @@ expression: value
   "parallelism": 1,
   "phase": "Succeeded",
   "pod_template": {
-    "annotations_count": 0,
+    "annotations": [],
     "containers": [
       {
         "args": null,
@@ -64,7 +63,7 @@ expression: value
     "priority_class": null,
     "restart_policy": "Never",
     "service_account": null,
-    "tolerations_count": 0,
+    "tolerations": [],
     "volumes": []
   },
   "selector": {

--- a/crates/kube-ext/tests/snapshots/projections__replicaset_detail.snap
+++ b/crates/kube-ext/tests/snapshots/projections__replicaset_detail.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/kube-ext/tests/projections.rs
-assertion_line: 39
 expression: value
 ---
 {
@@ -22,7 +21,7 @@ expression: value
   "min_ready_seconds": null,
   "observed_generation": 1,
   "pod_template": {
-    "annotations_count": 0,
+    "annotations": [],
     "containers": [
       {
         "args": null,
@@ -57,7 +56,7 @@ expression: value
     "priority_class": null,
     "restart_policy": null,
     "service_account": null,
-    "tolerations_count": 0,
+    "tolerations": [],
     "volumes": []
   },
   "replicas": {

--- a/crates/kube-ext/tests/snapshots/projections__statefulset_detail.snap
+++ b/crates/kube-ext/tests/snapshots/projections__statefulset_detail.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/kube-ext/tests/projections.rs
-assertion_line: 39
 expression: value
 ---
 {
@@ -21,7 +20,7 @@ expression: value
   "observed_generation": 2,
   "pod_management_policy": "OrderedReady",
   "pod_template": {
-    "annotations_count": 0,
+    "annotations": [],
     "containers": [
       {
         "args": null,
@@ -52,7 +51,7 @@ expression: value
     "priority_class": null,
     "restart_policy": null,
     "service_account": null,
-    "tolerations_count": 0,
+    "tolerations": [],
     "volumes": []
   },
   "replicas": {

--- a/ui/src/components/DetailPanel.tsx
+++ b/ui/src/components/DetailPanel.tsx
@@ -13,7 +13,7 @@ import type {
   ResourceKind,
   ResourceRow,
 } from "../types";
-import { tokens, FF_MONO, type ThemeMode, type Tokens, R_LG, FS_LG, FS_MD, FS_SM, FS_XS } from "../theme";
+import { tokens, FF_MONO, type ThemeMode, type Tokens, FS_LG, FS_MD, FS_SM, FS_XS } from "../theme";
 import {
   Chip,
   ContainerDots,
@@ -33,8 +33,10 @@ import {
   ChipWrap,
   ConditionChip,
   Copyable,
+  CollapsibleCard,
   DetailRow,
   EditSessionProvider,
+  ExpandableList,
   GlobalSaveBar,
   KeyValueChips,
   LinkValue,
@@ -42,6 +44,8 @@ import {
   SubGrid,
   ageFromIso,
   formatQuantity,
+  useCollapseGroup,
+  type CollapseSignal,
   type DetailNavigate,
   type SubEntry,
 } from "./detail";
@@ -54,6 +58,7 @@ import {
   StatefulSetSummary,
 } from "./detail/workload";
 import {
+  ContainerSectionMeta,
   EnvEditor,
   EnvFromEditor,
   ImageEditor,
@@ -61,6 +66,7 @@ import {
   MountsEditor,
   PortsEditor,
   ResourcesEditor,
+  TolerationList,
   VolumesEditor,
 } from "./detail/workload/shared";
 import {
@@ -785,18 +791,20 @@ export function DetailPanel({
                 </>
               )}
             </div>
-            <div
-              style={{
-                fontSize: FS_LG,
-                fontWeight: 600,
-                fontFamily: FF_MONO,
-                wordBreak: "break-all",
-                lineHeight: 1.3,
-                color: t.text,
-              }}
-            >
-              {target.name}
-            </div>
+            <Copyable text={target.name} block>
+              <span
+                style={{
+                  fontSize: FS_LG,
+                  fontWeight: 600,
+                  fontFamily: FF_MONO,
+                  wordBreak: "break-all",
+                  lineHeight: 1.3,
+                  color: t.text,
+                }}
+              >
+                {target.name}
+              </span>
+            </Copyable>
           </div>
           {canBack && (
             <IconBtn
@@ -1801,6 +1809,11 @@ function PodSummary({
   const reqId = useRef(0);
   const ns = target.namespace;
   const name = target.name;
+  // Container cards collapse by default; these drive the per-section
+  // "Expand all / Collapse all" toggles. Declared before the early returns to
+  // keep hook order stable across loading / error / ready renders.
+  const initGroup = useCollapseGroup();
+  const mainGroup = useCollapseGroup();
 
   useEffect(() => {
     if (!ns) {
@@ -2079,9 +2092,11 @@ function PodSummary({
         )}
         {d.tolerations.length > 0 && (
           <DetailRow t={t} label="Tolerations">
-            <span style={{ fontSize: FS_MD, color: t.textDim }}>
-              {d.tolerations.length} total
-            </span>
+            <ExpandableList
+              t={t}
+              items={d.tolerations}
+              render={(items) => <TolerationList t={t} tolerations={items} />}
+            />
           </DetailRow>
         )}
         {d.conditions.length > 0 && (
@@ -2259,15 +2274,11 @@ function PodSummary({
             t={t}
             title="Init Containers"
             right={
-              <span
-                style={{
-                  fontSize: FS_XS,
-                  color: t.textMuted,
-                  fontFamily: FF_MONO,
-                }}
-              >
-                {initContainers.length} total
-              </span>
+              <ContainerSectionMeta
+                t={t}
+                count={initContainers.length}
+                group={initGroup}
+              />
             }
           />
           <div style={{ marginBottom: 22 }}>
@@ -2277,6 +2288,7 @@ function PodSummary({
                 t={t}
                 mode={mode}
                 c={c}
+                signal={initGroup.signal}
                 namespace={ns}
                 podName={name}
                 onNavigate={onNavigate}
@@ -2294,15 +2306,11 @@ function PodSummary({
             t={t}
             title="Containers"
             right={
-              <span
-                style={{
-                  fontSize: FS_XS,
-                  color: t.textMuted,
-                  fontFamily: FF_MONO,
-                }}
-              >
-                {mainContainers.length} total
-              </span>
+              <ContainerSectionMeta
+                t={t}
+                count={mainContainers.length}
+                group={mainGroup}
+              />
             }
           />
           <div style={{ marginBottom: 22 }}>
@@ -2312,6 +2320,7 @@ function PodSummary({
                 t={t}
                 mode={mode}
                 c={c}
+                signal={mainGroup.signal}
                 namespace={ns}
                 podName={name}
                 onNavigate={onNavigate}
@@ -2583,6 +2592,7 @@ function ContainerCard({
   t,
   mode,
   c,
+  signal,
   namespace,
   podName,
   onNavigate,
@@ -2592,6 +2602,7 @@ function ContainerCard({
   t: Tokens;
   mode: ThemeMode;
   c: ContainerDetail;
+  signal?: CollapseSignal;
   namespace: string | null;
   podName: string;
   onNavigate?: DetailNavigate;
@@ -2599,63 +2610,61 @@ function ContainerCard({
   volumeNames?: string[];
 }) {
   return (
-    <div
-      style={{
-        border: `1px solid ${t.borderSoft}`,
-        borderRadius: R_LG,
-        marginBottom: 10,
-        background: t.surface,
-        overflow: "hidden",
-      }}
+    <CollapsibleCard
+      t={t}
+      signal={signal}
+      header={(open) => (
+        <>
+          <ContainerDots
+            containers={[
+              { name: c.name, status: c.state, kind: c.kind, ready: c.ready },
+            ]}
+            t={t}
+            showSeparator={false}
+          />
+          <span
+            style={{
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+              flex: 1,
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {c.name}
+          </span>
+          {!open && c.restart_count > 0 && (
+            <span
+              style={{
+                fontSize: FS_XS,
+                fontFamily: FF_MONO,
+                fontWeight: 600,
+                color: c.restart_count > 5 ? t.bad : t.warn,
+                flexShrink: 0,
+              }}
+            >
+              {c.restart_count} restart{c.restart_count === 1 ? "" : "s"}
+            </span>
+          )}
+          <span
+            style={{
+              fontSize: FS_XS,
+              fontWeight: 700,
+              color: t.textMuted,
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+              fontFamily: FF_MONO,
+            }}
+          >
+            {c.kind}
+          </span>
+          <StatusPill status={c.state} t={t} mode={mode} dense />
+        </>
+      )}
     >
-      {/* Header — name + status + kind tag */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 10,
-          padding: "10px 12px",
-          background: t.surfaceAlt,
-          borderBottom: `1px solid ${t.borderSoft}`,
-        }}
-      >
-        <ContainerDots
-          containers={[
-            { name: c.name, status: c.state, kind: c.kind, ready: c.ready },
-          ]}
-          t={t}
-          showSeparator={false}
-        />
-        <span
-          style={{
-            fontFamily: FF_MONO,
-            fontSize: FS_MD,
-            fontWeight: 600,
-            flex: 1,
-            minWidth: 0,
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {c.name}
-        </span>
-        <span
-          style={{
-            fontSize: FS_XS,
-            fontWeight: 700,
-            color: t.textMuted,
-            textTransform: "uppercase",
-            letterSpacing: 0.4,
-            fontFamily: FF_MONO,
-          }}
-        >
-          {c.kind}
-        </span>
-        <StatusPill status={c.state} t={t} mode={mode} dense />
-      </div>
-
-      <div style={{ padding: "4px 12px" }}>
         <DetailRow t={t} label="Status">
           <span style={{ fontSize: FS_MD, color: c.ready ? t.good : t.textDim }}>
             {c.state.toLowerCase()}
@@ -2984,8 +2993,7 @@ function ContainerCard({
             <ContainerSecurityRow t={t} s={c.security} />
           </DetailRow>
         )}
-      </div>
-    </div>
+    </CollapsibleCard>
   );
 }
 

--- a/ui/src/components/detail/collapsibleCard.test.tsx
+++ b/ui/src/components/detail/collapsibleCard.test.tsx
@@ -1,0 +1,145 @@
+// Tests for the collapsible container chrome: CollapsibleCard (per-card
+// toggle, body kept mounted via display so embedded editors survive a
+// collapse), and useCollapseGroup + ExpandAllButton (bulk expand/collapse
+// that still allows individual toggles).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import {
+  CollapsibleCard,
+  Copyable,
+  ExpandAllButton,
+  useCollapseGroup,
+} from "./primitives";
+import { tokens } from "../../theme";
+
+const t = tokens("dark");
+
+let clipboardWrites: string[];
+beforeEach(() => {
+  clipboardWrites = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn(async (text: string) => {
+        clipboardWrites.push(text);
+      }),
+    },
+  });
+});
+
+describe("CollapsibleCard", () => {
+  it("starts collapsed: header shown, body mounted but not visible", () => {
+    render(
+      <CollapsibleCard t={t} header={() => <span>hdr</span>}>
+        <span>body</span>
+      </CollapsibleCard>,
+    );
+    expect(screen.getByText("hdr")).toBeInTheDocument();
+    // Body stays in the DOM (so embedded editors keep their state) but is
+    // hidden until expanded.
+    expect(screen.getByText("body")).toBeInTheDocument();
+    expect(screen.getByText("body")).not.toBeVisible();
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("toggles the body open and closed on header click", () => {
+    render(
+      <CollapsibleCard t={t} header={() => <span>hdr</span>}>
+        <span>body</span>
+      </CollapsibleCard>,
+    );
+    const header = screen.getByRole("button");
+    fireEvent.click(header);
+    expect(screen.getByText("body")).toBeVisible();
+    expect(header).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(header);
+    expect(screen.getByText("body")).not.toBeVisible();
+  });
+
+  it("passes the open state to the header render-prop", () => {
+    render(
+      <CollapsibleCard
+        t={t}
+        header={(open) => <span>{open ? "is-open" : "is-closed"}</span>}
+      >
+        <span>body</span>
+      </CollapsibleCard>,
+    );
+    expect(screen.getByText("is-closed")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("is-open")).toBeInTheDocument();
+  });
+
+  it("honours defaultOpen", () => {
+    render(
+      <CollapsibleCard t={t} defaultOpen header={() => <span>hdr</span>}>
+        <span>body</span>
+      </CollapsibleCard>,
+    );
+    expect(screen.getByText("body")).toBeVisible();
+  });
+
+  it("a Copyable inside the header copies without toggling the card", () => {
+    render(
+      <CollapsibleCard
+        t={t}
+        header={() => (
+          <Copyable text="container-name">
+            <span>name</span>
+          </Copyable>
+        )}
+      >
+        <span>body</span>
+      </CollapsibleCard>,
+    );
+    fireEvent.click(screen.getByText("name"));
+    expect(clipboardWrites).toEqual(["container-name"]);
+    // Click was absorbed by Copyable — the card must not have expanded.
+    expect(screen.getByText("body")).not.toBeVisible();
+  });
+});
+
+function Group() {
+  const group = useCollapseGroup();
+  return (
+    <>
+      <ExpandAllButton t={t} allOpen={group.allOpen} onToggle={group.toggleAll} />
+      <CollapsibleCard t={t} signal={group.signal} header={() => <span>h1</span>}>
+        <span>body1</span>
+      </CollapsibleCard>
+      <CollapsibleCard t={t} signal={group.signal} header={() => <span>h2</span>}>
+        <span>body2</span>
+      </CollapsibleCard>
+    </>
+  );
+}
+
+describe("useCollapseGroup + ExpandAllButton", () => {
+  it("bulk-expands and bulk-collapses every card, flipping the label", () => {
+    render(<Group />);
+    const bulk = screen.getByRole("button", { name: /expand all/i });
+    expect(screen.getByText("body1")).not.toBeVisible();
+    expect(screen.getByText("body2")).not.toBeVisible();
+
+    fireEvent.click(bulk);
+    expect(screen.getByText("body1")).toBeVisible();
+    expect(screen.getByText("body2")).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: /collapse all/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /collapse all/i }));
+    expect(screen.getByText("body1")).not.toBeVisible();
+    expect(screen.getByText("body2")).not.toBeVisible();
+  });
+
+  it("lets an individual card toggle without disturbing its sibling", () => {
+    render(<Group />);
+    fireEvent.click(screen.getByRole("button", { name: /expand all/i }));
+    // Collapse only the first card via its own header.
+    fireEvent.click(screen.getByText("h1"));
+    expect(screen.getByText("body1")).not.toBeVisible();
+    expect(screen.getByText("body2")).toBeVisible();
+  });
+});

--- a/ui/src/components/detail/index.ts
+++ b/ui/src/components/detail/index.ts
@@ -11,6 +11,10 @@ export {
   LinkValue,
   ChipWrap,
   Mute,
+  ExpandableList,
+  CollapsibleCard,
+  useCollapseGroup,
+  ExpandAllButton,
   ConditionChip,
   SubGrid,
   ChipStrip,
@@ -23,6 +27,7 @@ export type {
   SubGroup,
   ChipStripItem,
   ConditionStatus,
+  CollapseSignal,
 } from "./primitives";
 export { ageFromIso, formatQuantity, parseQuantity } from "./helpers";
 export {

--- a/ui/src/components/detail/primitives.test.tsx
+++ b/ui/src/components/detail/primitives.test.tsx
@@ -10,7 +10,9 @@ import {
   ChipStrip,
   ConditionChip,
   Copyable,
+  copyHint,
   DetailRow,
+  ExpandableList,
   KeyValueChips,
   LinkValue,
   Mute,
@@ -103,6 +105,81 @@ describe("Copyable", () => {
     fireEvent.click(screen.getByText("v"));
     expect(onParent).not.toHaveBeenCalled();
     expect(clipboardWrites).toEqual(["x"]);
+  });
+});
+
+describe("copyHint", () => {
+  it("echoes a short single-line value so the operator can confirm it", () => {
+    expect(copyHint("postgres://example")).toBe(
+      "Click to copy · postgres://example",
+    );
+  });
+
+  it("drops the echo for a multi-line value (would be a wall of text)", () => {
+    expect(copyHint("line one\nline two")).toBe("Click to copy");
+  });
+
+  it("drops the echo once the value exceeds the length cap", () => {
+    expect(copyHint("a".repeat(81))).toBe("Click to copy");
+  });
+
+  it("keeps echoing right up to the length cap (no off-by-one)", () => {
+    const at = "a".repeat(80);
+    expect(copyHint(at)).toBe(`Click to copy · ${at}`);
+  });
+});
+
+describe("ExpandableList", () => {
+  const renderItems = (items: string[]) => (
+    <>
+      {items.map((it) => (
+        <span key={it}>{it}</span>
+      ))}
+    </>
+  );
+
+  it("renders everything with no toggle when at or under the threshold", () => {
+    const items = Array.from({ length: 10 }, (_, i) => `item-${i}`);
+    render(<ExpandableList t={t} items={items} render={renderItems} />);
+    expect(screen.getByText("item-0")).toBeInTheDocument();
+    expect(screen.getByText("item-9")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("shows only the first `threshold` items and a 'Show N more' toggle past it", () => {
+    const items = Array.from({ length: 13 }, (_, i) => `item-${i}`);
+    render(<ExpandableList t={t} items={items} render={renderItems} />);
+    // First 10 visible, 11th+ hidden.
+    expect(screen.getByText("item-9")).toBeInTheDocument();
+    expect(screen.queryByText("item-10")).not.toBeInTheDocument();
+    const toggle = screen.getByRole("button");
+    expect(toggle).toHaveTextContent("Show 3 more");
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("reveals the rest on click and re-collapses on 'Show less'", () => {
+    const items = Array.from({ length: 13 }, (_, i) => `item-${i}`);
+    render(<ExpandableList t={t} items={items} render={renderItems} />);
+    const toggle = screen.getByRole("button");
+
+    fireEvent.click(toggle);
+    expect(screen.getByText("item-12")).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Show less");
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(toggle);
+    expect(screen.queryByText("item-12")).not.toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Show 3 more");
+  });
+
+  it("honours a custom threshold", () => {
+    const items = ["a", "b", "c"];
+    render(
+      <ExpandableList t={t} items={items} threshold={2} render={renderItems} />,
+    );
+    expect(screen.getByText("b")).toBeInTheDocument();
+    expect(screen.queryByText("c")).not.toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveTextContent("Show 1 more");
   });
 });
 

--- a/ui/src/components/detail/primitives.tsx
+++ b/ui/src/components/detail/primitives.tsx
@@ -5,13 +5,14 @@
 // components compose these — they never reach in.
 
 import {
+  useEffect,
   useMemo,
   useRef,
   useState,
   type CSSProperties,
   type ReactNode,
 } from "react";
-import { FF_MONO, type Tokens, R_SM, FS_MD, FS_SM, FS_XS } from "../../theme";
+import { FF_MONO, type Tokens, R_SM, R_LG, FS_MD, FS_SM, FS_XS } from "../../theme";
 import { Chip, Icons, Tooltip } from "../ui";
 
 // ── Cross-kind navigation ──────────────────────────────────────────────────
@@ -105,6 +106,222 @@ export function Mute({ t, children }: { t: Tokens; children: ReactNode }) {
   return <span style={{ color: t.textMuted, fontSize: FS_MD }}>{children}</span>;
 }
 
+// ── ExpandableList ───────────────────────────────────────────────────────────
+// Read-only "show the first N, expand the rest" list for bulky collections
+// (annotations, tolerations, …). A small collection (≤ `threshold`) renders in
+// full with no chrome — most resources sit here, so no extra click. A large
+// one renders the first `threshold` items plus a "Show N more" toggle, keeping
+// the metadata block scannable without hiding the common case behind a count.
+// `render` is handed the slice to draw so callers that batch-render an array
+// (KeyValueChips) work unchanged.
+export const EXPANDABLE_LIST_THRESHOLD = 10;
+
+export function ExpandableList<T>({
+  t,
+  items,
+  threshold = EXPANDABLE_LIST_THRESHOLD,
+  render,
+}: {
+  t: Tokens;
+  items: T[];
+  threshold?: number;
+  render: (items: T[]) => ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const overflow = items.length > threshold;
+  const shown = overflow && !open ? items.slice(0, threshold) : items;
+  return (
+    <div style={{ width: "100%", minWidth: 0 }}>
+      {render(shown)}
+      {overflow && (
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            marginTop: 6,
+            padding: 0,
+            border: "none",
+            background: "transparent",
+            color: t.textDim,
+            cursor: "pointer",
+            fontSize: FS_SM,
+            fontFamily: "inherit",
+          }}
+        >
+          <span
+            style={{
+              display: "inline-flex",
+              color: t.textMuted,
+              transform: open ? "rotate(0deg)" : "rotate(-90deg)",
+              transition: "transform .12s ease",
+            }}
+          >
+            {Icons.chevD}
+          </span>
+          {open ? "Show less" : `Show ${items.length - threshold} more`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── CollapsibleCard ──────────────────────────────────────────────────────────
+// Bordered card with a click-to-toggle header and a hideable body. Used by the
+// container cards (Pod detail + workload Pod Template) so a long list of
+// init/sidecar containers collapses to a scannable row list, each expandable
+// on demand. Starts collapsed by default.
+//
+// The body is hidden with `display: none` rather than unmounted: the container
+// cards embed live edit-kit editors (`useEditField`) whose dirty buffers and
+// GlobalSaveBar registration must survive a collapse. Unmounting would drop an
+// in-flight edit; `display: none` keeps it mounted and intact.
+//
+// `header` is a render-prop of the open state so callers can show a compact
+// summary (image, status) only while collapsed and drop it once the full body
+// is visible. The whole header bar toggles; interactive children inside the
+// header (a `Copyable` name) stop propagation, so they act without toggling.
+//
+// `signal` lets a parent drive every card at once (an "Expand all" button)
+// while still allowing per-card toggles in between: when the signal's `nonce`
+// changes, the card snaps to the signalled `open`. See `useCollapseGroup`.
+export type CollapseSignal = { open: boolean; nonce: number };
+
+export function CollapsibleCard({
+  t,
+  header,
+  children,
+  defaultOpen = false,
+  signal,
+}: {
+  t: Tokens;
+  header: (open: boolean) => ReactNode;
+  children: ReactNode;
+  defaultOpen?: boolean;
+  signal?: CollapseSignal;
+}) {
+  const [open, setOpen] = useState(signal ? signal.open : defaultOpen);
+  const toggle = () => setOpen((o) => !o);
+  // Follow bulk expand/collapse: re-run only when the nonce ticks, so an
+  // individual toggle isn't clobbered on every parent re-render.
+  useEffect(() => {
+    if (signal) setOpen(signal.open);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signal?.nonce]);
+  return (
+    <div
+      style={{
+        border: `1px solid ${t.borderSoft}`,
+        borderRadius: R_LG,
+        marginBottom: 10,
+        background: t.surface,
+        overflow: "hidden",
+      }}
+    >
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        onClick={toggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            toggle();
+          }
+        }}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 10,
+          padding: "10px 12px",
+          background: t.surfaceAlt,
+          borderBottom: open ? `1px solid ${t.borderSoft}` : "none",
+          cursor: "pointer",
+        }}
+      >
+        <span
+          aria-hidden
+          style={{
+            display: "inline-flex",
+            color: t.textMuted,
+            transform: open ? "rotate(0deg)" : "rotate(-90deg)",
+            transition: "transform .12s ease",
+            flexShrink: 0,
+          }}
+        >
+          {Icons.chevD}
+        </span>
+        {header(open)}
+      </div>
+      {/* display toggle (not unmount) keeps embedded editors' state alive */}
+      <div style={{ padding: "4px 12px", display: open ? "block" : "none" }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// Drives a group of CollapsibleCards from one "Expand all / Collapse all"
+// control. `signal` is handed to every card; `expandAll` / `collapseAll` bump
+// its nonce so the cards snap open/closed. `allOpen` reflects the last bulk
+// action — what the toggle button should do next — not each card's live state
+// (individual toggles intentionally don't flip the bulk label).
+export function useCollapseGroup(defaultOpen = false) {
+  const [open, setOpen] = useState(defaultOpen);
+  const [nonce, setNonce] = useState(0);
+  const setAll = (v: boolean) => {
+    setOpen(v);
+    setNonce((n) => n + 1);
+  };
+  return {
+    signal: { open, nonce } as CollapseSignal,
+    allOpen: open,
+    expandAll: () => setAll(true),
+    collapseAll: () => setAll(false),
+    toggleAll: () => setAll(!open),
+  };
+}
+
+// Compact "Expand all / Collapse all" toggle for a CollapsibleCard group.
+// Drop into a Section's `right` slot next to the count.
+export function ExpandAllButton({
+  t,
+  allOpen,
+  onToggle,
+}: {
+  t: Tokens;
+  allOpen: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={allOpen}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding: 0,
+        border: "none",
+        background: "transparent",
+        color: t.textDim,
+        cursor: "pointer",
+        fontSize: FS_XS,
+        fontFamily: FF_MONO,
+        textTransform: "uppercase",
+        letterSpacing: 0.4,
+        fontWeight: 700,
+      }}
+    >
+      {allOpen ? "Collapse all" : "Expand all"}
+    </button>
+  );
+}
+
 // ── useCopyFlash ───────────────────────────────────────────────────────────
 // Hook that returns (ref, flash). Apply the ref to the element you want to
 // pulse, call flash() to trigger the .fs-copy-flash animation. Re-runnable
@@ -125,6 +342,18 @@ function copyToClipboard(text: string) {
   if (typeof navigator !== "undefined" && navigator.clipboard) {
     navigator.clipboard.writeText(text).catch(() => {});
   }
+}
+
+// The tooltip echoes the value so the operator can confirm what they'll copy.
+// But a multi-line or very long value (a whole ConfigMap blob, a JSON manifest)
+// turns that hint into an unreadable wall of text — and the value is already
+// visible in the panel right under the cursor. Past this point, drop the echo
+// and keep just the gesture.
+const COPY_HINT_MAX = 80;
+
+export function copyHint(text: string): string {
+  if (text.length > COPY_HINT_MAX || text.includes("\n")) return "Click to copy";
+  return `Click to copy · ${text}`;
 }
 
 // ── Copyable ───────────────────────────────────────────────────────────────
@@ -151,16 +380,17 @@ export function Copyable({
     copyToClipboard(text);
     flash();
   };
+  const hint = copyHint(text);
   const tooltip: ReactNode =
     label != null ? (
       <span style={{ display: "block" }}>
         {label}
         <span style={{ display: "block", opacity: 0.7, marginTop: 4 }}>
-          Click to copy · {text}
+          {hint}
         </span>
       </span>
     ) : (
-      `Click to copy · ${text}`
+      hint
     );
   return (
     <Tooltip label={tooltip}>

--- a/ui/src/components/detail/workload/shared.collapsedPairs.test.tsx
+++ b/ui/src/components/detail/workload/shared.collapsedPairs.test.tsx
@@ -1,0 +1,42 @@
+// Regression test for CollapsedPairs — the "show first N, expand the rest"
+// collapse used by the Annotations row. Small sets render in full; only past
+// the threshold do extra pairs hide behind a "Show N more" toggle.
+
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { CollapsedPairs } from "./shared";
+import { tokens } from "../../../theme";
+
+const t = tokens("dark");
+
+function pairs(n: number): [string, string][] {
+  return Array.from({ length: n }, (_, i) => [`key-${i}`, `val-${i}`]);
+}
+
+describe("CollapsedPairs", () => {
+  it("renders every pair with no toggle when at or under the threshold", () => {
+    render(<CollapsedPairs t={t} pairs={pairs(5)} />);
+    expect(screen.getByText("key-0=val-0")).toBeInTheDocument();
+    expect(screen.getByText("key-4=val-4")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("shows the first 10 and hides the rest behind 'Show N more' past the threshold", () => {
+    render(<CollapsedPairs t={t} pairs={pairs(13)} />);
+    expect(screen.getByText("key-9=val-9")).toBeInTheDocument();
+    expect(screen.queryByText("key-10=val-10")).not.toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveTextContent("Show 3 more");
+  });
+
+  it("expands to reveal the rest, then re-collapses", () => {
+    render(<CollapsedPairs t={t} pairs={pairs(13)} />);
+    const toggle = screen.getByRole("button");
+
+    fireEvent.click(toggle);
+    expect(screen.getByText("key-12=val-12")).toBeInTheDocument();
+    expect(toggle).toHaveTextContent("Show less");
+
+    fireEvent.click(toggle);
+    expect(screen.queryByText("key-12=val-12")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/detail/workload/shared.tolerations.test.tsx
+++ b/ui/src/components/detail/workload/shared.tolerations.test.tsx
@@ -1,0 +1,145 @@
+// Tests for the toleration renderers shared by the Pod detail and every
+// workload's Pod Template block. Before this, both surfaces showed "N total"
+// with no way to see the tolerations — these pin the canonical formatting and
+// the copy behaviour so a regression fails here.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { formatToleration, TolerationList } from "./shared";
+import { tokens } from "../../../theme";
+import type { PodToleration } from "../../../types";
+
+const t = tokens("dark");
+
+let clipboardWrites: string[];
+beforeEach(() => {
+  clipboardWrites = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: vi.fn(async (text: string) => {
+        clipboardWrites.push(text);
+      }),
+    },
+  });
+});
+
+describe("formatToleration", () => {
+  it("formats the common not-ready/Exists/NoExecute taint with a timeout", () => {
+    const tol: PodToleration = {
+      key: "node.kubernetes.io/not-ready",
+      operator: "Exists",
+      value: null,
+      effect: "NoExecute",
+      toleration_seconds: 300,
+    };
+    expect(formatToleration(tol)).toBe(
+      "node.kubernetes.io/not-ready:NoExecute op=Exists for 300s",
+    );
+  });
+
+  it("formats an Equal toleration with a value and no timeout", () => {
+    const tol: PodToleration = {
+      key: "dedicated",
+      operator: "Equal",
+      value: "gpu",
+      effect: "NoSchedule",
+      toleration_seconds: null,
+    };
+    expect(formatToleration(tol)).toBe("dedicated=gpu:NoSchedule op=Equal");
+  });
+
+  it("surfaces tolerate-everything (no key, no effect) rather than rendering blank", () => {
+    const tol: PodToleration = {
+      key: null,
+      operator: "Exists",
+      value: null,
+      effect: null,
+      toleration_seconds: null,
+    };
+    expect(formatToleration(tol)).toBe("*:* op=Exists");
+  });
+});
+
+describe("TolerationList", () => {
+  const tols: PodToleration[] = [
+    {
+      key: "node.kubernetes.io/not-ready",
+      operator: "Exists",
+      value: null,
+      effect: "NoExecute",
+      toleration_seconds: 300,
+    },
+    {
+      key: "dedicated",
+      operator: "Equal",
+      value: "gpu",
+      effect: "NoSchedule",
+      toleration_seconds: null,
+    },
+  ];
+
+  it("renders the key, effect chip, and eviction grace period per toleration", () => {
+    render(<TolerationList t={t} tolerations={tols} />);
+    // Structured fields are shown separately, not as one mono string.
+    expect(
+      screen.getByText("node.kubernetes.io/not-ready"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("NoExecute")).toBeInTheDocument();
+    expect(screen.getByText("evict after 300s")).toBeInTheDocument();
+    expect(screen.getByText("NoSchedule")).toBeInTheDocument();
+  });
+
+  it("shows the value for Equal but ignores it for Exists", () => {
+    render(
+      <TolerationList
+        t={t}
+        tolerations={[
+          // Equal → value is meaningful, render it.
+          {
+            key: "dedicated",
+            operator: "Equal",
+            value: "gpu",
+            effect: "NoSchedule",
+            toleration_seconds: null,
+          },
+          // Exists matches any value, so a stray value must not be shown.
+          {
+            key: "spot",
+            operator: "Exists",
+            value: "ignored",
+            effect: "NoSchedule",
+            toleration_seconds: null,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("gpu")).toBeInTheDocument();
+    expect(screen.queryByText("ignored")).not.toBeInTheDocument();
+  });
+
+  it("renders a keyless Exists as 'any taint' with 'all effects'", () => {
+    render(
+      <TolerationList
+        t={t}
+        tolerations={[
+          {
+            key: null,
+            operator: "Exists",
+            value: null,
+            effect: null,
+            toleration_seconds: null,
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("any taint")).toBeInTheDocument();
+    expect(screen.getByText("all effects")).toBeInTheDocument();
+  });
+
+  it("click-copies the canonical kubectl form", () => {
+    render(<TolerationList t={t} tolerations={tols} />);
+    fireEvent.click(screen.getByText("dedicated"));
+    expect(clipboardWrites).toEqual(["dedicated=gpu:NoSchedule op=Equal"]);
+  });
+});

--- a/ui/src/components/detail/workload/shared.tsx
+++ b/ui/src/components/detail/workload/shared.tsx
@@ -7,7 +7,6 @@ import { useMemo, useState } from "react";
 import {
   FF_MONO,
   type Tokens,
-  R_LG,
   R_SM,
   R_PILL,
   CONTROL_H,
@@ -28,8 +27,11 @@ import {
 import {
   ChipStrip,
   ChipWrap,
+  CollapsibleCard,
   Copyable,
   DetailRow,
+  ExpandableList,
+  ExpandAllButton,
   KeyValueChips,
   LinkValue,
   Mute,
@@ -37,8 +39,10 @@ import {
   ageFromIso,
   formatQuantity,
   parseQuantity,
+  useCollapseGroup,
   useEditField,
   useEditSession,
+  type CollapseSignal,
   type DetailNavigate,
 } from "..";
 import {
@@ -65,6 +69,7 @@ import type {
   ContainerPort,
   LabelSelectorSummary,
   PodTemplateSummary,
+  PodToleration,
   PodVolume,
   WorkloadCondition,
   WorkloadContainerSummary,
@@ -423,10 +428,8 @@ export function MetaPairsRow({
             </>
           ) : pairs.length === 0 ? (
             <Mute t={t}>—</Mute>
-          ) : collapsedAsCount && pairs.length > 4 ? (
-            <span style={{ fontSize: FS_MD, color: t.textDim }}>
-              {pairs.length} total
-            </span>
+          ) : collapsedAsCount ? (
+            <CollapsedPairs t={t} pairs={pairs} />
           ) : (
             <KeyValueChips t={t} pairs={pairs} />
           )}
@@ -446,6 +449,169 @@ export function MetaPairsRow({
         </div>
       </DetailRow>
     </>
+  );
+}
+
+// Read-only collapse for commonly-bulky pair lists (annotations). Small sets
+// render in full; once there are more than the threshold, the first N show
+// and the rest hide behind a "Show N more" toggle. Each long value
+// (last-applied-configuration, controller state) still collapses individually
+// inside KeyValueChips.
+export function CollapsedPairs({
+  t,
+  pairs,
+}: {
+  t: Tokens;
+  pairs: [string, string][];
+}) {
+  return (
+    <ExpandableList
+      t={t}
+      items={pairs}
+      render={(items) => <KeyValueChips t={t} pairs={items} />}
+    />
+  );
+}
+
+// Canonical kubectl-ish one-line form for a toleration, e.g.
+//   node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
+//   dedicated=gpu:NoSchedule op=Equal
+// A bare `op=Exists` with no key tolerates everything; an empty effect
+// tolerates all effects — surface both rather than rendering a blank.
+export function formatToleration(tol: PodToleration): string {
+  const key = tol.key ?? "*";
+  const value = tol.value ? `=${tol.value}` : "";
+  const effect = tol.effect ? `:${tol.effect}` : ":*";
+  const op = tol.operator ? ` op=${tol.operator}` : "";
+  const secs =
+    tol.toleration_seconds != null ? ` for ${tol.toleration_seconds}s` : "";
+  return `${key}${value}${effect}${op}${secs}`;
+}
+
+// Effect → severity colour + display label. NoExecute is the strongest (it
+// can evict an already-running pod), NoSchedule blocks placement, and
+// PreferNoSchedule is a soft preference. A missing effect tolerates every
+// effect on the matched key. Colours derive from the active palette's status
+// buckets (same approach as ConditionChip / statusFill) — no hardcoded hex.
+function effectFill(
+  t: Tokens,
+  effect: string | null,
+): { bg: string; fg: string; label: string } {
+  switch (effect) {
+    case "NoExecute":
+      return { bg: hexWithAlpha(t.bad, 0.16), fg: t.bad, label: "NoExecute" };
+    case "NoSchedule":
+      return { bg: hexWithAlpha(t.warn, 0.16), fg: t.warn, label: "NoSchedule" };
+    case "PreferNoSchedule":
+      return {
+        bg: hexWithAlpha(t.info, 0.16),
+        fg: t.info,
+        label: "PreferNoSchedule",
+      };
+    default:
+      return { bg: t.chip, fg: t.textMuted, label: "all effects" };
+  }
+}
+
+// Renders a list of tolerations as structured, colour-coded rows. Shared by
+// the Pod detail and every workload's Pod Template block so the presentation
+// stays identical. Each row shows key (or "any taint" for a keyless Exists),
+// the matched value when operator is Equal, a severity-coloured effect chip,
+// and the eviction grace period when set. The whole row click-copies the
+// canonical kubectl form for pasting into a manifest.
+export function TolerationList({
+  t,
+  tolerations,
+}: {
+  t: Tokens;
+  tolerations: PodToleration[];
+}) {
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", gap: 6, width: "100%" }}
+    >
+      {tolerations.map((tol, i) => (
+        <TolerationRow key={i} t={t} tol={tol} />
+      ))}
+    </div>
+  );
+}
+
+function TolerationRow({ t, tol }: { t: Tokens; tol: PodToleration }) {
+  const eff = effectFill(t, tol.effect);
+  const wildcard = !tol.key; // keyless Exists tolerates every taint
+  // Only Equal carries a meaningful value; Exists matches any value for the key.
+  const showValue = tol.operator !== "Exists" && !!tol.value;
+  return (
+    <Copyable text={formatToleration(tol)} block>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          flexWrap: "wrap",
+          gap: 8,
+          padding: "5px 8px",
+          border: `1px solid ${t.borderSoft}`,
+          borderRadius: R_SM,
+          background: t.surface,
+          minWidth: 0,
+        }}
+      >
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "baseline",
+            gap: 4,
+            fontFamily: FF_MONO,
+            fontSize: FS_SM,
+            minWidth: 0,
+          }}
+        >
+          {wildcard ? (
+            <span style={{ color: t.textMuted, fontStyle: "italic" }}>
+              any taint
+            </span>
+          ) : (
+            <span style={{ color: t.text, wordBreak: "break-all" }}>
+              {tol.key}
+            </span>
+          )}
+          {showValue && (
+            <>
+              <span style={{ color: t.textMuted }}>=</span>
+              <span style={{ color: t.text, wordBreak: "break-all" }}>
+                {tol.value}
+              </span>
+            </>
+          )}
+        </span>
+
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            padding: "1px 7px",
+            borderRadius: R_SM,
+            fontSize: FS_XS,
+            fontWeight: 600,
+            fontFamily: FF_MONO,
+            background: eff.bg,
+            color: eff.fg,
+          }}
+        >
+          {eff.label}
+        </span>
+
+        {tol.toleration_seconds != null && (
+          <span
+            title={`Evicted ${tol.toleration_seconds}s after the taint is applied`}
+            style={{ fontSize: FS_XS, color: t.textMuted, fontFamily: FF_MONO }}
+          >
+            evict after {tol.toleration_seconds}s
+          </span>
+        )}
+      </div>
+    </Copyable>
   );
 }
 
@@ -596,6 +762,8 @@ export function PodTemplateSection({
 }) {
   const initContainers = template.containers.filter((c) => c.kind === "init");
   const mainContainers = template.containers.filter((c) => c.kind !== "init");
+  const initGroup = useCollapseGroup();
+  const mainGroup = useCollapseGroup();
   const hostFlags: { label: string; tone: "bad" }[] = [];
   if (template.host_network) hostFlags.push({ label: "hostNetwork", tone: "bad" });
   if (template.host_pid) hostFlags.push({ label: "hostPID", tone: "bad" });
@@ -610,11 +778,9 @@ export function PodTemplateSection({
             <KeyValueChips t={t} pairs={template.labels} />
           </DetailRow>
         )}
-        {template.annotations_count > 0 && (
+        {template.annotations.length > 0 && (
           <DetailRow t={t} label="Pod Annotations">
-            <span style={{ fontSize: FS_MD, color: t.textDim }}>
-              {template.annotations_count} total
-            </span>
+            <CollapsedPairs t={t} pairs={template.annotations} />
           </DetailRow>
         )}
         {template.service_account && (
@@ -654,11 +820,13 @@ export function PodTemplateSection({
             <KeyValueChips t={t} pairs={template.node_selector} />
           </DetailRow>
         )}
-        {template.tolerations_count > 0 && (
+        {template.tolerations.length > 0 && (
           <DetailRow t={t} label="Tolerations">
-            <span style={{ fontSize: FS_MD, color: t.textDim }}>
-              {template.tolerations_count} total
-            </span>
+            <ExpandableList
+              t={t}
+              items={template.tolerations}
+              render={(items) => <TolerationList t={t} tolerations={items} />}
+            />
           </DetailRow>
         )}
         {template.image_pull_secrets.length > 0 && (
@@ -691,15 +859,11 @@ export function PodTemplateSection({
             t={t}
             title="Init Containers"
             right={
-              <span
-                style={{
-                  fontSize: FS_XS,
-                  color: t.textMuted,
-                  fontFamily: FF_MONO,
-                }}
-              >
-                {initContainers.length} total
-              </span>
+              <ContainerSectionMeta
+                t={t}
+                count={initContainers.length}
+                group={initGroup}
+              />
             }
           />
           <div style={{ marginBottom: 22 }}>
@@ -708,6 +872,7 @@ export function PodTemplateSection({
                 key={c.name}
                 t={t}
                 c={c}
+                signal={initGroup.signal}
                 editTarget={editTarget}
                 templateKind={templateKind}
                 onNavigate={onNavigate}
@@ -726,15 +891,11 @@ export function PodTemplateSection({
             t={t}
             title="Containers"
             right={
-              <span
-                style={{
-                  fontSize: FS_XS,
-                  color: t.textMuted,
-                  fontFamily: FF_MONO,
-                }}
-              >
-                {mainContainers.length} total
-              </span>
+              <ContainerSectionMeta
+                t={t}
+                count={mainContainers.length}
+                group={mainGroup}
+              />
             }
           />
           <div style={{ marginBottom: 22 }}>
@@ -743,6 +904,7 @@ export function PodTemplateSection({
                 key={c.name}
                 t={t}
                 c={c}
+                signal={mainGroup.signal}
                 editTarget={editTarget}
                 templateKind={templateKind}
                 onNavigate={onNavigate}
@@ -782,9 +944,41 @@ export function PodTemplateSection({
   );
 }
 
+// Count + "Expand all / Collapse all" toggle for a container section header.
+// The bulk toggle only appears when there's more than one card — a single
+// container has nothing to expand-all. Shared by the workload Pod Template and
+// the Pod detail's container sections.
+export function ContainerSectionMeta({
+  t,
+  count,
+  group,
+}: {
+  t: Tokens;
+  count: number;
+  group: { allOpen: boolean; toggleAll: () => void };
+}) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 10 }}>
+      {count > 1 && (
+        <ExpandAllButton
+          t={t}
+          allOpen={group.allOpen}
+          onToggle={group.toggleAll}
+        />
+      )}
+      <span
+        style={{ fontSize: FS_XS, color: t.textMuted, fontFamily: FF_MONO }}
+      >
+        {count} total
+      </span>
+    </span>
+  );
+}
+
 function ContainerSummaryCard({
   t,
   c,
+  signal,
   editTarget,
   templateKind = "workload",
   onNavigate,
@@ -794,6 +988,7 @@ function ContainerSummaryCard({
 }: {
   t: Tokens;
   c: WorkloadContainerSummary;
+  signal?: CollapseSignal;
   editTarget?: ApplyTarget;
   templateKind?: "workload" | "cronjob";
   onNavigate?: DetailNavigate;
@@ -812,55 +1007,58 @@ function ContainerSummaryCard({
     (c.requests && Object.keys(c.requests).length > 0) ||
     (c.limits && Object.keys(c.limits).length > 0);
   return (
-    <div
-      style={{
-        border: `1px solid ${t.borderSoft}`,
-        borderRadius: R_LG,
-        marginBottom: 10,
-        background: t.surface,
-        overflow: "hidden",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 10,
-          padding: "10px 12px",
-          background: t.surfaceAlt,
-          borderBottom: `1px solid ${t.borderSoft}`,
-        }}
-      >
-        <Copyable text={c.name}>
+    <CollapsibleCard
+      t={t}
+      signal={signal}
+      header={(open) => (
+        <>
+          <Copyable text={c.name}>
+            <span
+              style={{
+                fontFamily: FF_MONO,
+                fontSize: FS_MD,
+                fontWeight: 600,
+                flex: 1,
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {c.name}
+            </span>
+          </Copyable>
           <span
             style={{
+              fontSize: FS_XS,
+              fontWeight: 700,
+              color: t.textMuted,
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
               fontFamily: FF_MONO,
-              fontSize: FS_MD,
-              fontWeight: 600,
-              flex: 1,
-              minWidth: 0,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
             }}
           >
-            {c.name}
+            {c.kind}
           </span>
-        </Copyable>
-        <span
-          style={{
-            fontSize: FS_XS,
-            fontWeight: 700,
-            color: t.textMuted,
-            textTransform: "uppercase",
-            letterSpacing: 0.4,
-            fontFamily: FF_MONO,
-          }}
-        >
-          {c.kind}
-        </span>
-      </div>
-      <div style={{ padding: "4px 12px" }}>
+          {!open && c.image && (
+            <span
+              style={{
+                fontFamily: FF_MONO,
+                fontSize: FS_XS,
+                color: t.textMuted,
+                minWidth: 0,
+                maxWidth: "50%",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {c.image}
+            </span>
+          )}
+        </>
+      )}
+    >
         {editTarget ? (
           <ImageEditor
             t={t}
@@ -1113,8 +1311,7 @@ function ContainerSummaryCard({
             />
           </>
         )}
-      </div>
-    </div>
+    </CollapsibleCard>
   );
 }
 

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -785,12 +785,12 @@ export type WorkloadContainerSummary = {
 
 export type PodTemplateSummary = {
   labels: [string, string][];
-  annotations_count: number;
+  annotations: [string, string][];
   containers: WorkloadContainerSummary[];
   service_account: string | null;
   restart_policy: string | null;
   node_selector: [string, string][];
-  tolerations_count: number;
+  tolerations: PodToleration[];
   volumes: PodVolume[];
   image_pull_secrets: string[];
   priority_class: string | null;


### PR DESCRIPTION
…ons, copyable title

Make the detail panel scannable when resources are large:

- Containers collapse to one-line cards (Pod detail + workload Pod Template) with a per-section Expand all / Collapse all toggle. Body is hidden via display, not unmount, so inline edit-kit editors keep their dirty buffers.
- Annotations and tolerations show the first 10 and hide the rest behind a "Show N more" toggle (ExpandableList), instead of a dead-end count.
- Tolerations render as structured, severity-coloured rows (effect chip, eviction grace period) shared by Pod and Pod Template; full data now projected from the backend (pod_template no longer ships bare counts).
- Copy tooltips drop the value echo for long/multiline values.
- Detail-panel title is now click-to-copy.

New primitives: ExpandableList, CollapsibleCard + useCollapseGroup / ExpandAllButton. Tests cover all new behaviour; projection snapshots updated.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
