### PR TITLE
Fix/gke auth exec path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ ui/.vite/
 # Env
 .env
 .env.local
+.claude/

--- a/crates/app/src/helm_install.rs
+++ b/crates/app/src/helm_install.rs
@@ -4,9 +4,9 @@
 //! inherit the shell's `PATH` and `brew install helm` lives in
 //! `/opt/homebrew/bin`) often don't have `helm` resolvable to the
 //! FerrisScope process. This module manages a copy under
-//! `<config>/bin/helm[.exe]`. Combined with the macOS PATH augmentation in
-//! `main.rs::augment_macos_path` (which prepends the managed-bin dir to
-//! `$PATH`), every later `Command::new("helm")` resolves transparently.
+//! `<config>/bin/helm[.exe]`. Combined with the PATH recovery in
+//! `path_env::augment_path` (which prepends the managed-bin dir to `$PATH`),
+//! every later `Command::new("helm")` resolves transparently.
 //!
 //! Source: helm's official archive mirror at `get.helm.sh`. We:
 //!   1. Read `https://get.helm.sh/helm-latest-version` for the latest stable

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -9,6 +9,7 @@ mod clipboard_image;
 mod commands;
 mod helm_install;
 mod kubectl_install;
+mod path_env;
 mod secret_storage;
 mod ssh_scratch;
 mod state;
@@ -89,13 +90,15 @@ fn main() {
     #[cfg(target_os = "linux")]
     tracing::info!(target: "ferrisscope::startup", "{linux_render_summary}");
 
-    // macOS GUI apps launched from Finder/Dock/Spotlight inherit a minimal
-    // PATH (/usr/bin:/bin:/usr/sbin:/sbin) — not the user's shell PATH. That
-    // means Homebrew/MacPorts-installed CLIs (helm, kubectl, …) are invisible
-    // to `which::which` and `Command::new("foo")` until we paste the well-
-    // known dirs back in. Must happen before any tool-detection cache fires.
-    #[cfg(target_os = "macos")]
-    augment_macos_path();
+    // Desktop launches from Finder/Dock/Spotlight (macOS) or a .desktop unit
+    // (Linux) inherit a minimal PATH (/usr/bin:/bin:/usr/sbin:/sbin on macOS),
+    // not the user's shell PATH. That means Homebrew/gcloud-SDK CLIs (helm,
+    // kubectl, …) and the kube exec-auth plugins (gke-gcloud-auth-plugin,
+    // aws-iam-authenticator, kubelogin) are invisible to `which::which` and
+    // `Command::new("foo")` until we recover the real PATH. Must run here —
+    // single-threaded, before the tokio runtime, any cluster connect, or a
+    // tool-detection cache. No-op on Windows.
+    path_env::augment_path();
 
     // Best-effort: drop any .fs-update-old leftovers from the previous swap.
     updater::cleanup_old_update_files();
@@ -457,143 +460,6 @@ fn configure_linux_render_env() -> String {
     format!("linux render: mode={mode} vendor={vendor} session={session} applied=[{applied_str}] (override via FERRISSCOPE_SAFE_MODE=1)")
 }
 
-/// Prepend well-known macOS tool dirs to the process `PATH`. Why: GUI apps
-/// launched outside a login shell (Finder, Dock, Spotlight, Launchpad) inherit
-/// `/usr/bin:/bin:/usr/sbin:/sbin` — none of which contain Homebrew or
-/// MacPorts. Anything we shell out to (helm install/uninstall/upgrade, an
-/// operator-installed kubectl, mcp binaries…) must still resolve via `$PATH`,
-/// so we paste the well-known dirs in once at startup. Idempotent: dirs
-/// already present in `PATH` are not duplicated.
-///
-/// We also include our own `<config>/bin` so a managed helm/kubectl install
-/// is picked up by `which::which` without a separate detection codepath.
-#[cfg(target_os = "macos")]
-fn augment_macos_path() {
-    use std::path::PathBuf;
-
-    // `(path, always_include)` — `always_include` skips the `is_dir` filter
-    // so we still cover paths that don't exist yet (notably our managed-bin
-    // dir on a fresh install: helm/kubectl land there *after* startup, and
-    // we want them resolvable without a restart).
-    let mut additions: Vec<(PathBuf, bool)> = vec![
-        // Homebrew Apple-silicon prefix.
-        (PathBuf::from("/opt/homebrew/bin"), false),
-        (PathBuf::from("/opt/homebrew/sbin"), false),
-        // Homebrew Intel prefix + traditional manual-install dir.
-        (PathBuf::from("/usr/local/bin"), false),
-        (PathBuf::from("/usr/local/sbin"), false),
-        // MacPorts.
-        (PathBuf::from("/opt/local/bin"), false),
-        (PathBuf::from("/opt/local/sbin"), false),
-    ];
-    if let Ok(home) = std::env::var("HOME") {
-        additions.push((PathBuf::from(format!("{home}/.local/bin")), false));
-    }
-    if let Some(managed) = kubectl_install::managed_bin_dir() {
-        additions.push((managed, true));
-    }
-
-    let existing = std::env::var_os("PATH").unwrap_or_default();
-    let existing_entries: Vec<PathBuf> = std::env::split_paths(&existing).collect();
-
-    let (new_entries, applied) = plan_path_additions(&additions, &existing_entries, |p| p.is_dir());
-
-    let summary = if applied.is_empty() {
-        "none".to_string()
-    } else {
-        applied.join(",")
-    };
-    match std::env::join_paths(&new_entries) {
-        Ok(joined) => {
-            std::env::set_var("PATH", joined);
-            tracing::info!(
-                target: "ferrisscope::startup",
-                "macos path: prepended=[{summary}]"
-            );
-        }
-        Err(e) => {
-            tracing::warn!(
-                target: "ferrisscope::startup",
-                "macos path: could not join entries — leaving PATH untouched ({e})"
-            );
-        }
-    }
-}
-
-/// Pure planner for the PATH augmentation. Takes the proposed additions,
-/// the current PATH entries, and a closure that decides whether a non-
-/// always-included dir exists on disk. Returns `(new_entries, applied)`:
-/// `new_entries` is the full ordered PATH (additions first, then existing),
-/// `applied` lists what we actually prepended for the startup log.
-#[cfg(target_os = "macos")]
-fn plan_path_additions(
-    additions: &[(std::path::PathBuf, bool)],
-    existing: &[std::path::PathBuf],
-    exists: impl Fn(&std::path::Path) -> bool,
-) -> (Vec<std::path::PathBuf>, Vec<String>) {
-    let mut new_entries: Vec<std::path::PathBuf> =
-        Vec::with_capacity(additions.len() + existing.len());
-    let mut applied: Vec<String> = Vec::new();
-    for (add, always) in additions {
-        if existing.iter().any(|e| e == add) {
-            continue;
-        }
-        if !*always && !exists(add) {
-            continue;
-        }
-        applied.push(add.display().to_string());
-        new_entries.push(add.clone());
-    }
-    new_entries.extend(existing.iter().cloned());
-    (new_entries, applied)
-}
-
-#[cfg(all(test, target_os = "macos"))]
-mod path_planner_tests {
-    use super::plan_path_additions;
-    use std::path::PathBuf;
-
-    fn p(s: &str) -> PathBuf {
-        PathBuf::from(s)
-    }
-
-    #[test]
-    fn skips_missing_unless_always() {
-        let additions = vec![(p("/opt/homebrew/bin"), false), (p("/managed/bin"), true)];
-        let existing = vec![p("/usr/bin"), p("/bin")];
-        let (new_entries, applied) =
-            plan_path_additions(&additions, &existing, |path| path == p("/opt/homebrew/bin"));
-        assert_eq!(
-            new_entries,
-            vec![
-                p("/opt/homebrew/bin"),
-                p("/managed/bin"),
-                p("/usr/bin"),
-                p("/bin")
-            ]
-        );
-        assert_eq!(applied, vec!["/opt/homebrew/bin", "/managed/bin"]);
-    }
-
-    #[test]
-    fn dedupes_against_existing() {
-        let additions = vec![(p("/usr/local/bin"), false), (p("/managed/bin"), true)];
-        let existing = vec![p("/usr/local/bin"), p("/usr/bin")];
-        let (new_entries, applied) = plan_path_additions(&additions, &existing, |_| true);
-        // /usr/local/bin is already in PATH — must not be duplicated.
-        assert_eq!(
-            new_entries,
-            vec![p("/managed/bin"), p("/usr/local/bin"), p("/usr/bin")]
-        );
-        assert_eq!(applied, vec!["/managed/bin"]);
-    }
-
-    #[test]
-    fn preserves_existing_when_no_additions_apply() {
-        let additions = vec![(p("/opt/homebrew/bin"), false)];
-        let existing = vec![p("/usr/bin")];
-        let (new_entries, applied) = plan_path_additions(&additions, &existing, |_| false);
-        assert_eq!(new_entries, vec![p("/usr/bin")]);
-        assert!(applied.is_empty());
-    }
-}
+// PATH recovery for GUI launches lives in `path_env::augment_path` (called
+// from `main` above). Kept in its own module so the planning logic is pure and
+// unit-testable without a GUI or a real shell.

--- a/crates/app/src/path_env.rs
+++ b/crates/app/src/path_env.rs
@@ -1,0 +1,512 @@
+//! Process `PATH` recovery for GUI launches.
+//!
+//! A desktop app started from Finder/Dock/Spotlight (macOS) or a
+//! `.desktop`/systemd-user unit (Linux) is launched *outside* a login shell,
+//! so it inherits a minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin` on macOS)
+//! instead of the operator's real shell `PATH`. The rc files (`~/.zprofile`,
+//! `~/.zshrc`, …) that add Homebrew, the gcloud SDK, asdf, etc. are never
+//! sourced. The result: CLIs the operator installed are invisible to
+//! `which::which` and `Command::new("foo")` — including the exec-credential
+//! auth plugins kube-rs spawns for GKE / EKS / AKS (`gke-gcloud-auth-plugin`,
+//! `aws-iam-authenticator`, `kubelogin`). That is the macOS "Failed to load
+//! kube client: auth error: unable to run auth exec: No such file or
+//! directory" papercut: it reproduces only in the packaged `.app` (Finder
+//! launch), never under `cargo tauri dev` / a terminal launch.
+//!
+//! [`augment_path`] repairs this once at startup, before any kube `Client` is
+//! built and before the helm/kubectl `which` probes fire:
+//!   1. If the inherited `PATH` already looks rich (a terminal launch), do the
+//!      cheap curated top-up only — no shell spawn.
+//!   2. Otherwise recover the operator's real login+interactive shell `PATH`
+//!      (`$SHELL -ilc`, hard-timeout, sentinel-delimited) and merge it.
+//!   3. Always append a curated fallback list (Homebrew, the gcloud SDK dirs,
+//!      Rancher Desktop, our managed-bin dir) as a belt for when shell capture
+//!      times out or the tool lives somewhere unusual.
+//!
+//! No-op on Windows (its GUI `PATH` is not stripped the same way and `-ilc` is
+//! meaningless). Tauri-free; the planning logic is pure and unit-tested without
+//! a GUI or a real shell by injecting the directory-exists predicate and canned
+//! shell output.
+
+/// Recover the operator's real `PATH` (from their login shell) and merge a
+/// curated fallback list into the process environment. Idempotent; call once
+/// early at startup, on the main thread, before the tokio runtime spins up and
+/// before any kube `Client` is built. No-op on Windows.
+pub(crate) fn augment_path() {
+    #[cfg(not(target_os = "windows"))]
+    unix::augment_path();
+}
+
+#[cfg(not(target_os = "windows"))]
+mod unix {
+    use std::path::{Path, PathBuf};
+    use std::time::Duration;
+
+    /// Sentinel markers wrapped around the captured `env` dump so we can slice
+    /// the real output away from rc-file banners / MOTD noise / ANSI.
+    const PATH_START: &str = "__FS_PATH_START__";
+    const PATH_END: &str = "__FS_PATH_END__";
+
+    /// Hard wall-clock cap on the login-shell spawn. Heavy `oh-my-zsh` / `nvm` /
+    /// `conda` setups can take seconds; we must never block startup on them.
+    const SHELL_CAPTURE_TIMEOUT: Duration = Duration::from_secs(3);
+
+    /// POSIX shells we can drive with `-ilc 'command -p env'`. `fish` / `nu` /
+    /// `elvish` aren't POSIX, so for those we fall back to a standard shell for
+    /// the capture (the operator still gets the curated dirs).
+    const POSIX_SHELLS: &[&str] = &["bash", "zsh", "sh", "dash", "ksh"];
+
+    pub(super) fn augment_path() {
+        let existing: Vec<PathBuf> =
+            std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()).collect();
+
+        // Terminal launch → PATH is already rich; skip the (slow) shell spawn
+        // and just top up any missing curated dirs.
+        let captured = if path_looks_rich(&existing) {
+            tracing::info!(
+                target: "ferrisscope::startup",
+                "path: rich PATH detected (terminal launch) — skipping login-shell capture"
+            );
+            Vec::new()
+        } else {
+            match capture_login_shell_path() {
+                Some(p) => {
+                    tracing::info!(
+                        target: "ferrisscope::startup",
+                        "path: recovered {} dir(s) from login shell",
+                        p.len()
+                    );
+                    p
+                }
+                None => {
+                    tracing::info!(
+                        target: "ferrisscope::startup",
+                        "path: login-shell capture unavailable — using curated fallback only"
+                    );
+                    Vec::new()
+                }
+            }
+        };
+
+        let curated = curated_dirs();
+        let (merged, applied) = merge_paths(&captured, &existing, &curated, |p| p.is_dir());
+
+        if merged == existing {
+            return;
+        }
+        match std::env::join_paths(&merged) {
+            Ok(joined) => {
+                // SAFETY/soundness: `set_var` mutates the process-global env and
+                // is only sound while single-threaded. This runs at startup,
+                // before the tokio runtime / any `Cluster::connect` / exec
+                // spawn. (Edition 2021: still safe. On a future edition-2024
+                // bump this becomes `unsafe` — keep the call here, early and
+                // single-threaded; don't move or wrap it carelessly.)
+                std::env::set_var("PATH", joined);
+                let summary = if applied.is_empty() {
+                    "(reordered)".to_string()
+                } else {
+                    applied.join(",")
+                };
+                tracing::info!(target: "ferrisscope::startup", "path: prepended=[{summary}]");
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "ferrisscope::startup",
+                    "path: could not join entries — leaving PATH untouched ({e})"
+                );
+            }
+        }
+    }
+
+    /// Curated fallback directories appended after the captured/inherited
+    /// `PATH`. `(path, always_include)` — `always_include` skips the on-disk
+    /// check (used for our managed-bin dir, populated *after* startup so
+    /// helm/kubectl resolve without a restart). Non-existent dirs are dropped,
+    /// so listing macOS + Linux locations together is harmless.
+    fn curated_dirs() -> Vec<(PathBuf, bool)> {
+        let mut dirs: Vec<(PathBuf, bool)> = vec![
+            // Homebrew (Apple silicon) + Intel/manual-install + MacPorts.
+            (PathBuf::from("/opt/homebrew/bin"), false),
+            (PathBuf::from("/opt/homebrew/sbin"), false),
+            (PathBuf::from("/usr/local/bin"), false),
+            (PathBuf::from("/usr/local/sbin"), false),
+            (PathBuf::from("/opt/local/bin"), false),
+            (PathBuf::from("/opt/local/sbin"), false),
+            // Homebrew on Linux.
+            (PathBuf::from("/home/linuxbrew/.linuxbrew/bin"), false),
+            (PathBuf::from("/home/linuxbrew/.linuxbrew/sbin"), false),
+            // Homebrew-cask gcloud: the auth plugin lives beside `gcloud`.
+            (
+                PathBuf::from("/usr/local/share/google-cloud-sdk/bin"),
+                false,
+            ),
+            (
+                PathBuf::from("/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin"),
+                false,
+            ),
+        ];
+        if let Ok(home) = std::env::var("HOME") {
+            dirs.push((PathBuf::from(format!("{home}/.local/bin")), false));
+            // Standalone Google Cloud SDK installer — `gke-gcloud-auth-plugin`
+            // lives here. This dir is the most common gap behind the GKE
+            // "auth exec: No such file or directory" failure.
+            dirs.push((PathBuf::from(format!("{home}/google-cloud-sdk/bin")), false));
+            // Rancher Desktop.
+            dirs.push((PathBuf::from(format!("{home}/.rd/bin")), false));
+        }
+        if let Some(managed) = crate::kubectl_install::managed_bin_dir() {
+            dirs.push((managed, true));
+        }
+        dirs
+    }
+
+    /// Merge the recovered shell `PATH`, the inherited process `PATH`, and the
+    /// curated fallback into one ordered, de-duplicated list. Resolution
+    /// priority: captured shell dirs first (the operator's real config), then
+    /// the inherited dirs, then curated dirs as a last-resort belt. Returns
+    /// `(merged, applied)` where `applied` lists dirs newly introduced relative
+    /// to `existing` (for the startup log).
+    fn merge_paths(
+        captured: &[PathBuf],
+        existing: &[PathBuf],
+        curated: &[(PathBuf, bool)],
+        exists: impl Fn(&Path) -> bool,
+    ) -> (Vec<PathBuf>, Vec<String>) {
+        use std::collections::HashSet;
+
+        let existing_set: HashSet<&Path> = existing.iter().map(PathBuf::as_path).collect();
+        let mut out: Vec<PathBuf> =
+            Vec::with_capacity(captured.len() + existing.len() + curated.len());
+        let mut seen: HashSet<PathBuf> = HashSet::new();
+        let mut applied: Vec<String> = Vec::new();
+
+        // 1. Recovered shell PATH first (highest resolution priority).
+        for p in captured {
+            if seen.insert(p.clone()) {
+                if !existing_set.contains(p.as_path()) {
+                    applied.push(p.display().to_string());
+                }
+                out.push(p.clone());
+            }
+        }
+        // 2. The inherited process PATH, preserved.
+        for p in existing {
+            if seen.insert(p.clone()) {
+                out.push(p.clone());
+            }
+        }
+        // 3. Curated fallback dirs appended as a belt.
+        for (p, always) in curated {
+            if seen.contains(p) {
+                continue;
+            }
+            if !*always && !exists(p) {
+                continue;
+            }
+            if !existing_set.contains(p.as_path()) {
+                applied.push(p.display().to_string());
+            }
+            seen.insert(p.clone());
+            out.push(p.clone());
+        }
+        (out, applied)
+    }
+
+    /// Heuristic: does `existing` already look like a terminal-launch PATH?
+    /// Presence of Homebrew / `~/.local/bin` / the gcloud SDK / linuxbrew means
+    /// rc files were sourced — almost certainly not the stripped launchd PATH.
+    fn path_looks_rich(existing: &[PathBuf]) -> bool {
+        existing.iter().any(|p| {
+            let s = p.to_string_lossy();
+            s == "/opt/homebrew/bin"
+                || s == "/usr/local/bin"
+                || s.ends_with("/.local/bin")
+                || s.contains("google-cloud-sdk")
+                || s.contains("/.linuxbrew/")
+        })
+    }
+
+    /// Pick the shell to drive the capture. Prefers `$SHELL` when it's a POSIX
+    /// shell; otherwise falls back to a standard shell.
+    fn pick_capture_shell(
+        shell_env: Option<&str>,
+        exists: impl Fn(&Path) -> bool,
+    ) -> Option<PathBuf> {
+        if let Some(sh) = shell_env {
+            let path = Path::new(sh);
+            let base = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if POSIX_SHELLS.contains(&base) && exists(path) {
+                return Some(path.to_path_buf());
+            }
+        }
+        for fallback in ["/bin/zsh", "/bin/bash", "/bin/sh"] {
+            let p = Path::new(fallback);
+            if exists(p) {
+                return Some(p.to_path_buf());
+            }
+        }
+        None
+    }
+
+    /// Recover `PATH` by running the operator's login+interactive shell once.
+    /// Returns `None` on any failure (no shell, spawn error, timeout, or
+    /// missing sentinels) — the caller falls back to the curated list.
+    fn capture_login_shell_path() -> Option<Vec<PathBuf>> {
+        let shell = pick_capture_shell(std::env::var("SHELL").ok().as_deref(), is_executable)?;
+        let out = run_shell_capture(&shell, SHELL_CAPTURE_TIMEOUT)?;
+        parse_shell_path(&out)
+    }
+
+    /// Slice the `PATH=` value out of a sentinel-wrapped `env` dump. Tolerates
+    /// rc-file banner noise before the start marker and ANSI escapes inside.
+    fn parse_shell_path(stdout: &str) -> Option<Vec<PathBuf>> {
+        let start = stdout.find(PATH_START)? + PATH_START.len();
+        let rest = &stdout[start..];
+        let end = rest.find(PATH_END)?;
+        let slice = strip_ansi(&rest[..end]);
+        let line = slice.lines().find(|l| l.starts_with("PATH="))?;
+        let value = &line["PATH=".len()..];
+        let dirs: Vec<PathBuf> = value
+            .split(':')
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .collect();
+        if dirs.is_empty() {
+            None
+        } else {
+            Some(dirs)
+        }
+    }
+
+    /// Spawn `<shell> -ilc 'printf …; command -p env; printf …'`, draining
+    /// stdout on a thread so a large env dump can't deadlock the pipe, and
+    /// enforcing a hard timeout (killing the child on expiry so no orphaned
+    /// shell lingers). `command -p env` runs the real `env` via a default PATH
+    /// so a user-defined `env` function/alias can't corrupt the dump.
+    fn run_shell_capture(shell: &Path, timeout: Duration) -> Option<String> {
+        use std::io::Read;
+        use std::process::{Command, Stdio};
+        use std::time::Instant;
+
+        let script = format!("printf '{PATH_START}'; command -p env; printf '{PATH_END}'");
+        let mut child = Command::new(shell)
+            .args(["-ilc", &script])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            // Keep rc files from launching tmux / drawing / blocking on a TTY.
+            .env("TERM", "dumb")
+            .env("DISABLE_AUTO_UPDATE", "true")
+            .env("ZSH_TMUX_AUTOSTART", "false")
+            .spawn()
+            .ok()?;
+
+        let mut stdout = child.stdout.take()?;
+        let (tx, rx) = std::sync::mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            let mut buf = String::new();
+            let _ = stdout.read_to_string(&mut buf);
+            let _ = tx.send(buf);
+        });
+
+        let deadline = Instant::now() + timeout;
+        let killed = loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break false,
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        break true;
+                    }
+                    std::thread::sleep(Duration::from_millis(25));
+                }
+                Err(_) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break true;
+                }
+            }
+        };
+
+        let out = rx.recv_timeout(Duration::from_secs(1)).ok();
+        let _ = reader.join();
+        if killed {
+            tracing::warn!(
+                target: "ferrisscope::startup",
+                "path: login-shell capture timed out after {}s — using fallback",
+                timeout.as_secs()
+            );
+            return None;
+        }
+        out
+    }
+
+    /// Whether `p` is a regular file with any execute bit set.
+    fn is_executable(p: &Path) -> bool {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(p)
+            .map(|m| m.is_file() && (m.permissions().mode() & 0o111 != 0))
+            .unwrap_or(false)
+    }
+
+    /// Remove ANSI CSI escape sequences (`ESC [ … final-byte`). UTF-8 safe.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' {
+                if chars.peek() == Some(&'[') {
+                    chars.next();
+                    while let Some(&n) = chars.peek() {
+                        chars.next();
+                        if ('@'..='~').contains(&n) {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
+            out.push(c);
+        }
+        out
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn p(s: &str) -> PathBuf {
+            PathBuf::from(s)
+        }
+
+        #[test]
+        fn parse_extracts_path_between_sentinels() {
+            let out = format!(
+                "oh-my-zsh loading…\nMOTD banner\n{PATH_START}USER=me\n\
+                 PATH=/opt/homebrew/bin:/usr/bin:/bin\nSHELL=/bin/zsh\n{PATH_END}\n"
+            );
+            let dirs = parse_shell_path(&out).expect("should parse");
+            assert_eq!(dirs, vec![p("/opt/homebrew/bin"), p("/usr/bin"), p("/bin")]);
+        }
+
+        #[test]
+        fn parse_strips_ansi() {
+            let out = format!("{PATH_START}PATH=/usr/\x1b[0mbin:/bin{PATH_END}");
+            let dirs = parse_shell_path(&out).expect("parse");
+            assert_eq!(dirs, vec![p("/usr/bin"), p("/bin")]);
+        }
+
+        #[test]
+        fn parse_none_without_end_sentinel() {
+            // Child killed mid-output → no end marker → fall back.
+            let out = format!("{PATH_START}PATH=/usr/bin:/bin\n");
+            assert!(parse_shell_path(&out).is_none());
+        }
+
+        #[test]
+        fn parse_none_without_path_line() {
+            let out = format!("{PATH_START}USER=me\nSHELL=/bin/zsh\n{PATH_END}");
+            assert!(parse_shell_path(&out).is_none());
+        }
+
+        #[test]
+        fn stripped_path_is_not_rich() {
+            let minimal = vec![p("/usr/bin"), p("/bin"), p("/usr/sbin"), p("/sbin")];
+            assert!(!path_looks_rich(&minimal));
+        }
+
+        #[test]
+        fn homebrew_and_gcloud_paths_are_rich() {
+            assert!(path_looks_rich(&[p("/usr/bin"), p("/opt/homebrew/bin")]));
+            assert!(path_looks_rich(&[p("/Users/me/.local/bin")]));
+            assert!(path_looks_rich(&[p("/Users/me/google-cloud-sdk/bin")]));
+            assert!(path_looks_rich(&[p("/home/linuxbrew/.linuxbrew/bin")]));
+        }
+
+        #[test]
+        fn picks_posix_shell_env_when_present() {
+            let got = pick_capture_shell(Some("/bin/zsh"), |path| path == Path::new("/bin/zsh"));
+            assert_eq!(got, Some(p("/bin/zsh")));
+        }
+
+        #[test]
+        fn falls_back_for_non_posix_shell() {
+            // fish isn't POSIX → ignore $SHELL, fall back to a standard shell.
+            let got = pick_capture_shell(Some("/opt/homebrew/bin/fish"), |path| {
+                path == Path::new("/bin/zsh") || path == Path::new("/bin/bash")
+            });
+            assert_eq!(got, Some(p("/bin/zsh")));
+        }
+
+        #[test]
+        fn falls_back_when_shell_unset() {
+            let got = pick_capture_shell(None, |path| path == Path::new("/bin/bash"));
+            assert_eq!(got, Some(p("/bin/bash")));
+        }
+
+        #[test]
+        fn none_when_no_shell_available() {
+            assert_eq!(pick_capture_shell(Some("/bin/zsh"), |_| false), None);
+        }
+
+        #[test]
+        fn merge_captured_first_then_existing_then_curated() {
+            let captured = vec![p("/opt/homebrew/bin"), p("/usr/bin")];
+            let existing = vec![p("/usr/bin"), p("/bin")];
+            let curated = vec![
+                (p("/Users/me/google-cloud-sdk/bin"), false),
+                (p("/managed/bin"), true),
+                (p("/does/not/exist"), false),
+            ];
+            let exists = |x: &Path| x == Path::new("/Users/me/google-cloud-sdk/bin");
+            let (merged, applied) = merge_paths(&captured, &existing, &curated, exists);
+            assert_eq!(
+                merged,
+                vec![
+                    p("/opt/homebrew/bin"),
+                    p("/usr/bin"),
+                    p("/bin"),
+                    p("/Users/me/google-cloud-sdk/bin"),
+                    p("/managed/bin"),
+                ]
+            );
+            // /usr/bin and /bin were already in `existing` → not "applied".
+            assert_eq!(
+                applied,
+                vec![
+                    "/opt/homebrew/bin".to_string(),
+                    "/Users/me/google-cloud-sdk/bin".to_string(),
+                    "/managed/bin".to_string(),
+                ]
+            );
+        }
+
+        #[test]
+        fn merge_skips_missing_curated_and_leaves_path_unchanged() {
+            let captured: Vec<PathBuf> = vec![];
+            let existing = vec![p("/usr/bin"), p("/bin")];
+            let curated = vec![(p("/opt/homebrew/bin"), false)];
+            // Homebrew dir doesn't exist → skipped → PATH unchanged.
+            let (merged, applied) = merge_paths(&captured, &existing, &curated, |_| false);
+            assert_eq!(merged, existing);
+            assert!(applied.is_empty());
+        }
+
+        #[test]
+        fn merge_no_duplicate_when_curated_already_in_captured() {
+            let captured = vec![p("/opt/homebrew/bin")];
+            let existing = vec![p("/usr/bin")];
+            let curated = vec![(p("/opt/homebrew/bin"), false)];
+            let (merged, _) = merge_paths(&captured, &existing, &curated, |_| true);
+            assert_eq!(merged, vec![p("/opt/homebrew/bin"), p("/usr/bin")]);
+        }
+
+        #[test]
+        fn strip_ansi_removes_csi() {
+            assert_eq!(strip_ansi("\x1b[1;32mhi\x1b[0m"), "hi");
+            assert_eq!(strip_ansi("plain"), "plain");
+        }
+    }
+}

--- a/crates/core/src/cluster.rs
+++ b/crates/core/src/cluster.rs
@@ -46,6 +46,82 @@ fn build_compressed_client(config: Config) -> Result<Client> {
     Ok(builder.build())
 }
 
+/// The exec-credential plugin command configured for `context_name`'s user, if
+/// any (e.g. `gke-gcloud-auth-plugin`). Looked up off the parsed kubeconfig so
+/// an opaque ENOENT from kube-rs's `auth_exec` can be turned into an actionable
+/// "plugin X not found on PATH" message — kube-rs surfaces only the raw
+/// `io::Error`, not the command or an install hint.
+fn exec_plugin_for_context(kc: &Kubeconfig, context_name: &str) -> Option<String> {
+    let user = kc
+        .contexts
+        .iter()
+        .find(|c| c.name == context_name)
+        .and_then(|c| c.context.as_ref())
+        .and_then(|ctx| ctx.user.clone())?;
+    kc.auth_infos
+        .iter()
+        .find(|a| a.name == user)
+        .and_then(|a| a.auth_info.as_ref())
+        .and_then(|ai| ai.exec.as_ref())
+        .and_then(|e| e.command.clone())
+}
+
+/// If `err`'s source chain bottoms out in an `io::ErrorKind::NotFound` (the
+/// signature of a kubeconfig exec auth plugin missing from `PATH`) and we know
+/// the plugin command, replace the opaque kube error with an actionable one.
+/// Gated strictly on `NotFound` so a `PermissionDenied` plugin (a different
+/// failure) is never mislabelled as "not found".
+fn enrich_exec_error(err: Error, exec_command: Option<String>) -> Error {
+    match exec_command {
+        Some(command) if io_not_found_in_chain(&err) => {
+            let hint = exec_install_hint(&command);
+            Error::ExecPluginNotFound { command, hint }
+        }
+        _ => err,
+    }
+}
+
+/// Walk the [`std::error::Error`] source chain looking for an `io::Error` of
+/// kind `NotFound`. Depends only on the std error trait + an `io::Error`
+/// downcast, so it's robust to kube-rs's internal error-enum shape changing
+/// across versions.
+fn io_not_found_in_chain(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut cur: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = cur {
+        if let Some(io) = e.downcast_ref::<std::io::Error>() {
+            if io.kind() == std::io::ErrorKind::NotFound {
+                return true;
+            }
+        }
+        cur = e.source();
+    }
+    false
+}
+
+/// Best-effort, actionable install hint keyed off the plugin command name.
+/// kube-rs's `ExecConfig` doesn't parse the kubeconfig `installHint`, so we
+/// synthesize guidance for the common providers and fall back to a generic
+/// PATH explanation.
+fn exec_install_hint(command: &str) -> String {
+    let base = command.rsplit(['/', '\\']).next().unwrap_or(command);
+    if base.contains("gke-gcloud-auth-plugin") || base == "gcloud" {
+        "install the gcloud CLI and run `gcloud components install gke-gcloud-auth-plugin`, \
+         then ensure it is on your PATH"
+            .to_owned()
+    } else if base.contains("aws-iam-authenticator") {
+        "install aws-iam-authenticator and ensure it is on your PATH".to_owned()
+    } else if base.contains("aws") {
+        "install the AWS CLI v2 and ensure `aws` is on your PATH".to_owned()
+    } else if base.contains("kubelogin") {
+        "install Azure kubelogin (`az aks install-cli`) and ensure it is on your PATH".to_owned()
+    } else {
+        format!(
+            "ensure `{base}` is installed and on the PATH the app sees — it may resolve in \
+             your terminal but not when the app is launched from Finder/Dock"
+        )
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ClusterInfo {
     /// e.g. `v1.30.4`
@@ -112,12 +188,17 @@ impl Cluster {
             Some(p) => Kubeconfig::read_from(p)?,
             None => Kubeconfig::read()?,
         };
+        // Capture the context's exec-plugin command before `kubeconfig` is
+        // consumed, so a later ENOENT from that plugin can be turned into an
+        // actionable error instead of a raw "No such file or directory".
+        let exec_command = exec_plugin_for_context(&kubeconfig, context_name);
         let options = KubeConfigOptions {
             context: Some(context_name.to_owned()),
             ..Default::default()
         };
         let config = Config::from_custom_kubeconfig(kubeconfig, &options).await?;
-        let client = build_compressed_client(config.clone())?;
+        let client = build_compressed_client(config.clone())
+            .map_err(|e| enrich_exec_error(e, exec_command))?;
         Ok(Self {
             context_name: context_name.to_owned(),
             client,
@@ -213,12 +294,14 @@ impl Cluster {
         );
 
         // 6. Build the kube Config + Client off the rewritten kubeconfig.
+        let exec_command = exec_plugin_for_context(&kubeconfig, context_name);
         let options = KubeConfigOptions {
             context: Some(context_name.to_owned()),
             ..Default::default()
         };
         let config = Config::from_custom_kubeconfig(kubeconfig, &options).await?;
-        let client = build_compressed_client(config.clone())?;
+        let client = build_compressed_client(config.clone())
+            .map_err(|e| enrich_exec_error(e, exec_command))?;
 
         Ok(Self {
             context_name: context_name.to_owned(),
@@ -538,5 +621,117 @@ mod tests {
         );
         assert!(parse_server_url("ftp://nope:21").is_err());
         assert!(parse_server_url("https://:6443").is_err());
+    }
+
+    /// A synthetic error that wraps an `io::Error` in its source chain, to
+    /// exercise `io_not_found_in_chain` without depending on kube-rs internals.
+    #[derive(Debug)]
+    struct Wrap(std::io::Error);
+    impl std::fmt::Display for Wrap {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "wrap")
+        }
+    }
+    impl std::error::Error for Wrap {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    #[test]
+    fn io_not_found_walks_the_source_chain() {
+        let not_found = Wrap(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert!(io_not_found_in_chain(&not_found));
+        // A different io error in the chain must not match.
+        let denied = Wrap(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        assert!(!io_not_found_in_chain(&denied));
+        // A non-io error with no io source must not match.
+        assert!(!io_not_found_in_chain(&Error::Invalid("nope".into())));
+    }
+
+    #[test]
+    fn enrich_exec_error_only_relabels_not_found_with_a_command() {
+        // NotFound + known command → actionable ExecPluginNotFound.
+        let e = enrich_exec_error(
+            Error::Io(std::io::Error::from(std::io::ErrorKind::NotFound)),
+            Some("gke-gcloud-auth-plugin".to_owned()),
+        );
+        match e {
+            Error::ExecPluginNotFound { command, hint } => {
+                assert_eq!(command, "gke-gcloud-auth-plugin");
+                assert!(hint.contains("gke-gcloud-auth-plugin"));
+            }
+            other => panic!("expected ExecPluginNotFound, got {other:?}"),
+        }
+        // PermissionDenied → left untouched (not relabelled as "not found").
+        assert!(!matches!(
+            enrich_exec_error(
+                Error::Io(std::io::Error::from(std::io::ErrorKind::PermissionDenied)),
+                Some("gke-gcloud-auth-plugin".to_owned()),
+            ),
+            Error::ExecPluginNotFound { .. }
+        ));
+        // NotFound but no known plugin command → left untouched.
+        assert!(!matches!(
+            enrich_exec_error(
+                Error::Io(std::io::Error::from(std::io::ErrorKind::NotFound)),
+                None,
+            ),
+            Error::ExecPluginNotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn exec_install_hint_is_provider_specific() {
+        assert!(exec_install_hint("gke-gcloud-auth-plugin").contains("gcloud components install"));
+        assert!(exec_install_hint("gcloud").contains("gcloud components install"));
+        assert!(
+            exec_install_hint("/abs/path/aws-iam-authenticator").contains("aws-iam-authenticator")
+        );
+        assert!(exec_install_hint("kubelogin").contains("kubelogin"));
+        // Unknown plugin → generic PATH guidance naming the binary.
+        let generic = exec_install_hint("/opt/tools/my-custom-auth");
+        assert!(generic.contains("my-custom-auth"));
+        assert!(generic.contains("PATH"));
+    }
+
+    #[test]
+    fn exec_plugin_for_context_resolves_command_via_user() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+current-context: gke
+clusters:
+- name: c
+  cluster:
+    server: https://1.2.3.4
+contexts:
+- name: gke
+  context:
+    cluster: c
+    user: gke-user
+- name: no-exec
+  context:
+    cluster: c
+    user: token-user
+users:
+- name: gke-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+- name: token-user
+  user:
+    token: abc
+"#;
+        let kc = Kubeconfig::from_yaml(yaml).expect("parse kubeconfig");
+        assert_eq!(
+            exec_plugin_for_context(&kc, "gke"),
+            Some("gke-gcloud-auth-plugin".to_owned())
+        );
+        // A context whose user has no exec stanza → None.
+        assert_eq!(exec_plugin_for_context(&kc, "no-exec"), None);
+        // Unknown context → None.
+        assert_eq!(exec_plugin_for_context(&kc, "missing"), None);
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     #[error("yaml: {0}")]
     Yaml(#[from] serde_yaml::Error),
 
+    #[error("exec credential plugin '{command}' not found on PATH — {hint}")]
+    ExecPluginNotFound { command: String, hint: String },
+
     #[error("context not found: {0}")]
     ContextNotFound(String),
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
