### PR TITLE
feat(auth): full provider env/PATH support + readable plugin failures…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,6 +3270,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "either",
+ "form_urlencoded",
  "futures",
  "http",
  "http-body",
@@ -3288,6 +3289,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tame-oauth",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -6008,6 +6010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6106,6 +6114,21 @@ dependencies = [
  "pkg-config",
  "toml 0.8.2",
  "version-compare",
+]
+
+[[package]]
+name = "tame-oauth"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c206bbecfbc0aea8bf35f57bf34e8be060d2cf7efe3937f8d0bdfdd4205ed771"
+dependencies = [
+ "data-encoding",
+ "http",
+ "ring",
+ "serde",
+ "serde_json",
+ "twox-hash",
+ "url",
 ]
 
 [[package]]
@@ -7002,6 +7025,16 @@ dependencies = [
  "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,22 @@ futures = "0.3"
 bytes = "1"
 
 # Kubernetes
-kube = { version = "3.1", features = ["runtime", "client", "ws", "config"] }
+kube = { version = "3.1", features = [
+    "runtime",
+    "client",
+    "ws",
+    "config",
+    # Auth coverage for cloud + on-prem providers:
+    #   oauth     — GCP application-default-credentials (`auth-provider: gcp` ADC path).
+    #   oidc      — `auth-provider: oidc` (dex/keycloak/on-prem) + id-token refresh.
+    #   http-proxy — let kube-rs's own apiserver client honour HTTPS_PROXY/NO_PROXY
+    #                (corporate networks where the apiserver is only reachable via proxy).
+    # exec credential plugins (gke-gcloud-auth-plugin, aws, kubelogin) work without these;
+    # they cover the legacy auth-provider stanzas and proxied apiserver reach.
+    "oauth",
+    "oidc",
+    "http-proxy",
+] }
 k8s-openapi = { version = "0.27", features = ["latest"] }
 http = "1"
 http-body-util = "0.1"

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -403,6 +403,29 @@ pub(crate) async fn list_contexts(state: State<'_, AppState>) -> Result<Vec<Cont
     kubeconfig::list_contexts(&sources).map_err(|e| e.to_string())
 }
 
+/// Passive, read-only connection diagnostics for a context: the PATH the app
+/// sees, whether the context's exec plugin is findable, and which cloud/proxy/
+/// TLS env vars are present. Does NOT execute the plugin (live plugin stderr is
+/// already surfaced on connect failure). Backs the "Diagnose connection" UI.
+#[tauri::command]
+pub(crate) async fn diagnose_connection_cmd(
+    name: String,
+    state: State<'_, AppState>,
+) -> Result<ferrisscope_core::cluster::ConnectionDiagnostics, String> {
+    let context_name = kubeconfig::context_name_from_id(&name).to_owned();
+    let source_path = {
+        let s = state.sources.lock().await;
+        kubeconfig::source_path_for(&name, &s)
+    };
+    // Reads the kubeconfig from disk → keep off the async worker.
+    tokio::task::spawn_blocking(move || {
+        ferrisscope_core::cluster::diagnose_context(&context_name, source_path.as_deref())
+    })
+    .await
+    .map_err(|e| format!("diagnostics task failed: {e}"))?
+    .map_err(|e| e.to_string())
+}
+
 /// Wall-clock budget for `connect_context`. Long enough for slow auth plugins
 /// (gke/aws/oidc shell out and can be sluggish on a cold cache) but short
 /// enough that a wedged apiserver doesn't pin the panel forever. The frontend

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -127,6 +127,7 @@ fn main() {
             commands::helm_uninstall_managed,
             commands::list_contexts,
             commands::connect_context,
+            commands::diagnose_connection_cmd,
             commands::cancel_connect,
             commands::list_resource_kinds,
             commands::list_custom_resource_kinds,

--- a/crates/app/src/path_env.rs
+++ b/crates/app/src/path_env.rs
@@ -61,32 +61,43 @@ mod unix {
             std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()).collect();
 
         // Terminal launch → PATH is already rich; skip the (slow) shell spawn
-        // and just top up any missing curated dirs.
-        let captured = if path_looks_rich(&existing) {
+        // and just top up any missing curated dirs. On the rich path we also skip
+        // env capture: a rich PATH means a real login shell launched us, so the
+        // full environment (AWS_*, CLOUDSDK_*, proxy vars, …) was already
+        // inherited — there is nothing to recover.
+        let (captured, captured_env) = if path_looks_rich(&existing) {
             tracing::info!(
                 target: "ferrisscope::startup",
                 "path: rich PATH detected (terminal launch) — skipping login-shell capture"
             );
-            Vec::new()
+            (Vec::new(), Vec::new())
         } else {
-            match capture_login_shell_path() {
-                Some(p) => {
+            match capture_login_shell() {
+                Some((p, env)) => {
                     tracing::info!(
                         target: "ferrisscope::startup",
                         "path: recovered {} dir(s) from login shell",
                         p.len()
                     );
-                    p
+                    (p, env)
                 }
                 None => {
                     tracing::info!(
                         target: "ferrisscope::startup",
                         "path: login-shell capture unavailable — using curated fallback only"
                     );
-                    Vec::new()
+                    (Vec::new(), Vec::new())
                 }
             }
         };
+
+        // Sync whitelisted cloud / proxy / TLS env vars from the login shell so
+        // exec-credential plugins see the same environment as the operator's
+        // terminal. A found binary still fails auth without e.g. AWS_PROFILE,
+        // CLOUDSDK_CONFIG, or HTTPS_PROXY — these are absent on a Dock/.desktop
+        // launch. Done independently of the PATH change below so it still runs
+        // even if PATH happened to be unchanged. No-op on the rich path.
+        apply_shell_env(&captured_env);
 
         let curated = curated_dirs();
         let (merged, applied) = merge_paths(&captured, &existing, &curated, |p| p.is_dir());
@@ -280,10 +291,79 @@ mod unix {
     /// Recover `PATH` by running the operator's login+interactive shell once.
     /// Returns `None` on any failure (no shell, spawn error, timeout, or
     /// missing sentinels) — the caller falls back to the curated list.
-    fn capture_login_shell_path() -> Option<Vec<PathBuf>> {
+    /// `(KEY, VALUE)` env pairs harvested from the login shell.
+    type EnvPairs = Vec<(String, String)>;
+
+    /// Capture the login shell's `PATH` and full environment in a single spawn.
+    /// `PATH` is required (we fall back to curated dirs without it); the env map
+    /// is best-effort. Returns `(path_dirs, env_pairs)`.
+    fn capture_login_shell() -> Option<(Vec<PathBuf>, EnvPairs)> {
         let shell = pick_capture_shell(std::env::var("SHELL").ok().as_deref(), is_executable)?;
         let out = run_shell_capture(&shell, SHELL_CAPTURE_TIMEOUT)?;
-        parse_shell_path(&out)
+        let path = parse_shell_path(&out)?;
+        let env = parse_shell_env(&out).unwrap_or_default();
+        Some((path, env))
+    }
+
+    /// Exact env-var names worth syncing from the login shell. Cloud SDKs and
+    /// auth plugins read these; they are absent on a Dock/.desktop launch.
+    const ENV_EXACT: &[&str] = &[
+        "HOME",
+        "KUBECONFIG",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "all_proxy",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "CURL_CA_BUNDLE",
+    ];
+
+    /// Prefix families worth syncing (AWS / gcloud / Google / Azure / Kerberos).
+    const ENV_PREFIX: &[&str] = &["AWS_", "CLOUDSDK_", "GOOGLE_", "GCP_", "AZURE_", "KRB5"];
+
+    fn is_whitelisted_env(key: &str) -> bool {
+        ENV_EXACT.contains(&key) || ENV_PREFIX.iter().any(|p| key.starts_with(p))
+    }
+
+    /// Pure selection step (testable without touching the real process env):
+    /// keep only whitelisted vars, never `PATH` (handled separately), and only
+    /// those not already set in the current process (launch context wins).
+    fn select_env_vars(
+        captured: &[(String, String)],
+        is_set: impl Fn(&str) -> bool,
+    ) -> Vec<(String, String)> {
+        captured
+            .iter()
+            .filter(|(k, _)| k != "PATH" && is_whitelisted_env(k) && !is_set(k))
+            .cloned()
+            .collect()
+    }
+
+    /// Merge whitelisted captured vars into the process env (only-if-absent).
+    /// Sound for the same reason as the PATH `set_var`: called on the main thread
+    /// before the tokio runtime starts and before any cluster connect. Logs only
+    /// the var *names* — values may carry secrets or private paths.
+    fn apply_shell_env(captured: &[(String, String)]) {
+        let to_set = select_env_vars(captured, |k| std::env::var_os(k).is_some());
+        if to_set.is_empty() {
+            return;
+        }
+        let names: Vec<&str> = to_set.iter().map(|(k, _)| k.as_str()).collect();
+        for (k, v) in &to_set {
+            std::env::set_var(k, v);
+        }
+        tracing::info!(
+            target: "ferrisscope::startup",
+            "env: synced {} var(s) from login shell: [{}]",
+            names.len(),
+            names.join(", ")
+        );
     }
 
     /// Slice the `PATH=` value out of a sentinel-wrapped `env` dump. Tolerates
@@ -305,6 +385,43 @@ mod unix {
         } else {
             Some(dirs)
         }
+    }
+
+    /// Parse every `KEY=VALUE` line from the captured `env` dump (same sentinel
+    /// slice + ANSI strip as `parse_shell_path`). Lines that don't begin with a
+    /// valid shell identifier followed by `=` are skipped (banner noise, and the
+    /// continuation lines of rare multi-line values). Returns `None` if the
+    /// markers are absent or no pairs were found.
+    fn parse_shell_env(stdout: &str) -> Option<Vec<(String, String)>> {
+        let start = stdout.find(PATH_START)? + PATH_START.len();
+        let rest = &stdout[start..];
+        let end = rest.find(PATH_END)?;
+        let slice = strip_ansi(&rest[..end]);
+        let mut pairs = Vec::new();
+        for line in slice.lines() {
+            let Some(eq) = line.find('=') else { continue };
+            let key = &line[..eq];
+            if is_env_key(key) {
+                pairs.push((key.to_string(), line[eq + 1..].to_string()));
+            }
+        }
+        if pairs.is_empty() {
+            None
+        } else {
+            Some(pairs)
+        }
+    }
+
+    /// A valid POSIX-ish env-var name: leading letter/underscore, then
+    /// alphanumerics/underscores. Guards against treating banner text containing
+    /// `=` (e.g. `foo = bar`) as an env pair.
+    fn is_env_key(k: &str) -> bool {
+        let mut chars = k.chars();
+        match chars.next() {
+            Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+            _ => return false,
+        }
+        chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
     }
 
     /// Spawn `<shell> -ilc 'printf …; command -p env; printf …'`, draining
@@ -437,6 +554,73 @@ mod unix {
         fn parse_none_without_path_line() {
             let out = format!("{PATH_START}USER=me\nSHELL=/bin/zsh\n{PATH_END}");
             assert!(parse_shell_path(&out).is_none());
+        }
+
+        #[test]
+        fn parse_shell_env_extracts_all_pairs() {
+            let out = format!(
+                "banner noise\n{PATH_START}USER=me\n\
+                 PATH=/opt/homebrew/bin:/usr/bin\n\
+                 AWS_PROFILE=prod\nHTTPS_PROXY=http://proxy:8080\n\
+                 not an env line\nfoo = spaced\n{PATH_END}\n"
+            );
+            let env = parse_shell_env(&out).expect("parse env");
+            assert!(env.contains(&("USER".to_string(), "me".to_string())));
+            assert!(env.contains(&("AWS_PROFILE".to_string(), "prod".to_string())));
+            assert!(env.contains(&("HTTPS_PROXY".to_string(), "http://proxy:8080".to_string())));
+            // "foo = spaced" has a space before '=' → key "foo " is not a valid
+            // identifier → skipped.
+            assert!(!env.iter().any(|(k, _)| k == "foo " || k == "foo"));
+        }
+
+        #[test]
+        fn parse_shell_env_none_without_markers() {
+            assert!(parse_shell_env("PATH=/usr/bin\nAWS_PROFILE=x").is_none());
+        }
+
+        #[test]
+        fn env_whitelist_matches_exact_and_prefix() {
+            assert!(is_whitelisted_env("HOME"));
+            assert!(is_whitelisted_env("KUBECONFIG"));
+            assert!(is_whitelisted_env("HTTPS_PROXY"));
+            assert!(is_whitelisted_env("AWS_PROFILE"));
+            assert!(is_whitelisted_env("CLOUDSDK_CONFIG"));
+            assert!(is_whitelisted_env("GOOGLE_APPLICATION_CREDENTIALS"));
+            assert!(is_whitelisted_env("AZURE_CONFIG_DIR"));
+            // Not whitelisted — locale, shell identity, arbitrary vars.
+            assert!(!is_whitelisted_env("LANG"));
+            assert!(!is_whitelisted_env("USER"));
+            assert!(!is_whitelisted_env("EDITOR"));
+        }
+
+        #[test]
+        fn select_env_vars_filters_path_present_and_non_whitelisted() {
+            let captured = vec![
+                ("PATH".to_string(), "/should/not/leak".to_string()),
+                ("AWS_PROFILE".to_string(), "prod".to_string()),
+                ("AWS_REGION".to_string(), "us-east-1".to_string()),
+                ("HOME".to_string(), "/home/shell".to_string()),
+                ("EDITOR".to_string(), "vim".to_string()),
+            ];
+            // HOME is already set in the launch env → must be skipped (launch wins).
+            let already_set = |k: &str| k == "HOME";
+            let got = select_env_vars(&captured, already_set);
+            let keys: Vec<&str> = got.iter().map(|(k, _)| k.as_str()).collect();
+            assert!(keys.contains(&"AWS_PROFILE"));
+            assert!(keys.contains(&"AWS_REGION"));
+            assert!(!keys.contains(&"PATH")); // never synced here
+            assert!(!keys.contains(&"HOME")); // already set
+            assert!(!keys.contains(&"EDITOR")); // not whitelisted
+        }
+
+        #[test]
+        fn is_env_key_rejects_garbage() {
+            assert!(is_env_key("AWS_PROFILE"));
+            assert!(is_env_key("_FOO"));
+            assert!(!is_env_key(""));
+            assert!(!is_env_key("1ABC"));
+            assert!(!is_env_key("foo "));
+            assert!(!is_env_key("a-b"));
         }
 
         #[test]

--- a/crates/core/src/cluster.rs
+++ b/crates/core/src/cluster.rs
@@ -5,7 +5,7 @@
 //! we can talk to an apiserver.
 
 use crate::sync::LockExt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -13,7 +13,7 @@ use http::{header::ACCEPT_ENCODING, HeaderValue};
 use k8s_openapi::api::core::v1::Node;
 use kube::{
     api::{Api, ListParams},
-    client::ClientBuilder,
+    client::{AuthError, ClientBuilder},
     config::{KubeConfigOptions, Kubeconfig},
     Client, Config,
 };
@@ -73,13 +73,126 @@ fn exec_plugin_for_context(kc: &Kubeconfig, context_name: &str) -> Option<String
 /// Gated strictly on `NotFound` so a `PermissionDenied` plugin (a different
 /// failure) is never mislabelled as "not found".
 fn enrich_exec_error(err: Error, exec_command: Option<String>) -> Error {
-    match exec_command {
-        Some(command) if io_not_found_in_chain(&err) => {
+    // ENOENT — plugin binary missing from PATH (spawn failure). Highest
+    // priority: a missing binary and a non-zero exit are distinct failures, and
+    // "not found" is the more actionable label, so it wins when both could match.
+    if io_not_found_in_chain(&err) {
+        if let Some(command) = exec_command {
             let hint = exec_install_hint(&command);
-            Error::ExecPluginNotFound { command, hint }
+            return Error::ExecPluginNotFound { command, hint };
         }
-        _ => err,
+        return err;
     }
+    // Plugin ran but exited non-zero. kube-rs has the stderr in `AuthExecRun`,
+    // but its `Display` prints `{out:?}` (raw byte arrays). Reformat to readable,
+    // redacted, truncated UTF-8 so the operator sees the real cause.
+    if let Some((command, code, stderr)) = auth_exec_run_in_chain(&err) {
+        return Error::ExecPluginFailed {
+            command,
+            code,
+            stderr,
+        };
+    }
+    err
+}
+
+/// Walk the source chain for kube-rs's [`AuthError::AuthExecRun`] (the plugin
+/// ran and exited non-zero). Returns `(command, exit-code-string, readable
+/// stderr)`. The plugin's stderr is captured by kube-rs but only Debug-printed
+/// as raw bytes; we decode it lossily, redact credential material, and truncate.
+fn auth_exec_run_in_chain(
+    err: &(dyn std::error::Error + 'static),
+) -> Option<(String, String, String)> {
+    let mut cur: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = cur {
+        if let Some(AuthError::AuthExecRun { cmd, status, out }) = e.downcast_ref::<AuthError>() {
+            let code = status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| status.to_string());
+            // Prefer stderr (human error messages); fall back to stdout (some
+            // plugins emit the failure there).
+            let raw = if out.stderr.is_empty() {
+                String::from_utf8_lossy(&out.stdout)
+            } else {
+                String::from_utf8_lossy(&out.stderr)
+            };
+            return Some((cmd.clone(), code, redact_and_truncate(&raw)));
+        }
+        cur = e.source();
+    }
+    None
+}
+
+/// Make a plugin's raw stderr safe and compact for display: drop lines that
+/// look like they carry a credential (token JSON, JWT/base64 runs, Bearer
+/// headers), strip blank lines, and cap total length. Conservative on what it
+/// flags as secret so genuine error text ("reauth required", "invalid
+/// credentials") survives.
+fn redact_and_truncate(s: &str) -> String {
+    const MAX: usize = 1500;
+    let mut lines: Vec<&str> = Vec::new();
+    let mut redacted_any = false;
+    for line in s.lines() {
+        let t = line.trim_end();
+        if t.is_empty() {
+            continue;
+        }
+        if looks_secretish(t) {
+            redacted_any = true;
+            continue;
+        }
+        lines.push(t);
+    }
+    let mut out = lines.join("\n");
+    if redacted_any {
+        out.push_str("\n[credential material redacted]");
+    }
+    let out = out.trim().to_string();
+    let mut out = if out.len() > MAX {
+        let mut end = MAX;
+        while !out.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut truncated = out[..end].to_string();
+        truncated.push_str(" … (truncated)");
+        truncated
+    } else {
+        out
+    };
+    if out.is_empty() {
+        out = "(plugin produced no output)".to_string();
+    }
+    out
+}
+
+/// Heuristic: does this line likely contain a secret value (not merely the word
+/// "credentials")? Catches token JSON fields, `Bearer` headers, and long
+/// base64url/JWT runs. Excludes `/` and `.` from the run alphabet so file paths
+/// and dotted hostnames don't trip it.
+fn looks_secretish(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    if lower.contains("\"token\"")
+        || lower.contains("token=")
+        || lower.contains("bearer ")
+        || lower.contains("id_token")
+        || lower.contains("access_token")
+        || lower.contains("\"password\"")
+        || lower.contains("client-secret")
+    {
+        return true;
+    }
+    let mut run = 0usize;
+    let mut max_run = 0usize;
+    for c in line.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '+' | '_' | '-' | '=') {
+            run += 1;
+            max_run = max_run.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    max_run >= 40
 }
 
 /// Walk the [`std::error::Error`] source chain looking for an `io::Error` of
@@ -580,6 +693,166 @@ fn parse_server_url(url: &str) -> Result<(String, u16, String)> {
     Ok((host, port, scheme.to_owned()))
 }
 
+// ---------------------------------------------------------------------------
+// Connection diagnostics (passive / read-only)
+//
+// Answers "what does the app actually see" without executing the auth plugin
+// (kube-rs already surfaces live plugin stderr via `enrich_exec_error`). Reports
+// the resolved PATH, whether the context's exec plugin is findable, and which
+// cloud/proxy/TLS env vars are present (presence only — never values).
+// ---------------------------------------------------------------------------
+
+/// Cloud / proxy / TLS env vars whose *presence* is worth showing the operator
+/// when a connection fails. Values are deliberately never read or returned.
+const DIAG_ENV_KEYS: &[&str] = &[
+    "HOME",
+    "USERPROFILE", // Windows HOME equivalent
+    "KUBECONFIG",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "AWS_PROFILE",
+    "AWS_REGION",
+    "AWS_ROLE_ARN",
+    "AWS_WEB_IDENTITY_TOKEN_FILE",
+    "AWS_SHARED_CREDENTIALS_FILE",
+    "CLOUDSDK_CONFIG",
+    "CLOUDSDK_CORE_PROJECT",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "AZURE_CONFIG_DIR",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+];
+
+/// The exec-credential plugin declared for a context, including its args.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ExecProbe {
+    pub command: String,
+    pub args: Vec<String>,
+    /// Absolute path the command resolves to on the app's PATH, if found.
+    pub resolved_path: Option<String>,
+    pub found: bool,
+}
+
+/// Presence (not value) of one diagnostic env var.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct EnvPresence {
+    pub key: String,
+    pub present: bool,
+}
+
+/// Read-only snapshot of what the app sees for a context's connection.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ConnectionDiagnostics {
+    /// The process PATH the app will hand to exec plugins, split per entry.
+    pub resolved_path: Vec<String>,
+    /// The context's exec plugin + whether it's findable. `None` if the context
+    /// uses no exec plugin (in-cluster token, client cert, basic auth, …).
+    pub exec: Option<ExecProbe>,
+    pub env_presence: Vec<EnvPresence>,
+}
+
+/// Extract a context's exec command + args (the args matter for diagnostics:
+/// e.g. `gke-gcloud-auth-plugin` vs `gcloud config config-helper`).
+fn exec_for_context(kc: &Kubeconfig, context_name: &str) -> Option<(String, Vec<String>)> {
+    let user = kc
+        .contexts
+        .iter()
+        .find(|c| c.name == context_name)
+        .and_then(|c| c.context.as_ref())
+        .and_then(|ctx| ctx.user.clone())?;
+    let exec = kc
+        .auth_infos
+        .iter()
+        .find(|a| a.name == user)
+        .and_then(|a| a.auth_info.as_ref())
+        .and_then(|ai| ai.exec.as_ref())?;
+    let command = exec.command.clone()?;
+    let args = exec.args.clone().unwrap_or_default();
+    Some((command, args))
+}
+
+/// Expand one candidate into the forms a spawn would actually try. On Windows a
+/// bare `foo` resolves to `foo.exe`/`foo.cmd`/… via PATHEXT (which `Command::new`
+/// applies), so the diagnostic must do the same or it falsely reports a present
+/// `.exe` as missing. On unix the command is taken verbatim.
+fn path_candidates(base: PathBuf) -> Vec<PathBuf> {
+    #[cfg(windows)]
+    {
+        let mut v = vec![base.clone()];
+        if base.extension().is_none() {
+            let exts =
+                std::env::var("PATHEXT").unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_owned());
+            for ext in exts.split(';').filter(|e| !e.is_empty()) {
+                let mut p = base.clone().into_os_string();
+                p.push(ext);
+                v.push(PathBuf::from(p));
+            }
+        }
+        v
+    }
+    #[cfg(not(windows))]
+    {
+        vec![base]
+    }
+}
+
+/// Resolve a command against the app's current PATH the same way a spawn would:
+/// an absolute / path-bearing command is checked directly; a bare name is
+/// scanned across PATH entries (applying PATHEXT on Windows). Returns the
+/// resolved file, or `None` if missing.
+fn resolve_in_path(command: &str) -> Option<PathBuf> {
+    if command.contains('/') || command.contains(std::path::MAIN_SEPARATOR) {
+        return path_candidates(PathBuf::from(command))
+            .into_iter()
+            .find(|p| p.is_file());
+    }
+    let path_var = std::env::var_os("PATH")?;
+    std::env::split_paths(&path_var)
+        .flat_map(|dir| path_candidates(dir.join(command)))
+        .find(|cand| cand.is_file())
+}
+
+/// Build a read-only [`ConnectionDiagnostics`] for a context. Reads the
+/// kubeconfig and inspects the process env/PATH; never executes the plugin.
+pub fn diagnose_context(
+    context_name: &str,
+    source_path: Option<&Path>,
+) -> Result<ConnectionDiagnostics> {
+    let kubeconfig = match source_path {
+        Some(p) => Kubeconfig::read_from(p)?,
+        None => Kubeconfig::read()?,
+    };
+    let exec = exec_for_context(&kubeconfig, context_name).map(|(command, args)| {
+        let resolved = resolve_in_path(&command);
+        ExecProbe {
+            found: resolved.is_some(),
+            resolved_path: resolved.map(|p| p.display().to_string()),
+            command,
+            args,
+        }
+    });
+    let resolved_path = std::env::var_os("PATH")
+        .map(|p| {
+            std::env::split_paths(&p)
+                .map(|d| d.display().to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    let env_presence = DIAG_ENV_KEYS
+        .iter()
+        .map(|k| EnvPresence {
+            key: (*k).to_string(),
+            present: std::env::var_os(k).is_some(),
+        })
+        .collect();
+    Ok(ConnectionDiagnostics {
+        resolved_path,
+        exec,
+        env_presence,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -731,5 +1004,160 @@ users:
         assert_eq!(exec_plugin_for_context(&kc, "no-exec"), None);
         // Unknown context → None.
         assert_eq!(exec_plugin_for_context(&kc, "missing"), None);
+    }
+
+    #[test]
+    fn exec_for_context_extracts_command_and_args() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster: { server: https://1.2.3.4 }
+contexts:
+- name: aws
+  context: { cluster: c, user: aws-user }
+users:
+- name: aws-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+      args: ["eks", "get-token", "--cluster-name", "prod"]
+"#;
+        let kc = Kubeconfig::from_yaml(yaml).expect("parse kubeconfig");
+        let (cmd, args) = exec_for_context(&kc, "aws").expect("exec present");
+        assert_eq!(cmd, "aws");
+        assert_eq!(args, vec!["eks", "get-token", "--cluster-name", "prod"]);
+        assert!(exec_for_context(&kc, "missing").is_none());
+    }
+
+    #[test]
+    fn resolve_in_path_handles_absolute_and_missing() {
+        // An absolute path to a real file resolves to itself.
+        let mut tmp = std::env::temp_dir();
+        tmp.push(format!("fs-diag-probe-{}", std::process::id()));
+        std::fs::write(&tmp, b"#!/bin/sh\n").expect("write temp");
+        let abs = tmp.display().to_string();
+        assert_eq!(resolve_in_path(&abs), Some(tmp.clone()));
+        std::fs::remove_file(&tmp).ok();
+        // A bare name that doesn't exist anywhere on PATH → None.
+        assert!(resolve_in_path("fs-definitely-not-a-real-binary-xyz").is_none());
+    }
+
+    #[test]
+    fn diagnose_context_reports_exec_and_env_presence() {
+        let yaml = r#"
+apiVersion: v1
+kind: Config
+clusters:
+- name: c
+  cluster: { server: https://1.2.3.4 }
+contexts:
+- name: gke
+  context: { cluster: c, user: gke-user }
+users:
+- name: gke-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+"#;
+        let mut path = std::env::temp_dir();
+        path.push(format!("fs-diag-kubeconfig-{}.yaml", std::process::id()));
+        std::fs::write(&path, yaml).expect("write kubeconfig");
+
+        let diag = diagnose_context("gke", Some(path.as_path())).expect("diagnose");
+        std::fs::remove_file(&path).ok();
+
+        let exec = diag.exec.expect("exec probe present");
+        assert_eq!(exec.command, "gke-gcloud-auth-plugin");
+        // Plugin almost certainly not installed in CI → found=false, no path.
+        assert_eq!(exec.found, exec.resolved_path.is_some());
+        // Env presence covers the full diagnostic key set, values never leaked.
+        assert_eq!(diag.env_presence.len(), DIAG_ENV_KEYS.len());
+        assert!(diag.env_presence.iter().any(|e| e.key == "HOME"));
+    }
+
+    #[test]
+    fn redact_and_truncate_keeps_error_text_drops_secrets() {
+        let raw = "ERROR: (gcloud.auth) reauth required\n\
+                   invalid credentials for project foo\n\
+                   token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTABCDEFGH\n";
+        let out = redact_and_truncate(raw);
+        // Human-readable diagnostics survive…
+        assert!(out.contains("reauth required"));
+        // …including a line that merely mentions "credentials" (no secret value).
+        assert!(out.contains("invalid credentials for project foo"));
+        // …but the token line is gone, replaced by a marker.
+        assert!(!out.contains("eyJhbGci"));
+        assert!(!out.contains("token="));
+        assert!(out.contains("[credential material redacted]"));
+    }
+
+    #[test]
+    fn redact_and_truncate_caps_length_and_handles_empty() {
+        // Long but non-secret text (spaces break the base64-run heuristic).
+        let long = "err line ".repeat(1000);
+        let out = redact_and_truncate(&long);
+        assert!(out.len() <= 1500 + 32);
+        assert!(out.ends_with("… (truncated)"));
+        assert_eq!(
+            redact_and_truncate("   \n  \n"),
+            "(plugin produced no output)"
+        );
+    }
+
+    #[test]
+    fn looks_secretish_flags_tokens_not_paths() {
+        assert!(looks_secretish("\"token\": \"abc\""));
+        assert!(looks_secretish("Authorization: Bearer abc123"));
+        assert!(looks_secretish(&format!("blob {}", "A".repeat(45))));
+        // File paths and dotted hostnames must NOT be flagged.
+        assert!(!looks_secretish(
+            "/Users/me/.config/gcloud/application_default_credentials.json"
+        ));
+        assert!(!looks_secretish(
+            "could not reach oauth2.googleapis.com:443"
+        ));
+        assert!(!looks_secretish("invalid credentials"));
+    }
+
+    // kube-rs surfaces a non-zero plugin exit as `AuthError::AuthExecRun`, which
+    // carries the captured `Output`. Build one and assert we reformat it into a
+    // readable `ExecPluginFailed`. `ExitStatus` is only constructible via the
+    // unix extension trait, so gate on unix (our only shipping targets).
+    #[cfg(unix)]
+    #[test]
+    fn enrich_reformats_auth_exec_run_into_readable_failure() {
+        use std::os::unix::process::ExitStatusExt;
+        let status = std::process::ExitStatus::from_raw(1 << 8); // exit code 1
+        let out = std::process::Output {
+            status,
+            stdout: Vec::new(),
+            stderr: b"ERROR: (gcloud.auth) reauth required\ntoken=eyJhbGciABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789\n".to_vec(),
+        };
+        let auth = AuthError::AuthExecRun {
+            cmd: "gke-gcloud-auth-plugin".to_owned(),
+            status,
+            out,
+        };
+        // Wrap in the real error path: kube::Error::Auth → our Error::Kube.
+        let err = Error::Kube(kube::Error::Auth(auth));
+        // No exec_command passed — the command must come from AuthExecRun itself,
+        // proving the path works even when we couldn't pre-extract the plugin.
+        match enrich_exec_error(err, None) {
+            Error::ExecPluginFailed {
+                command,
+                code,
+                stderr,
+            } => {
+                assert_eq!(command, "gke-gcloud-auth-plugin");
+                assert_eq!(code, "1");
+                assert!(stderr.contains("reauth required"));
+                assert!(!stderr.contains("eyJhbGci"));
+            }
+            other => panic!("expected ExecPluginFailed, got {other:?}"),
+        }
     }
 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -17,6 +17,17 @@ pub enum Error {
     #[error("exec credential plugin '{command}' not found on PATH — {hint}")]
     ExecPluginNotFound { command: String, hint: String },
 
+    /// The exec plugin ran but exited non-zero. kube-rs captures the plugin's
+    /// stdout/stderr but only Display-prints it as raw bytes; we reformat the
+    /// stderr as readable, redacted, truncated UTF-8 so the operator sees the
+    /// real cause (e.g. "gcloud auth login required", expired creds).
+    #[error("exec credential plugin '{command}' failed (exit {code}) — {stderr}")]
+    ExecPluginFailed {
+        command: String,
+        code: String,
+        stderr: String,
+    },
+
     #[error("context not found: {0}")]
     ContextNotFound(String),
 

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -67,6 +67,17 @@ describe("contexts + connect", () => {
       connectId: "abc-123",
     });
   });
+
+  it("diagnoseConnection → 'diagnose_connection_cmd' with name", async () => {
+    const cap = captureNext({
+      resolved_path: ["/usr/bin"],
+      exec: null,
+      env_presence: [{ key: "HOME", present: true }],
+    });
+    await api.diagnoseConnection("default::ctx-a");
+    expect(cap.calls[0]?.cmd).toBe("diagnose_connection_cmd");
+    expect(cap.calls[0]?.args).toEqual({ name: "default::ctx-a" });
+  });
 });
 
 describe("subscribeResource", () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -23,6 +23,7 @@ import type {
   ChatEvent,
   ClusterHealthEvent,
   ClusterInfo,
+  ConnectionDiagnostics,
   ClusterProbe,
   ClusterRoleBindingDetail,
   ClusterRoleDetail,
@@ -125,6 +126,11 @@ export const api = {
     invoke<ClusterInfo>("connect_context", { name, connectId }),
   cancelConnect: (connectId: string) =>
     invoke<void>("cancel_connect", { connectId }),
+  /// Passive connection diagnostics for a context: resolved PATH, whether the
+  /// exec plugin is findable, and which cloud/proxy/TLS env vars are present.
+  /// Never executes the plugin.
+  diagnoseConnection: (name: string) =>
+    invoke<ConnectionDiagnostics>("diagnose_connection_cmd", { name }),
 
   listResourceKinds: () => invoke<ResourceKind[]>("list_resource_kinds"),
   // CRD-derived dynamic kinds. Per-cluster (CRDs are cluster-local), so

--- a/ui/src/components/ClusterPanel.tsx
+++ b/ui/src/components/ClusterPanel.tsx
@@ -8,6 +8,7 @@ import {
 } from "../lib/useClusterConnection";
 import { ClusterBar } from "./ClusterBar";
 import { ResourceTable } from "./ResourceTable";
+import { ConnectionDiagnosticsModal } from "./ConnectionDiagnosticsModal";
 import { Btn, EmptyState, ErrorBlock, LoadingLine } from "./ui";
 
 type Props = {
@@ -80,6 +81,7 @@ export function ClusterPanel({ mode, context }: Props) {
             title="Could not connect to this cluster"
             reason={state.message}
             onReconnect={reconnect}
+            diagnoseContext={context}
           />
         ) : state.status === "cancelled" ? (
           <ReconnectBanner
@@ -150,17 +152,22 @@ function ConnectingLabel({
 // regardless of how the cluster got broken. Exported for the
 // per-member failure strips in VirtualClusterPanel.
 export function ReconnectBanner({
-  
   title,
   reason,
   onReconnect,
+  diagnoseContext,
 }: {
   mode: ThemeMode;
   title: string;
   reason: string | null;
   onReconnect: () => void;
+  /// When set, renders a "Diagnose" button that opens passive connection
+  /// diagnostics for this context. Omitted where diagnosis makes no sense
+  /// (a healthy cluster gone temporarily unavailable, a cancelled connect).
+  diagnoseContext?: ContextInfo;
 }) {
   const t = useResolvedTheme().tokens;
+  const [showDiag, setShowDiag] = useState(false);
   return (
     <div
       role="alert"
@@ -200,9 +207,27 @@ export function ReconnectBanner({
           </div>
         )}
       </div>
+      {diagnoseContext && (
+        <Btn
+          t={t}
+          variant="secondary"
+          size="sm"
+          onClick={() => setShowDiag(true)}
+        >
+          Diagnose
+        </Btn>
+      )}
       <Btn t={t} variant="primary" size="sm" onClick={onReconnect}>
         Reconnect
       </Btn>
+      {diagnoseContext && showDiag && (
+        <ConnectionDiagnosticsModal
+          t={t}
+          contextId={diagnoseContext.id}
+          contextName={diagnoseContext.name}
+          onClose={() => setShowDiag(false)}
+        />
+      )}
     </div>
   );
 }

--- a/ui/src/components/ConnectionDiagnosticsModal.test.tsx
+++ b/ui/src/components/ConnectionDiagnosticsModal.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { tokens } from "../theme";
+import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
+import { ConnectionDiagnosticsModal } from "./ConnectionDiagnosticsModal";
+import type { ConnectionDiagnostics } from "../types";
+
+const t = tokens("dark");
+
+const SAMPLE: ConnectionDiagnostics = {
+  resolved_path: ["/opt/homebrew/bin", "/usr/bin"],
+  exec: {
+    command: "gke-gcloud-auth-plugin",
+    args: ["--version"],
+    resolved_path: null,
+    found: false,
+  },
+  env_presence: [
+    { key: "HOME", present: true },
+    { key: "AWS_PROFILE", present: false },
+  ],
+};
+
+beforeEach(() => {
+  resetMockInvoke();
+});
+
+describe("ConnectionDiagnosticsModal", () => {
+  it("calls diagnose_connection_cmd with the context id and renders the result", async () => {
+    let seenArgs: Record<string, unknown> | undefined;
+    setMockInvoke((cmd, args) => {
+      expect(cmd).toBe("diagnose_connection_cmd");
+      seenArgs = args;
+      return SAMPLE;
+    });
+
+    render(
+      <ConnectionDiagnosticsModal
+        t={t}
+        contextId="default::prod"
+        contextName="prod"
+        onClose={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("gke-gcloud-auth-plugin")).toBeInTheDocument();
+    });
+    // The composite id (not the display name) goes to the backend.
+    expect(seenArgs).toEqual({ name: "default::prod" });
+    // Unfound plugin → warn chip; PATH entries + env chips present.
+    expect(screen.getByText("NOT found on PATH")).toBeInTheDocument();
+    expect(screen.getByText("/opt/homebrew/bin")).toBeInTheDocument();
+    expect(screen.getByText(/HOME/)).toBeInTheDocument();
+    expect(screen.getByText(/AWS_PROFILE/)).toBeInTheDocument();
+  });
+
+  it("invokes onClose when Close is clicked", async () => {
+    setMockInvoke(() => SAMPLE);
+    const onClose = vi.fn();
+    render(
+      <ConnectionDiagnosticsModal
+        t={t}
+        contextId="default::prod"
+        contextName="prod"
+        onClose={onClose}
+      />,
+    );
+    await waitFor(() => screen.getByText("gke-gcloud-auth-plugin"));
+    fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a backend error", async () => {
+    setMockInvoke(() => {
+      throw new Error("boom: kubeconfig unreadable");
+    });
+    render(
+      <ConnectionDiagnosticsModal
+        t={t}
+        contextId="default::prod"
+        contextName="prod"
+        onClose={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/boom: kubeconfig unreadable/)).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/components/ConnectionDiagnosticsModal.tsx
+++ b/ui/src/components/ConnectionDiagnosticsModal.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { api } from "../api";
+import type { ConnectionDiagnostics } from "../types";
+import type { Tokens } from "../theme";
+import { FS_MD, FS_SM } from "../theme";
+import { Section, Chip, Btn } from "./ui";
+import { Copyable, Mono, Mute } from "./detail/primitives";
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "loaded"; data: ConnectionDiagnostics };
+
+// Passive, read-only "why can't I connect" surface. Shows the PATH the app
+// actually sees, whether the context's exec credential plugin is findable, and
+// which cloud/proxy/TLS env vars are present (presence only — never values).
+// Mirrors `diagnose_connection_cmd`; never executes the plugin.
+export function ConnectionDiagnosticsModal({
+  t,
+  contextId,
+  contextName,
+  onClose,
+}: {
+  t: Tokens;
+  /// The composite context id (e.g. "default::prod") — same value passed to
+  /// connect. The backend extracts the context name from it.
+  contextId: string;
+  contextName: string;
+  onClose: () => void;
+}) {
+  const [s, setS] = useState<LoadState>({ status: "loading" });
+
+  useEffect(() => {
+    let live = true;
+    setS({ status: "loading" });
+    api
+      .diagnoseConnection(contextId)
+      .then((data) => {
+        if (live) setS({ status: "loaded", data });
+      })
+      .catch((e: unknown) => {
+        if (live) setS({ status: "error", message: String(e) });
+      });
+    return () => {
+      live = false;
+    };
+  }, [contextId]);
+
+  // Esc closes.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Connection diagnostics for ${contextName}`}
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: t.scrim,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+        padding: 24,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: t.surface,
+          border: `1px solid ${t.border}`,
+          borderRadius: 10,
+          width: "min(640px, 100%)",
+          maxHeight: "85vh",
+          overflow: "auto",
+          padding: 18,
+          display: "flex",
+          flexDirection: "column",
+          gap: 14,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ color: t.text, fontSize: FS_MD, fontWeight: 600 }}>
+              Connection diagnostics
+            </div>
+            <Mute t={t}>{contextName}</Mute>
+          </div>
+          <Btn t={t} variant="secondary" size="sm" onClick={onClose}>
+            Close
+          </Btn>
+        </div>
+
+        {s.status === "loading" && <Mute t={t}>Inspecting…</Mute>}
+        {s.status === "error" && (
+          <div style={{ color: t.bad, fontSize: FS_SM }}>{s.message}</div>
+        )}
+        {s.status === "loaded" && <DiagnosticsBody t={t} data={s.data} />}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function DiagnosticsBody({ t, data }: { t: Tokens; data: ConnectionDiagnostics }) {
+  return (
+    <>
+      <div>
+        <Section t={t} title="Auth plugin" />
+        {data.exec ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <Copyable text={data.exec.command}>
+              <Mono>{data.exec.command}</Mono>
+            </Copyable>
+            {data.exec.args.length > 0 && (
+              <Copyable text={data.exec.args.join(" ")}>
+                <Mono style={{ color: t.textDim, fontSize: FS_SM }}>
+                  {data.exec.args.join(" ")}
+                </Mono>
+              </Copyable>
+            )}
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <Chip t={t} tone={data.exec.found ? "accent" : "warn"}>
+                {data.exec.found ? "found on PATH" : "NOT found on PATH"}
+              </Chip>
+              {data.exec.resolved_path ? (
+                <Copyable text={data.exec.resolved_path}>
+                  <Mono style={{ fontSize: FS_SM }}>
+                    {data.exec.resolved_path}
+                  </Mono>
+                </Copyable>
+              ) : (
+                <Mute t={t}>
+                  the app can&apos;t see this binary — it may resolve in your
+                  terminal but not when launched from the Dock/.desktop
+                </Mute>
+              )}
+            </div>
+          </div>
+        ) : (
+          <Mute t={t}>
+            This context authenticates without an exec credential plugin.
+          </Mute>
+        )}
+      </div>
+
+      <div>
+        <Section
+          t={t}
+          title="PATH"
+          right={<Mute t={t}>{`${data.resolved_path.length} entries`}</Mute>}
+        />
+        <Copyable text={data.resolved_path.join(":")}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {data.resolved_path.map((p, i) => (
+              <Mono key={`${p}-${i}`} style={{ fontSize: FS_SM }}>
+                {p}
+              </Mono>
+            ))}
+          </div>
+        </Copyable>
+      </div>
+
+      <div>
+        <Section
+          t={t}
+          title="Environment"
+          right={<Mute t={t}>presence only — values never read</Mute>}
+        />
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {data.env_presence.map((e) => (
+            <Chip key={e.key} t={t} mono tone={e.present ? "accent" : "neutral"}>
+              {e.present ? "✓ " : "· "}
+              {e.key}
+            </Chip>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -95,6 +95,32 @@ export type ContextInfo = {
   source_path: string | null;
 };
 
+/// The exec-credential plugin a context declares, plus whether the app can find
+/// it on the PATH it sees. Mirrors `ferrisscope_core::cluster::ExecProbe`.
+export type ExecProbe = {
+  command: string;
+  args: string[];
+  /// Absolute path the command resolves to, if found.
+  resolved_path: string | null;
+  found: boolean;
+};
+
+/// Presence (never the value) of one diagnostic env var.
+export type EnvPresence = {
+  key: string;
+  present: boolean;
+};
+
+/// Passive, read-only snapshot of what the app sees for a context's connection.
+/// Mirrors `ferrisscope_core::cluster::ConnectionDiagnostics`.
+export type ConnectionDiagnostics = {
+  /// The process PATH the app hands to exec plugins, one entry per element.
+  resolved_path: string[];
+  /// The context's exec plugin probe, or null if it uses no exec plugin.
+  exec: ExecProbe | null;
+  env_presence: EnvPresence[];
+};
+
 export type KubeconfigSourceKind = "file" | "folder" | "ssh";
 
 export type SshAuthInput =


### PR DESCRIPTION
… + diagnostics

Bring cloud-provider auth (GKE/EKS/AKS/OIDC, incl. corporate networks) to parity with the freelens model, staying on kube-rs in-process exec auth.

- core: enable kube `oauth`, `oidc`, `http-proxy` features. Covers legacy `auth-provider: gcp`/`oidc` (dex/keycloak), id-token refresh, and letting the apiserver client honour HTTPS_PROXY/NO_PROXY on proxied networks.

- app(path_env): sync the full login-shell environment, not just PATH. The shell capture already dumped the whole env; now parse every KEY=VALUE and merge a whitelisted set (AWS_*/CLOUDSDK_*/GOOGLE_*/AZURE_*/proxy/TLS/HOME/ KUBECONFIG) only-if-absent so the launch context still wins. Closes the "plugin binary found but auth fails" gap on Dock/.desktop launches. Unix-only (Windows GUI already inherits the full env).

- core(cluster): reformat non-zero exec-plugin exits. kube-rs captures the plugin's stderr in AuthError::AuthExecRun but Display-prints it as raw bytes; match it and surface readable, credential-redacted, truncated UTF-8 via a new Error::ExecPluginFailed. No plugin re-run.

- core/app/ui: passive connection diagnostics. New diagnose_context + diagnose_connection_cmd report the resolved PATH, whether the context's exec plugin is findable (PATHEXT-aware on Windows), and which cloud/proxy/TLS env vars are present (presence only, never values). Surfaced via a "Diagnose" button on the connect-error banner; never executes the plugin.

Tests: unit tests for env parsing/whitelist/merge, stderr redaction + AuthExecRun reformatting, exec resolution + env presence; api command-shape test and a ConnectionDiagnosticsModal render/interaction test. Verified with cargo fmt/clippy -D warnings, full workspace cargo test, tsc strict, full vitest, and a windows-gnu cross-compile.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
