### PR TITLE
feat(filter): label-selector support in the resource filter box

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Lens is the de-facto desktop IDE for Kubernetes, but it bundles an entire Chromi
 | **Custom Resources** | Dynamic CRD discovery + browseable instances |
 | **Well-known CRDs** | Gateway API today (GatewayClass / Gateway / HTTPRoute / GRPCRoute / ReferenceGrant) — first-class category, columns, and detail panel without a typed crate per ecosystem |
 
+- **Filtering** (⌘F or `/`) — one box, auto-detecting. Plain text is a case-insensitive **name** substring; add regex metachars (`| * + ? ( ) ^ $ [ ] { }`) to switch to a name **regex** (`^api.*-prod$`). Type a `=` and it becomes a **label selector**: `app=nginx` (exact), `app=web.*` (regex value), `app=nginx|redis` (OR within a value). Comma separates terms — same key is OR'd, different keys are AND'd (`app=web,app=api,tier=prod` → (web or api) and prod). `app=` / `app!=` test for a label's presence / absence, and `app!=web` excludes. A bad pattern lights the box red.
+
 ### Detail panels & inline editing
 - Kind-agnostic detail primitives: copyable values everywhere, cross-kind navigation (owner refs, node names, service-account refs, image-pull-secret refs, volume sources), key/value chip strips, condition chips with invert support for "True is bad" conditions, sub-grids for nested structs.
 - **Inline editing** — ConfigMap and Secret data, ResourceQuota limits, LimitRange items, Deployment / StatefulSet / ReplicaSet replicas, PVC size, plus labels and annotations, straight from the detail panel. Edits go through Server-Side Apply, so FerrisScope coexists with your controllers and GitOps instead of stomping their fields.

--- a/crates/kube-ext/src/watcher.rs
+++ b/crates/kube-ext/src/watcher.rs
@@ -21,7 +21,7 @@
 //! and the drainer always sees the latest state.
 
 use ferrisscope_core::sync::LockExt;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -480,6 +480,7 @@ impl ResourceWatcher {
                     }
                 }
                 let row = with_uid(uid.clone(), S::project(&obj));
+                let row = with_labels(row, Some(obj.labels()));
                 // Drop the typed object as soon as projection is done.
                 drop(obj);
                 // No-op suppression: if the projected row is byte-
@@ -643,6 +644,7 @@ impl ResourceWatcher {
                     }
                 }
                 let row = with_uid(uid.clone(), project_task(&obj));
+                let row = with_labels(row, Some(obj.labels()));
                 // No-op suppression — see typed-watcher branch above
                 // for the rationale. Same behaviour: cheap structural
                 // equality on the projected row; on miss, update the
@@ -1314,6 +1316,28 @@ fn with_uid(uid: String, projected: Value) -> Value {
     }
 }
 
+/// Inject the object's labels into a projected row under the reserved
+/// `__labels` key. The frontend filter box uses it for label-selector
+/// matching (`app=nginx`, `tier=prod,app=web`). Attached only when there
+/// is at least one label, so the per-update bus payload stays minimal —
+/// label-less objects add nothing. The `__` prefix marks it as synthetic
+/// row metadata (cf. `__sid` / `__clusterId` on the frontend), never a
+/// table column. No-op when the projection isn't a JSON object.
+fn with_labels(row: Value, labels: Option<&BTreeMap<String, String>>) -> Value {
+    let Some(labels) = labels.filter(|m| !m.is_empty()) else {
+        return row;
+    };
+    let Value::Object(mut map) = row else {
+        return row;
+    };
+    let projected: serde_json::Map<String, Value> = labels
+        .iter()
+        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+        .collect();
+    map.insert("__labels".to_owned(), Value::Object(projected));
+    Value::Object(map)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1322,6 +1346,33 @@ mod tests {
 
     fn row(name: &str) -> Value {
         json!({ "uid": "ignored", "name": name })
+    }
+
+    #[test]
+    fn with_labels_attaches_only_when_present() {
+        let base = with_uid("u1".to_owned(), json!({ "name": "nginx" }));
+
+        // None / empty → no `__labels`, original fields untouched.
+        let none = with_labels(base.clone(), None);
+        assert_eq!(none["uid"], json!("u1"));
+        assert_eq!(none["name"], json!("nginx"));
+        assert!(none.get("__labels").is_none());
+
+        let empty = with_labels(base.clone(), Some(&BTreeMap::new()));
+        assert!(empty.get("__labels").is_none());
+
+        // Non-empty → mirrored under `__labels`, siblings preserved.
+        let labels: BTreeMap<String, String> = [
+            ("app".to_owned(), "nginx".to_owned()),
+            ("tier".to_owned(), "frontend".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+        let tagged = with_labels(base, Some(&labels));
+        assert_eq!(tagged["uid"], json!("u1"));
+        assert_eq!(tagged["name"], json!("nginx"));
+        assert_eq!(tagged["__labels"]["app"], json!("nginx"));
+        assert_eq!(tagged["__labels"]["tier"], json!("frontend"));
     }
 
     #[tokio::test]

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -254,8 +254,8 @@ export function AppHeader({
                     placeholder="Filter rows…"
                     title={
                       filterInvalid
-                        ? "Invalid regex pattern"
-                        : "Plain text = substring · use | * + ? ( ) ^ $ to switch to regex"
+                        ? "Invalid pattern (bad regex or label selector)"
+                        : "Name: text=substring, | * + ? ( ) ^ $ → regex · Labels: app=nginx, app=web.* (regex), app=a|b or app=a,app=b (or), app=web,tier=prod (and), app= / app!= (has/not)"
                     }
                     style={{
                       width: 220,
@@ -322,10 +322,10 @@ export function AppHeader({
                     onClick={openFilterEditor}
                     title={
                       filterInvalid
-                        ? `Invalid regex: ${tableFilter}`
+                        ? `Invalid filter: ${tableFilter}`
                         : tableFilter
                           ? `Filter: "${tableFilter}" — edit (${MOD_KEY}F or /)`
-                          : `Filter visible rows (${MOD_KEY}F or /). Plain text matches substring; metachars switch to regex.`
+                          : `Filter visible rows (${MOD_KEY}F or /). Text matches name (substring/regex); k=v matches labels (e.g. app=nginx).`
                     }
                     style={{
                       display: "inline-flex",

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -611,8 +611,9 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
       })
       .filter((r) => {
         if (parsed.mode === "off") return true;
-        const name = typeof r.name === "string" ? r.name : "";
-        return parsed.test(name);
+        // Pass the whole row — name modes read `r.name`, label mode reads
+        // `r.__labels` (watcher-injected).
+        return parsed.test(r);
       });
   }, [rows, selectedNamespaces, tableFilter, kind.namespaced]);
 

--- a/ui/src/lib/tableFilter.test.ts
+++ b/ui/src/lib/tableFilter.test.ts
@@ -1,33 +1,41 @@
 // parseTableFilter is the operator's main "find a row" entry point. It's a
-// small function but the bucket-detection rules (substring vs regex, dot is
-// literal) are exactly the kind of thing that's silently easy to break.
+// small function but the bucket-detection rules (substring vs regex vs
+// labels, dot is literal) are exactly the kind of thing that's silently
+// easy to break.
 
 import { describe, it, expect } from "vitest";
-import { parseTableFilter } from "./tableFilter";
+import { parseTableFilter, type TableFilterRow } from "./tableFilter";
 
-describe("parseTableFilter — mode detection", () => {
+// Test helpers — the predicate takes a row, not a bare string.
+const n = (name: string): TableFilterRow => ({ name });
+const l = (labels: Record<string, string>): TableFilterRow => ({
+  name: "x",
+  __labels: labels,
+});
+
+describe("parseTableFilter — name modes", () => {
   it("empty / whitespace-only input is the off mode and matches everything", () => {
     expect(parseTableFilter("").mode).toBe("off");
     expect(parseTableFilter("   ").mode).toBe("off");
-    expect(parseTableFilter("").test("anything")).toBe(true);
-    expect(parseTableFilter("\t\n").test("")).toBe(true);
+    expect(parseTableFilter("").test(n("anything"))).toBe(true);
+    expect(parseTableFilter("\t\n").test(n(""))).toBe(true);
   });
 
   it("bare alphanumeric input is substring + case-insensitive", () => {
     const f = parseTableFilter("Pod");
     expect(f.mode).toBe("substring");
-    expect(f.test("nginx-pod-7d8")).toBe(true);
-    expect(f.test("NGINX-POD-7D8")).toBe(true);
-    expect(f.test("nginx")).toBe(false);
+    expect(f.test(n("nginx-pod-7d8"))).toBe(true);
+    expect(f.test(n("NGINX-POD-7D8"))).toBe(true);
+    expect(f.test(n("nginx"))).toBe(false);
   });
 
   it("a literal dot stays in substring mode (image tags shouldn't promote)", () => {
     const f = parseTableFilter("nginx-1.27");
     expect(f.mode).toBe("substring");
     // The dot is literal — would match if interpreted as regex.
-    expect(f.test("nginx-1.27.0")).toBe(true);
+    expect(f.test(n("nginx-1.27.0"))).toBe(true);
     // And won't match across an arbitrary char (regex `.` would have here).
-    expect(f.test("nginx-1X27")).toBe(false);
+    expect(f.test(n("nginx-1X27"))).toBe(false);
   });
 
   it("any other metachar promotes to regex", () => {
@@ -40,24 +48,162 @@ describe("parseTableFilter — mode detection", () => {
 
   it("regex is case-insensitive (operator-friendly)", () => {
     const f = parseTableFilter("^Worker-");
-    expect(f.test("worker-0")).toBe(true);
-    expect(f.test("WORKER-1")).toBe(true);
-    expect(f.test("api-0")).toBe(false);
+    expect(f.test(n("worker-0"))).toBe(true);
+    expect(f.test(n("WORKER-1"))).toBe(true);
+    expect(f.test(n("api-0"))).toBe(false);
   });
 
   it("invalid regex returns invalid:true and a never-matching predicate", () => {
     const f = parseTableFilter("(unclosed");
     expect(f.mode).toBe("regex");
     expect(f.invalid).toBe(true);
-    expect(f.test("anything")).toBe(false);
-    expect(f.test("")).toBe(false);
+    expect(f.test(n("anything"))).toBe(false);
+    expect(f.test(n(""))).toBe(false);
   });
 
   it("valid regex anchors still work", () => {
     const f = parseTableFilter("^api.*-prod$");
     expect(f.mode).toBe("regex");
-    expect(f.test("api-foo-prod")).toBe(true);
-    expect(f.test("apifoo-prod")).toBe(true);
-    expect(f.test("apifoo-prod-stage")).toBe(false);
+    expect(f.test(n("api-foo-prod"))).toBe(true);
+    expect(f.test(n("apifoo-prod"))).toBe(true);
+    expect(f.test(n("apifoo-prod-stage"))).toBe(false);
+  });
+});
+
+describe("parseTableFilter — label mode", () => {
+  it("any `=` switches to label mode", () => {
+    expect(parseTableFilter("app=nginx").mode).toBe("labels");
+    expect(parseTableFilter("app!=nginx").mode).toBe("labels");
+    expect(parseTableFilter("app=").mode).toBe("labels");
+  });
+
+  it("plain value is exact + case-sensitive (kubectl `=`)", () => {
+    const f = parseTableFilter("app=web");
+    expect(f.test(l({ app: "web" }))).toBe(true);
+    expect(f.test(l({ app: "web-frontend" }))).toBe(false);
+    expect(f.test(l({ app: "WEB" }))).toBe(false);
+    expect(f.test(l({ tier: "web" }))).toBe(false); // wrong key
+    expect(f.test(n("web"))).toBe(false); // no labels at all
+  });
+
+  it("a metachar value matches as a case-insensitive regex", () => {
+    const f = parseTableFilter("app=web.*");
+    expect(f.test(l({ app: "web" }))).toBe(true);
+    expect(f.test(l({ app: "web-frontend" }))).toBe(true);
+    expect(f.test(l({ app: "WEB-API" }))).toBe(true); // case-insensitive
+    expect(f.test(l({ app: "api" }))).toBe(false);
+  });
+
+  it("`|` in the value is OR (regex alternation)", () => {
+    const f = parseTableFilter("app=nginx|mysql");
+    expect(f.test(l({ app: "nginx" }))).toBe(true);
+    expect(f.test(l({ app: "mysql" }))).toBe(true);
+    expect(f.test(l({ app: "redis" }))).toBe(false);
+  });
+
+  it("empty value is an existence check (`key=`)", () => {
+    const f = parseTableFilter("app=");
+    expect(f.test(l({ app: "anything" }))).toBe(true);
+    expect(f.test(l({ app: "" }))).toBe(true); // present, empty value
+    expect(f.test(l({ tier: "x" }))).toBe(false);
+    expect(f.test(n("x"))).toBe(false);
+  });
+
+  it("empty negated value is an absence check (`key!=`)", () => {
+    const f = parseTableFilter("app!=");
+    expect(f.test(l({ tier: "x" }))).toBe(true); // app absent
+    expect(f.test(n("x"))).toBe(true); // no labels at all
+    expect(f.test(l({ app: "nginx" }))).toBe(false);
+  });
+
+  it("`key!=value` is true when absent OR differing (kubectl `!=`)", () => {
+    const f = parseTableFilter("app!=web");
+    expect(f.test(l({ app: "api" }))).toBe(true); // differs
+    expect(f.test(l({ tier: "x" }))).toBe(true); // absent
+    expect(f.test(n("x"))).toBe(true); // no labels
+    expect(f.test(l({ app: "web" }))).toBe(false); // equals
+  });
+
+  it("comma across DIFFERENT keys is AND", () => {
+    const f = parseTableFilter("app=web,tier=prod");
+    expect(f.test(l({ app: "web", tier: "prod" }))).toBe(true);
+    expect(f.test(l({ app: "web", tier: "dev" }))).toBe(false);
+    expect(f.test(l({ app: "web" }))).toBe(false);
+    expect(f.test(l({ tier: "prod" }))).toBe(false);
+  });
+
+  it("comma across the SAME key is OR (the reported case)", () => {
+    const f = parseTableFilter("app=nginx,app=redis");
+    expect(f.test(l({ app: "nginx" }))).toBe(true);
+    expect(f.test(l({ app: "redis" }))).toBe(true);
+    expect(f.test(l({ app: "other" }))).toBe(false);
+    expect(f.test(l({ tier: "x" }))).toBe(false);
+  });
+
+  it("mixes same-key OR with cross-key AND", () => {
+    const f = parseTableFilter("app=web,app=api,tier=prod");
+    // (app=web OR app=api) AND tier=prod
+    expect(f.test(l({ app: "web", tier: "prod" }))).toBe(true);
+    expect(f.test(l({ app: "api", tier: "prod" }))).toBe(true);
+    expect(f.test(l({ app: "web", tier: "dev" }))).toBe(false); // wrong tier
+    expect(f.test(l({ app: "db", tier: "prod" }))).toBe(false); // wrong app
+  });
+
+  it("same-key OR composes with regex values", () => {
+    const f = parseTableFilter("app=web.*,app=db");
+    expect(f.test(l({ app: "web-frontend" }))).toBe(true); // regex term
+    expect(f.test(l({ app: "db" }))).toBe(true); // exact term
+    expect(f.test(l({ app: "cache" }))).toBe(false);
+  });
+
+  it("negation stays an AND'd exclusion alongside same-key OR", () => {
+    const f = parseTableFilter("app=web,app=api,app!=web");
+    // app∈{web,api} but excluding web → effectively app=api only
+    expect(f.test(l({ app: "api" }))).toBe(true);
+    expect(f.test(l({ app: "web" }))).toBe(false);
+    expect(f.test(l({ app: "db" }))).toBe(false);
+  });
+
+  it("AND + regex value compose", () => {
+    const f = parseTableFilter("app=web.*,tier=prod");
+    expect(f.test(l({ app: "web-frontend", tier: "prod" }))).toBe(true);
+    expect(f.test(l({ app: "web-frontend", tier: "dev" }))).toBe(false);
+  });
+
+  it("invalid: empty key or bad regex value → invalid + never matches", () => {
+    const noKey = parseTableFilter("=x");
+    expect(noKey.mode).toBe("labels");
+    expect(noKey.invalid).toBe(true);
+    expect(noKey.test(l({ app: "x" }))).toBe(false);
+
+    const badRe = parseTableFilter("app=(unclosed");
+    expect(badRe.invalid).toBe(true);
+    expect(badRe.test(l({ app: "(unclosed" }))).toBe(false);
+  });
+
+  it("tolerates trailing / doubled commas", () => {
+    const f = parseTableFilter("app=web,");
+    expect(f.invalid).toBeUndefined();
+    expect(f.test(l({ app: "web" }))).toBe(true);
+  });
+
+  it("does not match JS object prototype members as labels", () => {
+    // `labels[key]` would inherit these from Object.prototype; hasOwnProperty
+    // must not. A pod without these labels must not match.
+    for (const proto of ["toString", "constructor", "hasOwnProperty", "valueOf"]) {
+      const exists = parseTableFilter(`${proto}=`);
+      expect(exists.test(l({ app: "web" }))).toBe(false);
+      const eq = parseTableFilter(`${proto}=x`);
+      expect(eq.test(l({ app: "web" }))).toBe(false);
+    }
+    // …but a real label literally named `toString` still matches when present.
+    expect(parseTableFilter("toString=").test(l({ toString: "v" }))).toBe(true);
+  });
+
+  it("a comma inside a regex quantifier is invalid (comma is the AND separator)", () => {
+    const f = parseTableFilter("app=a{1,3}");
+    expect(f.mode).toBe("labels");
+    expect(f.invalid).toBe(true);
+    expect(f.test(l({ app: "aaa" }))).toBe(false);
   });
 });

--- a/ui/src/lib/tableFilter.ts
+++ b/ui/src/lib/tableFilter.ts
@@ -2,6 +2,7 @@
 //
 // Modes (auto-detected):
 //   - empty                 → match everything (filter inactive)
+//   - labels if the input contains `=`  (e.g. `app=nginx`, `tier=prod,app=web`)
 //   - regex if the input contains any of `| * + ? ( ) ^ $ \ [ ] { }`
 //   - bare text otherwise   → case-insensitive substring match on `name`
 //
@@ -13,29 +14,171 @@
 // to its regex meaning — which is the operator's likely intent in a
 // pattern like `app.*foo` anyway.
 //
-// Invalid regex returns a never-matching predicate plus `invalid: true`
+// `=` is checked BEFORE the regex triggers: it's an unambiguous sentinel
+// for label mode. K8s label values can't contain `=` and DNS-1123 names
+// can't either, so a string with `=` is always a label query, never a
+// name pattern. Label mode reads `row.__labels` (injected by the watcher);
+// the name modes read `row.name`. Comma-separated label terms with the same
+// key are OR'd, distinct keys are AND'd, `!=` is an exclusion — see
+// `parseLabelFilter` for the precise rule.
+//
+// Invalid input returns a never-matching predicate plus `invalid: true`
 // so the AppHeader can render a red chip — empty results then read as
 // "broken pattern" rather than "nothing matched the typo'd substring."
 
-export type TableFilterMode = "off" | "substring" | "regex";
+export type TableFilterMode = "off" | "substring" | "regex" | "labels";
+
+/// Minimal shape the predicate needs from a resource row. `name` is the
+/// resource name (name modes); `__labels` is the watcher-injected label map
+/// (label mode). Both optional — a row missing the field simply won't match.
+export type TableFilterRow = {
+  name?: unknown;
+  __labels?: Record<string, string>;
+};
 
 export type ParsedTableFilter = {
   mode: TableFilterMode;
-  test: (name: string) => boolean;
-  /// Set when `mode === "regex"` and the pattern failed to compile.
+  test: (row: TableFilterRow) => boolean;
+  /// Set when the pattern failed to compile / parse (bad regex, empty key).
   invalid?: boolean;
 };
 
 const REGEX_TRIGGERS = /[|*+?()^$\\\[\]{}]/;
 
+// A single `key[op]value` term in label mode. `op` distinguishes `=` from
+// `!=`; an empty `value` means existence (`key=`) / absence (`key!=`).
+type LabelTerm = {
+  key: string;
+  negate: boolean;
+  // null → existence/absence check; otherwise a value matcher.
+  match: ((value: string) => boolean) | null;
+};
+
+function rowName(row: TableFilterRow): string {
+  return typeof row.name === "string" ? row.name : "";
+}
+
+// Build a value matcher: regex (case-insensitive) when the value carries
+// metachars, exact (case-sensitive, kubectl `=` semantics) otherwise.
+// Returns null on a regex that fails to compile.
+function valueMatcher(value: string): ((v: string) => boolean) | null {
+  if (REGEX_TRIGGERS.test(value)) {
+    try {
+      const re = new RegExp(value, "i");
+      return (v) => re.test(v);
+    } catch {
+      return null;
+    }
+  }
+  return (v) => v === value;
+}
+
+function parseLabelFilter(raw: string): ParsedTableFilter {
+  const invalid: ParsedTableFilter = {
+    mode: "labels",
+    test: () => false,
+    invalid: true,
+  };
+
+  const terms: LabelTerm[] = [];
+  for (const rawTerm of raw.split(",")) {
+    const term = rawTerm.trim();
+    if (!term) continue; // tolerate trailing / doubled commas
+
+    const negate = term.includes("!=");
+    const sep = negate ? "!=" : "=";
+    const idx = term.indexOf(sep);
+    if (idx < 0) return invalid; // term has no operator — e.g. a comma landed
+    // inside a regex quantifier (`app=a{1,3}`); comma separates terms, so
+    // that's unsupported. Fail honestly (red) rather than silently match nothing.
+    const key = term.slice(0, idx).trim();
+    const value = term.slice(idx + sep.length).trim();
+
+    if (!key) return invalid; // `=x` / `!=x` — no key to match
+
+    if (value === "") {
+      terms.push({ key, negate, match: null }); // existence / absence
+      continue;
+    }
+    const match = valueMatcher(value);
+    if (!match) return invalid; // bad regex value
+    terms.push({ key, negate, match });
+  }
+
+  if (terms.length === 0) return invalid; // bare `=` with nothing around it
+
+  // Semantics: positive (`=`) terms that share a key are OR'd together; the
+  // resulting per-key groups are AND'd across distinct keys; every negative
+  // (`!=`) term is an AND'd exclusion. So `app=a,app=b` → app∈{a,b};
+  // `app=a,tier=b` → app=a AND tier=b. OR within one term still works via a
+  // regex value (`app=a|b`). Groups are precomputed here, not per-row — the
+  // predicate runs once per visible row on a hot path.
+  const posGroups: { key: string; terms: LabelTerm[] }[] = [];
+  const byKey = new Map<string, LabelTerm[]>();
+  const negatives: LabelTerm[] = [];
+  for (const t of terms) {
+    if (t.negate) {
+      negatives.push(t);
+      continue;
+    }
+    let group = byKey.get(t.key);
+    if (!group) {
+      group = [];
+      byKey.set(t.key, group);
+      posGroups.push({ key: t.key, terms: group });
+    }
+    group.push(t);
+  }
+
+  // hasOwnProperty, NOT `labels[key]`: a bare index read inherits object
+  // prototype members, so `toString` / `constructor` would report a label
+  // that isn't there. Returns the own value, or undefined when absent.
+  const ownValue = (
+    labels: Record<string, string> | undefined,
+    key: string,
+  ): string | undefined =>
+    labels != null && Object.prototype.hasOwnProperty.call(labels, key)
+      ? labels[key]
+      : undefined;
+
+  return {
+    mode: "labels",
+    test: (row) => {
+      const labels = row.__labels;
+      // Every positive key-group must have at least one matching term (OR).
+      for (const group of posGroups) {
+        const value = ownValue(labels, group.key);
+        const ok = group.terms.some((t) =>
+          // match === null → existence (`key=`): presence alone satisfies.
+          t.match === null ? value !== undefined : value !== undefined && t.match(value),
+        );
+        if (!ok) return false;
+      }
+      // Every negative term must hold (AND). `key!=value` is satisfied when the
+      // label is absent OR its value differs; `key!=` requires absence.
+      for (const t of negatives) {
+        const value = ownValue(labels, t.key);
+        if (t.match === null) {
+          if (value !== undefined) return false; // absence required, but present
+        } else if (value !== undefined && t.match(value)) {
+          return false; // present and matches the excluded value
+        }
+      }
+      return true;
+    },
+  };
+}
+
 export function parseTableFilter(raw: string): ParsedTableFilter {
   const trimmed = raw.trim();
   if (!trimmed) return { mode: "off", test: () => true };
 
+  if (trimmed.includes("=")) return parseLabelFilter(trimmed);
+
   if (REGEX_TRIGGERS.test(trimmed)) {
     try {
       const re = new RegExp(trimmed, "i");
-      return { mode: "regex", test: (name) => re.test(name) };
+      return { mode: "regex", test: (row) => re.test(rowName(row)) };
     } catch {
       return { mode: "regex", test: () => false, invalid: true };
     }
@@ -44,6 +187,6 @@ export function parseTableFilter(raw: string): ParsedTableFilter {
   const lc = trimmed.toLowerCase();
   return {
     mode: "substring",
-    test: (name) => name.toLowerCase().includes(lc),
+    test: (row) => rowName(row).toLowerCase().includes(lc),
   };
 }

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -364,9 +364,13 @@ export type ResourceKind = {
 
 /// A row produced by the backend projection. Always contains `uid`; remaining
 /// keys correspond to the kind's registered columns. Pod rows additionally
-/// carry `containers` for the logs side panel.
+/// carry `containers` for the logs side panel. `__labels` is synthetic row
+/// metadata (the object's `metadata.labels`, injected by the watcher only
+/// when non-empty) used by the filter box's label-selector mode — it is not
+/// a column.
 export type ResourceRow = {
   uid: string;
+  __labels?: Record<string, string>;
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
The filter box matched only the resource name. It now also accepts Kubernetes label selectors, auto-detected by the presence of `=`:

- `app=nginx` exact value; `app=web.*` regex value (case-insensitive)
- comma-separated terms: same key OR'd, distinct keys AND'd
- `app=` / `app!=` presence/absence, `app!=web` exclusion

Labels reach the frontend via a new `__labels` field injected once at the generic projection site in the watcher (typed + dynamic paths), so every kind gets it without per-kind changes. Attached only when non-empty to keep the per-update bus payload minimal.

Name substring/regex behavior is unchanged. Parser guards against prototype-member keys (hasOwnProperty), empty keys, and bad regex (red border). Tests cover both modes.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
