### PR TITLE
feat(about): dynamic, cached release notes ("What's new") in About

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -349,6 +349,18 @@ pub(crate) async fn apply_update(release: crate::updater::ReleaseInfo) -> Result
         .map_err(|e| format!("apply-update task failed: {e}"))?
 }
 
+/// Dynamic "What's new" notes for the About panel: every release newer than the
+/// installed build, newest-first, with parsed change items. Disk-cached and
+/// ETag-revalidated; `force` skips the freshness window (still ETag-guarded).
+#[tauri::command]
+pub(crate) async fn get_release_notes_cmd(
+    force: bool,
+) -> Result<crate::updater::ReleaseNotesBundle, String> {
+    tokio::task::spawn_blocking(move || crate::updater::fetch_release_notes(force))
+        .await
+        .map_err(|e| format!("release-notes task failed: {e}"))?
+}
+
 // ── kubectl install / detection ──────────────────────────────────────────
 
 #[tauri::command]

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -136,6 +136,7 @@ fn main() {
             commands::updater_info,
             commands::check_for_update,
             commands::apply_update,
+            commands::get_release_notes_cmd,
             commands::kubectl_get_status,
             commands::kubectl_install_managed,
             commands::kubectl_uninstall_managed,

--- a/crates/app/src/updater.rs
+++ b/crates/app/src/updater.rs
@@ -68,7 +68,20 @@ struct ApplyUpdateCommand {
 struct GitHubRelease {
     tag_name: String,
     html_url: String,
+    #[serde(default)]
     assets: Vec<GitHubAsset>,
+    // Release-notes fields. Optional so the leaner `check_latest_release`
+    // deserialize (and older releases with empty bodies) keep working.
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    published_at: Option<String>,
+    #[serde(default)]
+    prerelease: bool,
+    #[serde(default)]
+    draft: bool,
 }
 
 #[derive(Deserialize)]
@@ -327,6 +340,371 @@ pub(crate) fn check_latest_release() -> Result<CheckOutcome, String> {
             download_url: asset.browser_download_url,
         },
     })
+}
+
+// ── Release notes ────────────────────────────────────────────────────────────
+//
+// Dynamic "What's new" for the About panel. We read the GitHub *list* endpoint
+// (not just /latest), parse each release body's "What's Changed" section into
+// structured change items, and keep only releases strictly newer than the
+// installed build. The bundle is cached on disk (next to prefs.json) and
+// revalidated with an ETag so opening About doesn't hammer the API.
+
+const GITHUB_RELEASES_LIST_API: &str =
+    "https://api.github.com/repos/dzcorp/FerrisScope/releases?per_page=100";
+/// Serve cached notes without a network round-trip for this long; matches the
+/// 6h background update-check cadence. Past this we revalidate with the ETag,
+/// so a 304 still costs no download.
+const NOTES_CACHE_TTL_MS: u64 = 6 * 60 * 60 * 1000;
+
+/// One parsed bullet from a release's "What's Changed" list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ChangeItem {
+    /// Conventional-commit type: `feat` / `fix` / `refactor` / `docs` / `perf`
+    /// / `chore` / … or `other` when the title isn't conventional.
+    pub(crate) kind: String,
+    /// Conventional-commit scope (`watch`, `port-forward`), if present.
+    pub(crate) scope: Option<String>,
+    /// Human-readable subject with the type/scope prefix and PR tail stripped.
+    pub(crate) text: String,
+    /// PR number parsed from the `… in …/pull/N` tail (or `(#N)`).
+    pub(crate) pr: Option<u64>,
+    /// Author login parsed from the `… by @login …` tail.
+    pub(crate) author: Option<String>,
+}
+
+/// One release newer than the installed build, with its parsed changes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ReleaseNote {
+    pub(crate) version: String,
+    pub(crate) tag: String,
+    pub(crate) name: Option<String>,
+    pub(crate) published_at: Option<String>,
+    pub(crate) html_url: String,
+    pub(crate) changes: Vec<ChangeItem>,
+}
+
+/// What `get_release_notes` returns to the frontend. `releases` is newest-first
+/// and contains only versions strictly greater than `current_version`, so an
+/// up-to-date install yields an empty list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ReleaseNotesBundle {
+    pub(crate) current_version: String,
+    pub(crate) latest_version: Option<String>,
+    pub(crate) releases: Vec<ReleaseNote>,
+    pub(crate) fetched_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct NotesCacheEntry {
+    #[serde(default)]
+    etag: Option<String>,
+    #[serde(default)]
+    fetched_at: u64,
+    bundle: ReleaseNotesBundle,
+}
+
+struct EtagResponse {
+    status: u16,
+    etag: Option<String>,
+    body: String,
+}
+
+/// Parse a release body's "What's Changed" section into structured items.
+/// Total — returns an empty Vec on a missing/empty section so older releases
+/// (and any future format drift) degrade gracefully rather than panicking.
+fn parse_whats_changed(body: &str) -> Vec<ChangeItem> {
+    let lower = body.to_ascii_lowercase();
+    // GitHub uses a curly apostrophe in "What's Changed"; tolerate both.
+    let Some(header) = lower
+        .find("what's changed")
+        .or_else(|| lower.find("what\u{2019}s changed"))
+    else {
+        return Vec::new();
+    };
+    // Skip to the line after the header.
+    let after = match body[header..].find('\n') {
+        Some(nl) => header + nl + 1,
+        None => return Vec::new(),
+    };
+
+    let mut items = Vec::new();
+    for line in body[after..].lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let low = trimmed.to_ascii_lowercase();
+        // Footer or next section ends the list.
+        if low.starts_with("**full changelog") || low.starts_with("full changelog") {
+            break;
+        }
+        if trimmed.starts_with('#') {
+            break;
+        }
+        let Some(rest) = trimmed
+            .strip_prefix("* ")
+            .or_else(|| trimmed.strip_prefix("- "))
+            .or_else(|| trimmed.strip_prefix("\u{2022} "))
+        else {
+            continue;
+        };
+        items.push(parse_change_line(rest));
+    }
+    items
+}
+
+/// Parse one bullet, e.g.
+/// `fix(watch): TCP keepalive by @yzhelezko in https://github.com/o/r/pull/44`.
+fn parse_change_line(line: &str) -> ChangeItem {
+    let mut text = line.trim().to_string();
+    let mut author = None;
+    let mut pr = None;
+
+    if let Some(by_idx) = text.rfind(" by @") {
+        let tail = text[by_idx + 5..].trim().to_string();
+        text = text[..by_idx].trim().to_string();
+        if let Some(in_idx) = tail.find(" in ") {
+            let who = tail[..in_idx].trim();
+            if !who.is_empty() {
+                author = Some(who.to_string());
+            }
+            let url = tail[in_idx + 4..].trim();
+            pr = url
+                .rsplit('/')
+                .next()
+                .and_then(|n| n.trim().parse::<u64>().ok());
+        } else if !tail.is_empty() {
+            author = Some(tail);
+        }
+    } else if let Some(hash_idx) = text.rfind("(#") {
+        // "title (#44)" form.
+        let inner = text[hash_idx + 2..].trim_end_matches(')');
+        if let Ok(n) = inner.trim().parse::<u64>() {
+            pr = Some(n);
+            text = text[..hash_idx].trim().to_string();
+        }
+    }
+
+    let (kind, scope, subject) = split_conventional(&text);
+    ChangeItem {
+        kind,
+        scope,
+        text: subject,
+        pr,
+        author,
+    }
+}
+
+/// Split a conventional-commit title into (kind, scope, subject). Non-conforming
+/// titles fall back to `("other", None, <whole title>)`.
+fn split_conventional(text: &str) -> (String, Option<String>, String) {
+    if let Some(colon) = text.find(": ") {
+        let head = &text[..colon];
+        let subject = text[colon + 2..].trim().to_string();
+        let (kind_raw, scope) = match (head.find('('), head.find(')')) {
+            (Some(open), Some(close)) if close > open => (
+                head[..open].to_string(),
+                Some(head[open + 1..close].trim().to_string()),
+            ),
+            _ => (head.to_string(), None),
+        };
+        if let Some(kind) = normalize_kind(kind_raw.trim_end_matches('!')) {
+            return (kind, scope.filter(|s| !s.is_empty()), subject);
+        }
+    }
+    ("other".to_string(), None, text.trim().to_string())
+}
+
+/// Recognise the conventional-commit types we group on. Unknown → None
+/// (caller maps to `other`).
+fn normalize_kind(kind: &str) -> Option<String> {
+    let k = kind.trim().to_ascii_lowercase();
+    matches!(
+        k.as_str(),
+        "feat"
+            | "fix"
+            | "refactor"
+            | "perf"
+            | "docs"
+            | "chore"
+            | "test"
+            | "build"
+            | "ci"
+            | "style"
+            | "revert"
+    )
+    .then_some(k)
+}
+
+fn now_unix_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Debug builds (`make dev`) run with version `0.1.0`. We use this both to
+/// preview the panel one-version-behind and to keep dev cache off the released
+/// cache file, so testing in dev never clobbers a real install's cached notes.
+fn is_dev_build() -> bool {
+    cfg!(debug_assertions)
+}
+
+fn notes_cache_path() -> Option<PathBuf> {
+    // Separate file in dev so a debug run's preview bundle never overwrites the
+    // released build's cache (different effective version, different contents).
+    let file = if is_dev_build() {
+        "release_notes.dev.json"
+    } else {
+        "release_notes.json"
+    };
+    directories::ProjectDirs::from("dev", "ferrisscope", "ferrisscope")
+        .map(|p| p.config_dir().join(file))
+}
+
+fn read_notes_cache() -> Option<NotesCacheEntry> {
+    let path = notes_cache_path()?;
+    let data = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn write_notes_cache(entry: &NotesCacheEntry) -> Result<(), String> {
+    let path = notes_cache_path().ok_or("No config dir for release-notes cache")?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create cache dir: {e}"))?;
+    }
+    let data =
+        serde_json::to_string(entry).map_err(|e| format!("serialize release-notes cache: {e}"))?;
+    std::fs::write(&path, data).map_err(|e| format!("write release-notes cache: {e}"))
+}
+
+/// Build a `ReleaseNotesBundle` from the raw GitHub releases list + the
+/// installed version. Pure (no IO) so it's unit-testable against fixtures.
+///
+/// `preview_one_behind` is the dev affordance: in a debug build the installed
+/// version is `0.1.0` (lower than every release), which would otherwise list
+/// *every* release as "new" and make the panel impossible to eyeball. When set,
+/// we filter as if installed at the second-newest tag, so the panel shows just
+/// the newest release — exactly what a real one-version-behind user sees.
+/// `current_version` in the returned bundle is always the *real* installed
+/// version (cache identity + display depend on it being stable).
+fn build_bundle(
+    releases: Vec<GitHubRelease>,
+    current_str: &str,
+    fetched_at: u64,
+    preview_one_behind: bool,
+) -> ReleaseNotesBundle {
+    // First pass: parse every non-draft release into (version, note).
+    let mut parsed: Vec<(Version, ReleaseNote)> = Vec::new();
+    for r in releases {
+        // Skip drafts and prereleases — the updater tracks stable releases only
+        // (GitHub's /latest endpoint, which `check_latest_release` uses, does
+        // the same), so the notes panel must agree with the update offer.
+        if r.draft || r.prerelease {
+            continue;
+        }
+        let Ok(v_str) = normalize_version(&r.tag_name) else {
+            continue;
+        };
+        let Ok(v) = Version::parse(&v_str) else {
+            continue;
+        };
+        let changes = r
+            .body
+            .as_deref()
+            .map(parse_whats_changed)
+            .unwrap_or_default();
+        parsed.push((
+            v,
+            ReleaseNote {
+                version: v_str,
+                tag: r.tag_name,
+                name: r.name,
+                published_at: r.published_at,
+                html_url: r.html_url,
+                changes,
+            },
+        ));
+    }
+
+    let latest = parsed.iter().map(|(v, _)| v).max().cloned();
+
+    // Threshold: releases strictly greater than this are "new".
+    let threshold: Option<Version> = if preview_one_behind {
+        let mut versions: Vec<Version> = parsed.iter().map(|(v, _)| v.clone()).collect();
+        versions.sort();
+        versions.dedup();
+        if versions.len() >= 2 {
+            // Second-newest → only the newest release surfaces.
+            Some(versions[versions.len() - 2].clone())
+        } else {
+            // 0 or 1 releases: floor so the single release (if any) shows.
+            Some(Version::new(0, 0, 0))
+        }
+    } else {
+        Version::parse(current_str).ok()
+    };
+
+    let mut notes: Vec<(Version, ReleaseNote)> = parsed
+        .into_iter()
+        .filter(|(v, _)| threshold.as_ref().is_none_or(|t| v > t))
+        .collect();
+    // Newest-first.
+    notes.sort_by(|a, b| b.0.cmp(&a.0));
+
+    ReleaseNotesBundle {
+        current_version: current_str.to_string(),
+        latest_version: latest.map(|v| v.to_string()),
+        releases: notes.into_iter().map(|(_, n)| n).collect(),
+        fetched_at,
+    }
+}
+
+/// Fetch (or serve cached) release notes for versions newer than the installed
+/// build. `force` skips the freshness window but still sends the ETag, so an
+/// unchanged list returns 304 with no body download.
+pub(crate) fn fetch_release_notes(force: bool) -> Result<ReleaseNotesBundle, String> {
+    let current_str = current_version().to_string();
+    let now = now_unix_ms();
+    let cache = read_notes_cache();
+
+    if !force {
+        if let Some(c) = &cache {
+            let fresh = now.saturating_sub(c.fetched_at) < NOTES_CACHE_TTL_MS;
+            if fresh && c.bundle.current_version == current_str {
+                return Ok(c.bundle.clone());
+            }
+        }
+    }
+
+    let etag = cache.as_ref().and_then(|c| c.etag.clone());
+    let resp = http_get_with_etag(GITHUB_RELEASES_LIST_API, etag.as_deref())?;
+
+    if resp.status == 304 {
+        if let Some(mut c) = cache {
+            // Still current; just stamp it so we don't revalidate every open.
+            if c.bundle.current_version == current_str {
+                c.fetched_at = now;
+                let bundle = c.bundle.clone();
+                let _ = write_notes_cache(&c);
+                return Ok(bundle);
+            }
+        }
+        return Err("GitHub returned 304 but no usable cached notes were available.".to_string());
+    }
+
+    let releases: Vec<GitHubRelease> = serde_json::from_str(&resp.body)
+        .map_err(|e| format!("Invalid GitHub releases response: {e}"))?;
+    let bundle = build_bundle(releases, &current_str, now, is_dev_build());
+    let entry = NotesCacheEntry {
+        etag: resp.etag,
+        fetched_at: now,
+        bundle: bundle.clone(),
+    };
+    let _ = write_notes_cache(&entry);
+    Ok(bundle)
 }
 
 pub(crate) fn prepare_and_spawn_update(release: &ReleaseInfo) -> Result<(), String> {
@@ -942,6 +1320,46 @@ fn http_get_response(url: &str, json: bool) -> Result<Box<dyn io::Read>, String>
     Ok(Box::new(body.into_reader()))
 }
 
+/// GET that keeps the status code + ETag header so callers can do conditional
+/// requests. Sends `If-None-Match` when `if_none_match` is set; a 304 returns an
+/// empty body (caller reuses its cache). 304 is not an error here — ureq only
+/// maps >= 400 to `Error::StatusCode`.
+fn http_get_with_etag(url: &str, if_none_match: Option<&str>) -> Result<EtagResponse, String> {
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(30)))
+        .build()
+        .into();
+    let mut request = agent
+        .get(url)
+        .header("User-Agent", &format!("ferrisscope/{}", current_version()))
+        .header("Accept", "application/vnd.github+json");
+    if let Some(etag) = if_none_match {
+        request = request.header("If-None-Match", etag);
+    }
+    let (parts, body) = request.call().map_err(format_http_error)?.into_parts();
+    let status = parts.status.as_u16();
+    let etag = parts
+        .headers
+        .get("etag")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let text = if status == 304 {
+        String::new()
+    } else {
+        use std::io::Read;
+        let mut s = String::new();
+        body.into_reader()
+            .read_to_string(&mut s)
+            .map_err(|err| format!("Failed to read HTTP response body: {err}"))?;
+        s
+    };
+    Ok(EtagResponse {
+        status,
+        etag,
+        body: text,
+    })
+}
+
 fn format_http_error(error: ureq::Error) -> String {
     match error {
         ureq::Error::StatusCode(code) => format!("HTTP {code} while contacting GitHub"),
@@ -952,10 +1370,28 @@ fn format_http_error(error: ureq::Error) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        asset_suffix, current_version, normalize_version, parse_apply_update_command,
-        supported_target_label,
+        asset_suffix, build_bundle, current_version, normalize_version, parse_apply_update_command,
+        parse_change_line, parse_whats_changed, split_conventional, supported_target_label,
+        GitHubRelease,
     };
     use std::ffi::OsString;
+
+    fn fixture_releases() -> Vec<GitHubRelease> {
+        // `json!` strings carry real newlines (from `\n`), so `parse_whats_changed`
+        // sees genuine line breaks — a raw string literal would not.
+        let v = serde_json::json!([
+            {"tag_name":"v1.0.27","html_url":"https://x/v1.0.27","name":"v1.0.27","published_at":"2026-06-20T00:00:00Z","prerelease":false,"draft":false,
+             "body":"## What's Changed\n* feat(a): newest by @u in https://x/pull/45"},
+            {"tag_name":"v1.0.26","html_url":"https://x/v1.0.26","name":"v1.0.26","prerelease":false,"draft":false,
+             "body":"## What's Changed\n* fix(b): middle by @u in https://x/pull/44"},
+            {"tag_name":"v1.0.25","html_url":"https://x/v1.0.25","prerelease":false,"draft":false,"body":""},
+            {"tag_name":"v1.0.28-rc1","html_url":"https://x/rc","prerelease":true,"draft":false,
+             "body":"## What's Changed\n* feat(z): pre by @u in https://x/pull/99"},
+            {"tag_name":"v9.9.9","html_url":"https://x/draft","prerelease":false,"draft":true,
+             "body":"## What's Changed\n* feat(z): draft by @u in https://x/pull/100"}
+        ]);
+        serde_json::from_value(v).expect("valid releases fixture")
+    }
 
     #[test]
     fn strips_v_prefix() {
@@ -1154,5 +1590,116 @@ mod tests {
             OsString::from("/d"),
         ];
         assert!(parse_apply_update_command(args).is_err());
+    }
+
+    // ── Release notes ────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_whats_changed_extracts_bullets() {
+        let body = "Some intro blurb.\n\n\
+            ## What's Changed\n\
+            * fix(watch): TCP keepalive on watch sockets by @yzhelezko in https://github.com/dzcorp/FerrisScope/pull/44\n\
+            * feat(port-forward): global DNS forwarding by @yzhelezko in https://github.com/dzcorp/FerrisScope/pull/45\n\n\
+            **Full Changelog**: https://github.com/dzcorp/FerrisScope/compare/v1.0.26...v1.0.27";
+        let items = parse_whats_changed(body);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].kind, "fix");
+        assert_eq!(items[0].scope.as_deref(), Some("watch"));
+        assert_eq!(items[0].text, "TCP keepalive on watch sockets");
+        assert_eq!(items[0].pr, Some(44));
+        assert_eq!(items[0].author.as_deref(), Some("yzhelezko"));
+        assert_eq!(items[1].kind, "feat");
+        assert_eq!(items[1].scope.as_deref(), Some("port-forward"));
+        assert_eq!(items[1].pr, Some(45));
+    }
+
+    #[test]
+    fn parse_whats_changed_tolerates_missing_section() {
+        // Older releases ship empty bodies / install boilerplate only.
+        assert!(parse_whats_changed("").is_empty());
+        assert!(parse_whats_changed("Download the AppImage below.").is_empty());
+        // Curly apostrophe variant is still recognised.
+        let curly = "## What\u{2019}s Changed\n* chore: bump deps by @bot in https://x/pull/9";
+        let items = parse_whats_changed(curly);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].kind, "chore");
+        assert_eq!(items[0].pr, Some(9));
+    }
+
+    #[test]
+    fn parse_whats_changed_stops_at_next_heading() {
+        let body = "## What's Changed\n* fix: a by @u in https://x/pull/1\n## New Contributors\n* @newbie made their first contribution";
+        let items = parse_whats_changed(body);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].text, "a");
+    }
+
+    #[test]
+    fn parse_change_line_handles_hash_form_and_plain() {
+        let hash = parse_change_line("feat(ui): nicer about panel (#123)");
+        assert_eq!(hash.kind, "feat");
+        assert_eq!(hash.scope.as_deref(), Some("ui"));
+        assert_eq!(hash.text, "nicer about panel");
+        assert_eq!(hash.pr, Some(123));
+        assert!(hash.author.is_none());
+
+        // Non-conventional title → "other", whole text preserved.
+        let plain = parse_change_line("Update README by @docsbot in https://x/pull/7");
+        assert_eq!(plain.kind, "other");
+        assert!(plain.scope.is_none());
+        assert_eq!(plain.text, "Update README");
+        assert_eq!(plain.author.as_deref(), Some("docsbot"));
+        assert_eq!(plain.pr, Some(7));
+    }
+
+    #[test]
+    fn split_conventional_recognises_types_and_breaking_marker() {
+        assert_eq!(
+            split_conventional("refactor(core)!: drop legacy path"),
+            (
+                "refactor".into(),
+                Some("core".into()),
+                "drop legacy path".into()
+            )
+        );
+        assert_eq!(
+            split_conventional("docs: tidy"),
+            ("docs".into(), None, "tidy".into())
+        );
+        // Unknown type prefix is not treated as conventional.
+        assert_eq!(
+            split_conventional("wip(thing): half done"),
+            ("other".into(), None, "wip(thing): half done".into())
+        );
+    }
+
+    #[test]
+    fn build_bundle_filters_to_newer_stable_releases() {
+        let bundle = build_bundle(fixture_releases(), "1.0.25", 1000, false);
+        // 1.0.26 and 1.0.27 are newer than 1.0.25; rc + draft excluded.
+        let versions: Vec<&str> = bundle.releases.iter().map(|r| r.version.as_str()).collect();
+        assert_eq!(versions, vec!["1.0.27", "1.0.26"]); // newest-first
+                                                        // latest_version reflects the newest *stable* release.
+        assert_eq!(bundle.latest_version.as_deref(), Some("1.0.27"));
+        assert_eq!(bundle.current_version, "1.0.25");
+        assert_eq!(bundle.fetched_at, 1000);
+    }
+
+    #[test]
+    fn build_bundle_up_to_date_is_empty() {
+        let bundle = build_bundle(fixture_releases(), "1.0.27", 0, false);
+        assert!(bundle.releases.is_empty());
+        assert_eq!(bundle.latest_version.as_deref(), Some("1.0.27"));
+    }
+
+    #[test]
+    fn build_bundle_dev_preview_shows_only_newest() {
+        // Dev build (real version 0.1.0) would otherwise list every release.
+        // Preview mode pretends we're at the second-newest tag → only newest.
+        let bundle = build_bundle(fixture_releases(), "0.1.0", 0, true);
+        let versions: Vec<&str> = bundle.releases.iter().map(|r| r.version.as_str()).collect();
+        assert_eq!(versions, vec!["1.0.27"]);
+        // Real installed version is preserved for cache identity / display.
+        assert_eq!(bundle.current_version, "0.1.0");
     }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -400,7 +400,8 @@ export default function App() {
             // durable signal.
             if (prev !== v && seen !== v) {
               toast.info(
-                `FerrisScope v${v} is available\nOpen Settings → About to update or skip this version.`,
+                `FerrisScope v${v} is available\nClick to see what's new, update, or skip.`,
+                { route: { section: "about", anchor: "about-whatsnew" } },
               );
             }
           } else {

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -49,6 +49,29 @@ describe("ping / updater plumbing", () => {
     expect(cap.calls[0]?.cmd).toBe("apply_update");
     expect(cap.calls[0]?.args).toEqual({ release });
   });
+
+  it("getReleaseNotes → 'get_release_notes_cmd' with force=false by default", async () => {
+    const cap = captureNext({
+      current_version: "1.0.0",
+      latest_version: "1.0.1",
+      releases: [],
+      fetched_at: 0,
+    });
+    await api.getReleaseNotes();
+    expect(cap.calls[0]?.cmd).toBe("get_release_notes_cmd");
+    expect(cap.calls[0]?.args).toEqual({ force: false });
+  });
+
+  it("getReleaseNotes forwards force=true", async () => {
+    const cap = captureNext({
+      current_version: "1.0.0",
+      latest_version: null,
+      releases: [],
+      fetched_at: 0,
+    });
+    await api.getReleaseNotes(true);
+    expect(cap.calls[0]?.args).toEqual({ force: true });
+  });
 });
 
 describe("contexts + connect", () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -87,6 +87,7 @@ import type {
   PromChangedEvent,
   PromTarget,
   ReleaseInfo,
+  ReleaseNotesBundle,
   ReplicaSetDetail,
   ResourceDelta,
   ResourceKind,
@@ -125,6 +126,11 @@ export const api = {
   checkForUpdate: () => invoke<UpdateCheckOutcome>("check_for_update"),
   applyUpdate: (release: ReleaseInfo) =>
     invoke<void>("apply_update", { release }),
+  /// Dynamic "What's new" notes for every release newer than the installed
+  /// build. Disk-cached + ETag-revalidated in the backend; `force` skips the
+  /// freshness window (still no download on a 304).
+  getReleaseNotes: (force = false) =>
+    invoke<ReleaseNotesBundle>("get_release_notes_cmd", { force }),
   listContexts: () => invoke<ContextInfo[]>("list_contexts"),
   connectContext: (name: string, connectId: string) =>
     invoke<ClusterInfo>("connect_context", { name, connectId }),

--- a/ui/src/components/HeaderToast.test.tsx
+++ b/ui/src/components/HeaderToast.test.tsx
@@ -1,0 +1,53 @@
+// HeaderToast routing: a routed toast (the "update available" notice) must
+// deep-link to its Settings target and dismiss itself; every other toast keeps
+// the original behaviour of opening the notifications panel.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { HeaderToast } from "./HeaderToast";
+import { useAppStore } from "../store";
+import type { Toast } from "../store";
+
+function seed(toast: Toast) {
+  useAppStore.setState({
+    toasts: [toast],
+    settingsOpen: false,
+    settingsTarget: null,
+    notificationsOpen: false,
+  });
+}
+
+afterEach(cleanup);
+
+describe("HeaderToast routing", () => {
+  it("routed toast click opens Settings at the target and dismisses the toast", () => {
+    seed({
+      id: "u",
+      tone: "info",
+      text: "update available",
+      durationMs: 0,
+      route: { section: "about", anchor: "about-whatsnew" },
+    });
+    render(<HeaderToast mode="dark" />);
+
+    fireEvent.click(screen.getByText("update available").closest("button")!);
+
+    const s = useAppStore.getState();
+    expect(s.settingsOpen).toBe(true);
+    expect(s.settingsTarget).toEqual({ section: "about", anchor: "about-whatsnew" });
+    expect(s.notificationsOpen).toBe(false);
+    // Dismissed so it doesn't linger over the destination.
+    expect(s.toasts).toHaveLength(0);
+  });
+
+  it("plain toast click opens the notifications panel", () => {
+    seed({ id: "p", tone: "info", text: "something happened", durationMs: 0 });
+    render(<HeaderToast mode="dark" />);
+
+    fireEvent.click(screen.getByText("something happened").closest("button")!);
+
+    const s = useAppStore.getState();
+    expect(s.notificationsOpen).toBe(true);
+    expect(s.settingsOpen).toBe(false);
+  });
+});

--- a/ui/src/components/HeaderToast.tsx
+++ b/ui/src/components/HeaderToast.tsx
@@ -43,6 +43,7 @@ function HeaderToastCard({
 }) {
   const dismissToast = useAppStore((s) => s.dismissToast);
   const openNotifications = useAppStore((s) => s.openNotifications);
+  const openSettings = useAppStore((s) => s.openSettings);
 
   useEffect(() => {
     if (toast.durationMs <= 0) return;
@@ -74,7 +75,17 @@ function HeaderToastCard({
   const sticky = tone === "bad" && toast.durationMs <= 0;
   const ringShadow = sticky ? `0 0 0 1px ${withAlpha(t.bad, 0.32)}` : "none";
 
-  const onCardClick = () => openNotifications();
+  // Routed toasts (e.g. "update available" → About → What's new) deep-link to
+  // Settings; everything else opens the notifications panel. Dismiss the toast
+  // either way so it doesn't linger over the destination.
+  const onCardClick = () => {
+    if (toast.route) {
+      openSettings(toast.route);
+      dismissToast(toast.id);
+    } else {
+      openNotifications();
+    }
+  };
   const onDismissClick = (e: MouseEvent) => {
     e.stopPropagation();
     dismissToast(toast.id);

--- a/ui/src/components/ReleaseNotes.test.tsx
+++ b/ui/src/components/ReleaseNotes.test.tsx
@@ -1,0 +1,123 @@
+// ReleaseNotes: the About panel's dynamic "What's new" view. Guards the merged
+// grouping, the version-range title, the per-version toggle, and the
+// loading/empty/error states — the bits CLAUDE.md calls "finishing the loop".
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import { ReleaseNotes } from "./ReleaseNotes";
+import { tokens } from "../theme";
+import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { ReleaseNote, ReleaseNotesBundle } from "../types";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
+const t = tokens("dark");
+
+function rel(version: string, changes: ReleaseNote["changes"]): ReleaseNote {
+  return {
+    version,
+    tag: `v${version}`,
+    name: `v${version}`,
+    published_at: "2026-06-20T00:00:00Z",
+    html_url: `https://github.com/dzcorp/FerrisScope/releases/tag/v${version}`,
+    changes,
+  };
+}
+
+function bundle(releases: ReleaseNote[]): ReleaseNotesBundle {
+  return {
+    current_version: "1.0.0",
+    latest_version: releases[0]?.version ?? null,
+    releases,
+    fetched_at: 0,
+  };
+}
+
+const MULTI = bundle([
+  rel("1.0.27", [
+    { kind: "feat", scope: "port-forward", text: "global DNS forwarding", pr: 45, author: "u" },
+  ]),
+  rel("1.0.26", [{ kind: "fix", scope: "watch", text: "keepalive", pr: 44, author: "u" }]),
+]);
+
+beforeEach(() => {
+  vi.mocked(openUrl).mockClear();
+});
+
+afterEach(() => {
+  resetMockInvoke();
+  cleanup();
+});
+
+describe("ReleaseNotes", () => {
+  it("renders a merged, version-range title with grouped changes", async () => {
+    setMockInvoke(() => MULTI);
+    render(<ReleaseNotes t={t} />);
+
+    expect(await screen.findByText("What's new in v1.0.26 – v1.0.27")).toBeTruthy();
+    // Both groups present, changes merged across the two releases.
+    expect(screen.getByText("Features")).toBeTruthy();
+    expect(screen.getByText("Fixes")).toBeTruthy();
+    expect(screen.getByText("global DNS forwarding")).toBeTruthy();
+    expect(screen.getByText("keepalive")).toBeTruthy();
+    // PR deep-link renders.
+    expect(screen.getByText("#45")).toBeTruthy();
+  });
+
+  it("toggles to a per-version breakdown and back", async () => {
+    setMockInvoke(() => MULTI);
+    render(<ReleaseNotes t={t} />);
+    const toggle = await screen.findByText("Show per-version");
+    fireEvent.click(toggle);
+    // Per-version headers appear (one per release).
+    expect(screen.getByText("v1.0.27")).toBeTruthy();
+    expect(screen.getByText("v1.0.26")).toBeTruthy();
+    expect(screen.getByText("Show merged")).toBeTruthy();
+  });
+
+  it("uses a single version (no range) when only one release pends", async () => {
+    setMockInvoke(() => bundle([rel("1.0.27", [{ kind: "feat", scope: null, text: "a", pr: 1, author: null }])]));
+    render(<ReleaseNotes t={t} />);
+    expect(await screen.findByText("What's new in v1.0.27")).toBeTruthy();
+    // No per-version toggle for a single release.
+    expect(screen.queryByText("Show per-version")).toBeNull();
+  });
+
+  it("shows an up-to-date message when there are no newer releases", async () => {
+    setMockInvoke(() => bundle([]));
+    render(<ReleaseNotes t={t} />);
+    expect(
+      await screen.findByText(/on the latest version/i),
+    ).toBeTruthy();
+  });
+
+  it("surfaces a load error", async () => {
+    setMockInvoke(() => {
+      throw new Error("network down");
+    });
+    render(<ReleaseNotes t={t} />);
+    await waitFor(() => {
+      expect(screen.getByText(/network down/i)).toBeTruthy();
+    });
+  });
+
+  it("force-refetches when reloadKey changes, but not on first render", async () => {
+    const calls: { force: unknown }[] = [];
+    setMockInvoke((_cmd, args) => {
+      calls.push({ force: (args as { force: unknown }).force });
+      return MULTI;
+    });
+    const { rerender } = render(<ReleaseNotes t={t} reloadKey="a:1.0.0" />);
+    await screen.findByText("What's new in v1.0.26 – v1.0.27");
+    // Mount load is cached (force=false), no extra fetch yet.
+    expect(calls).toEqual([{ force: false }]);
+
+    // A check that changes the detected version → one forced refetch.
+    rerender(<ReleaseNotes t={t} reloadKey="a:1.0.27" />);
+    await waitFor(() => expect(calls).toHaveLength(2));
+    expect(calls[1]).toEqual({ force: true });
+  });
+});

--- a/ui/src/components/ReleaseNotes.tsx
+++ b/ui/src/components/ReleaseNotes.tsx
@@ -1,0 +1,365 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { api } from "../api";
+import type { ReleaseNote, ReleaseNotesBundle } from "../types";
+import {
+  type Tokens,
+  FF_MONO,
+  FS_LG,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  R_SM,
+} from "../theme";
+import { Chip, ErrorBlock } from "./ui";
+import {
+  type ChangeGroupKey,
+  type GroupedChange,
+  groupChanges,
+  totalChangeCount,
+  versionRangeLabel,
+} from "../lib/releaseNotes";
+
+// Accent dot colour per group. Features lean "good" (green), fixes "info"
+// (blue), everything else stays muted — keeps the panel readable at a glance
+// without inventing new tokens.
+function groupColor(t: Tokens, key: ChangeGroupKey): string {
+  if (key === "features") return t.good;
+  if (key === "fixes") return t.info;
+  return t.textMuted;
+}
+
+// Build `https://github.com/<owner>/<repo>` from a release html_url so PR links
+// don't hard-code the repo. Falls back to null when the URL is unexpected.
+function repoBaseFromReleaseUrl(htmlUrl: string | undefined): string | null {
+  if (!htmlUrl) return null;
+  const m = htmlUrl.match(/^(https:\/\/github\.com\/[^/]+\/[^/]+)/);
+  return m && m[1] ? m[1] : null;
+}
+
+function PrLink({ t, repoBase, pr }: { t: Tokens; repoBase: string | null; pr: number }) {
+  if (!repoBase) {
+    return <span style={{ color: t.textMuted, fontFamily: FF_MONO, fontSize: FS_XS }}>#{pr}</span>;
+  }
+  return (
+    <button
+      type="button"
+      title={`Open PR #${pr} on GitHub`}
+      onClick={() => void openUrl(`${repoBase}/pull/${pr}`)}
+      style={{
+        background: "transparent",
+        border: 0,
+        padding: 0,
+        cursor: "pointer",
+        color: t.accent,
+        fontFamily: FF_MONO,
+        fontSize: FS_XS,
+      }}
+    >
+      #{pr}
+    </button>
+  );
+}
+
+function ChangeRow({
+  t,
+  change,
+  repoBase,
+  showVersion,
+}: {
+  t: Tokens;
+  change: GroupedChange;
+  repoBase: string | null;
+  showVersion?: boolean;
+}) {
+  return (
+    <li
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        gap: 8,
+        padding: "3px 0",
+        fontSize: FS_MD,
+        color: t.text,
+        lineHeight: 1.45,
+      }}
+    >
+      <span aria-hidden style={{ color: t.textMuted, flexShrink: 0 }}>
+        •
+      </span>
+      <span style={{ flex: 1, minWidth: 0 }}>
+        {change.scope ? (
+          <span style={{ color: t.textDim, fontFamily: FF_MONO }}>{change.scope}: </span>
+        ) : null}
+        {change.text}
+      </span>
+      {showVersion ? (
+        <span style={{ color: t.textMuted, fontFamily: FF_MONO, fontSize: FS_XS, flexShrink: 0 }}>
+          v{change.version}
+        </span>
+      ) : null}
+      {change.pr != null ? (
+        <span style={{ flexShrink: 0 }}>
+          <PrLink t={t} repoBase={repoBase} pr={change.pr} />
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+// Merged view: every pending release folded into Features / Fixes / Other.
+function MergedView({
+  t,
+  releases,
+  repoBase,
+  multi,
+}: {
+  t: Tokens;
+  releases: ReleaseNote[];
+  repoBase: string | null;
+  multi: boolean;
+}) {
+  const groups = groupChanges(releases);
+  if (groups.length === 0) {
+    return (
+      <div style={{ fontSize: FS_MD, color: t.textDim, marginTop: 8 }}>
+        No detailed notes for these releases — open them on GitHub for the full changelog.
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14, marginTop: 12 }}>
+      {groups.map((g) => (
+        <div key={g.key}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: FS_SM,
+              fontWeight: 600,
+              color: t.textDim,
+              marginBottom: 4,
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: 99,
+                background: groupColor(t, g.key),
+                flexShrink: 0,
+              }}
+            />
+            {g.label}
+            <span style={{ color: t.textMuted, fontWeight: 400 }}>({g.items.length})</span>
+          </div>
+          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+            {g.items.map((c, i) => (
+              <ChangeRow
+                key={`${c.version}-${c.pr ?? i}`}
+                t={t}
+                change={c}
+                repoBase={repoBase}
+                // Only worth showing the source version when several releases
+                // are merged together.
+                showVersion={multi}
+              />
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Per-version breakdown: one block per release, newest first.
+function PerVersionView({
+  t,
+  releases,
+  repoBase,
+}: {
+  t: Tokens;
+  releases: ReleaseNote[];
+  repoBase: string | null;
+}) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14, marginTop: 12 }}>
+      {releases.map((rel) => (
+        <div key={rel.tag}>
+          <button
+            type="button"
+            title="Open this release on GitHub"
+            onClick={() => void openUrl(rel.html_url)}
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              gap: 8,
+              background: "transparent",
+              border: 0,
+              padding: 0,
+              cursor: "pointer",
+              color: t.text,
+              fontFamily: FF_MONO,
+              fontSize: FS_MD,
+              fontWeight: 600,
+            }}
+          >
+            v{rel.version}
+            {rel.published_at ? (
+              <span style={{ color: t.textMuted, fontWeight: 400, fontSize: FS_XS }}>
+                {rel.published_at.slice(0, 10)}
+              </span>
+            ) : null}
+          </button>
+          {rel.changes.length === 0 ? (
+            <div style={{ fontSize: FS_SM, color: t.textMuted, marginTop: 2 }}>
+              No detailed notes.
+            </div>
+          ) : (
+            <ul style={{ listStyle: "none", margin: "4px 0 0", padding: 0 }}>
+              {rel.changes.map((c, i) => (
+                <ChangeRow
+                  key={c.pr ?? i}
+                  t={t}
+                  change={{ ...c, version: rel.version }}
+                  repoBase={repoBase}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/// The About panel's dynamic "What's new" view. Owns its own fetch (the backend
+/// caches + ETag-revalidates, so mounting is cheap) and renders the merged,
+/// version-collapsed changelog for every release newer than the installed
+/// build. Shows loading / empty / error states.
+export function ReleaseNotes({
+  t,
+  reloadKey,
+}: {
+  t: Tokens;
+  /// Force-refetch the notes when this value changes (skipping the freshness
+  /// window). The About panel passes the latest version the update check found,
+  /// so hitting its "Check for updates" button surfaces a just-published
+  /// release here even if the 6h cache is still warm. The mount fetch is always
+  /// cached — this only fires on subsequent changes.
+  reloadKey?: string;
+}) {
+  const [bundle, setBundle] = useState<ReleaseNotesBundle | null>(null);
+  const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
+  const [errMsg, setErrMsg] = useState("");
+  const [expanded, setExpanded] = useState(false);
+
+  const load = useCallback((force: boolean) => {
+    if (!force) setPhase("loading");
+    api
+      .getReleaseNotes(force)
+      .then((b) => {
+        setBundle(b);
+        setPhase("ready");
+      })
+      .catch((e) => {
+        setErrMsg(String(e));
+        setPhase("error");
+      });
+  }, []);
+
+  // Cached fetch on mount.
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
+  // Force-refetch when the update check reports a different version. Skip the
+  // first run — mount already did the cached load.
+  const firstReload = useRef(true);
+  useEffect(() => {
+    if (firstReload.current) {
+      firstReload.current = false;
+      return;
+    }
+    load(true);
+  }, [reloadKey, load]);
+
+  const releases = bundle?.releases ?? [];
+  const multi = releases.length > 1;
+  const repoBase = repoBaseFromReleaseUrl(releases[0]?.html_url);
+
+  return (
+    <div data-fs-anchor="about-whatsnew" style={{ marginTop: 18 }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+        <div style={{ fontSize: FS_LG, fontWeight: 700, color: t.text }}>
+          {phase === "ready" && releases.length > 0
+            ? `What's new in ${versionRangeLabel(releases)}`
+            : "What's new"}
+        </div>
+        {phase === "ready" && releases.length > 0 ? (
+          <Chip t={t} tone="accent">
+            {totalChangeCount(releases)} change
+            {totalChangeCount(releases) === 1 ? "" : "s"}
+          </Chip>
+        ) : null}
+      </div>
+
+      {phase === "loading" ? (
+        <div style={{ fontSize: FS_MD, color: t.textDim, marginTop: 12 }}>
+          Loading release notes…
+        </div>
+      ) : null}
+
+      {phase === "error" ? (
+        <div style={{ marginTop: 12 }}>
+          <ErrorBlock
+            t={t}
+            message={errMsg}
+            kindLabel="release notes"
+            verb="load"
+            inline
+          />
+        </div>
+      ) : null}
+
+      {phase === "ready" && releases.length === 0 ? (
+        <div style={{ fontSize: FS_MD, color: t.textDim, marginTop: 12 }}>
+          You're on the latest version — no newer releases.
+        </div>
+      ) : null}
+
+      {phase === "ready" && releases.length > 0 ? (
+        <>
+          {expanded ? (
+            <PerVersionView t={t} releases={releases} repoBase={repoBase} />
+          ) : (
+            <MergedView t={t} releases={releases} repoBase={repoBase} multi={multi} />
+          )}
+          {multi ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              style={{
+                marginTop: 12,
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                background: "transparent",
+                border: `1px solid ${t.border}`,
+                borderRadius: R_SM,
+                padding: "4px 10px",
+                cursor: "pointer",
+                color: t.textDim,
+                fontSize: FS_SM,
+              }}
+            >
+              {expanded ? "Show merged" : "Show per-version"}
+            </button>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -47,6 +47,7 @@ import {
 import { MOD_KEY, SHIFT_KEY, ALT_KEY } from "../lib/keyboard";
 import { AiSection } from "./settings/AiSection";
 import { ToolsSection } from "./settings/ToolsSection";
+import { ReleaseNotes } from "./ReleaseNotes";
 
 // Re-export from `types.ts` so the rest of the app uses one canonical
 // `SettingsSectionId` (the store typed `openSettings(target)` against
@@ -2258,6 +2259,21 @@ function AboutSection({}: { mode: ThemeMode }) {
           />
         )}
       </div>
+      {/* Dynamic "What's new" — every release newer than the installed build,
+          merged with skipped versions collapsed into a range. The notification
+          toast deep-links here via the `about-whatsnew` anchor. */}
+      <ReleaseNotes
+        t={t}
+        // Re-fetch notes when a check changes the detected version, so the
+        // existing "Check for updates" button above also refreshes this panel.
+        reloadKey={
+          update.kind === "available"
+            ? `a:${update.release.version}`
+            : update.kind === "up_to_date"
+              ? `u:${update.latest}`
+              : ""
+        }
+      />
     </div>
   );
 }

--- a/ui/src/lib/dialog.ts
+++ b/ui/src/lib/dialog.ts
@@ -4,6 +4,7 @@
 
 import { useAppStore } from "../store";
 import type { Toast, ToastTone } from "../store";
+import type { SettingsTarget } from "../types";
 
 export type ConfirmOpts = {
   title: string;
@@ -38,7 +39,15 @@ const DEFAULT_TOAST_MS: Record<ToastTone, number> = {
   bad: 0, // sticky — operator must dismiss
 };
 
-function emit(tone: ToastTone, text: string, durationMs?: number): string {
+/// Extra, optional toast behaviour. `route` deep-links the toast (and its
+/// notification-log entry) to a Settings target instead of the notifications
+/// panel — see `Toast.route`.
+export type ToastOptions = {
+  durationMs?: number;
+  route?: SettingsTarget;
+};
+
+function emit(tone: ToastTone, text: string, opts?: ToastOptions): string {
   const id = makeId();
   // Header strip can only render one line — split multi-line input so the
   // first line stays the headline and the rest moves into `body`, which is
@@ -52,16 +61,27 @@ function emit(tone: ToastTone, text: string, durationMs?: number): string {
     tone,
     text: headline,
     body,
-    durationMs: durationMs ?? DEFAULT_TOAST_MS[tone],
+    durationMs: opts?.durationMs ?? DEFAULT_TOAST_MS[tone],
+    route: opts?.route,
   };
   useAppStore.getState().pushToast(toast);
   return id;
 }
 
+// Back-compat: callers may pass a bare `durationMs` number (legacy) or a
+// `ToastOptions` object. Normalise to options.
+function toOptions(arg?: number | ToastOptions): ToastOptions | undefined {
+  return typeof arg === "number" ? { durationMs: arg } : arg;
+}
+
 export const toast = {
-  info: (text: string, durationMs?: number) => emit("info", text, durationMs),
-  ok: (text: string, durationMs?: number) => emit("ok", text, durationMs),
-  warn: (text: string, durationMs?: number) => emit("warn", text, durationMs),
-  bad: (text: string, durationMs?: number) => emit("bad", text, durationMs),
+  info: (text: string, arg?: number | ToastOptions) =>
+    emit("info", text, toOptions(arg)),
+  ok: (text: string, arg?: number | ToastOptions) =>
+    emit("ok", text, toOptions(arg)),
+  warn: (text: string, arg?: number | ToastOptions) =>
+    emit("warn", text, toOptions(arg)),
+  bad: (text: string, arg?: number | ToastOptions) =>
+    emit("bad", text, toOptions(arg)),
   dismiss: (id: string) => useAppStore.getState().dismissToast(id),
 };

--- a/ui/src/lib/releaseNotes.test.ts
+++ b/ui/src/lib/releaseNotes.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import type { ChangeItem, ReleaseNote } from "../types";
+import {
+  changeSummary,
+  groupChanges,
+  groupKeyForKind,
+  totalChangeCount,
+  versionRangeLabel,
+} from "./releaseNotes";
+
+function change(partial: Partial<ChangeItem>): ChangeItem {
+  return {
+    kind: "other",
+    scope: null,
+    text: "x",
+    pr: null,
+    author: null,
+    ...partial,
+  };
+}
+
+function release(version: string, changes: ChangeItem[]): ReleaseNote {
+  return {
+    version,
+    tag: `v${version}`,
+    name: `v${version}`,
+    published_at: null,
+    html_url: `https://github.com/dzcorp/FerrisScope/releases/tag/v${version}`,
+    changes,
+  };
+}
+
+describe("versionRangeLabel", () => {
+  it("returns a single version when only one release pends", () => {
+    expect(versionRangeLabel([release("1.0.27", [])])).toBe("v1.0.27");
+  });
+
+  it("collapses skipped versions into a range (newest-first input)", () => {
+    const releases = [
+      release("1.0.27", []),
+      release("1.0.26", []),
+      release("1.0.1", []),
+    ];
+    expect(versionRangeLabel(releases)).toBe("v1.0.1 – v1.0.27");
+  });
+
+  it("is empty for no releases", () => {
+    expect(versionRangeLabel([])).toBe("");
+  });
+});
+
+describe("groupKeyForKind", () => {
+  it("maps feat/fix to their groups and everything else to other", () => {
+    expect(groupKeyForKind("feat")).toBe("features");
+    expect(groupKeyForKind("fix")).toBe("fixes");
+    expect(groupKeyForKind("refactor")).toBe("other");
+    expect(groupKeyForKind("perf")).toBe("other");
+    expect(groupKeyForKind("anything")).toBe("other");
+  });
+});
+
+describe("groupChanges", () => {
+  it("merges changes across releases, tagging source version, dropping empty groups", () => {
+    const releases = [
+      release("1.0.27", [change({ kind: "feat", text: "newest" })]),
+      release("1.0.26", [
+        change({ kind: "fix", text: "a" }),
+        change({ kind: "chore", text: "bump" }),
+      ]),
+    ];
+    const groups = groupChanges(releases);
+    // Features, Fixes, Other — all three present here.
+    expect(groups.map((g) => g.key)).toEqual(["features", "fixes", "other"]);
+    const features = groups.find((g) => g.key === "features");
+    expect(features?.items).toHaveLength(1);
+    expect(features?.items[0]?.version).toBe("1.0.27");
+    // "chore" folds into Other.
+    expect(groups.find((g) => g.key === "other")?.items[0]?.text).toBe("bump");
+  });
+
+  it("omits groups with no items", () => {
+    const groups = groupChanges([
+      release("1.0.1", [change({ kind: "feat", text: "only feature" })]),
+    ]);
+    expect(groups.map((g) => g.key)).toEqual(["features"]);
+  });
+});
+
+describe("totalChangeCount", () => {
+  it("sums changes across all releases", () => {
+    const releases = [
+      release("1.0.27", [change({}), change({})]),
+      release("1.0.26", [change({})]),
+    ];
+    expect(totalChangeCount(releases)).toBe(3);
+  });
+});
+
+describe("changeSummary", () => {
+  it("prefixes the scope when present", () => {
+    expect(changeSummary(change({ scope: "watch", text: "keepalive" }))).toBe(
+      "watch: keepalive",
+    );
+    expect(changeSummary(change({ scope: null, text: "plain" }))).toBe("plain");
+  });
+});

--- a/ui/src/lib/releaseNotes.ts
+++ b/ui/src/lib/releaseNotes.ts
@@ -1,0 +1,80 @@
+// Pure helpers for the About panel's "What's new" view. No React, no IO — the
+// backend (`updater::fetch_release_notes`) owns fetching + caching; this module
+// only shapes the bundle for display. Unit-tested in `releaseNotes.test.ts`.
+
+import type { ChangeItem, ReleaseNote } from "../types";
+
+export type ChangeGroupKey = "features" | "fixes" | "other";
+
+/// A change item annotated with the release it came from, so the merged view
+/// can still show "which version" in the per-version breakdown.
+export type GroupedChange = ChangeItem & { version: string };
+
+export type ChangeGroup = {
+  key: ChangeGroupKey;
+  label: string;
+  items: GroupedChange[];
+};
+
+// Conventional-commit kind → display bucket. Anything not listed (perf,
+// refactor, docs, chore, test, build, ci, style, revert, other) folds into
+// "Other" so the panel stays at three predictable sections.
+const GROUP_OF: Record<string, ChangeGroupKey> = {
+  feat: "features",
+  fix: "fixes",
+};
+
+const GROUP_ORDER: { key: ChangeGroupKey; label: string }[] = [
+  { key: "features", label: "Features" },
+  { key: "fixes", label: "Fixes" },
+  { key: "other", label: "Other" },
+];
+
+export function groupKeyForKind(kind: string): ChangeGroupKey {
+  return GROUP_OF[kind] ?? "other";
+}
+
+/// Merge every pending release's changes into Features / Fixes / Other,
+/// tagging each item with its source version. Empty groups are dropped and
+/// in-group order follows the input (newest release first).
+export function groupChanges(releases: ReleaseNote[]): ChangeGroup[] {
+  const buckets: Record<ChangeGroupKey, GroupedChange[]> = {
+    features: [],
+    fixes: [],
+    other: [],
+  };
+  for (const rel of releases) {
+    for (const change of rel.changes) {
+      buckets[groupKeyForKind(change.kind)].push({
+        ...change,
+        version: rel.version,
+      });
+    }
+  }
+  return GROUP_ORDER.map((g) => ({ ...g, items: buckets[g.key] })).filter(
+    (g) => g.items.length > 0,
+  );
+}
+
+/// Title label that collapses skipped versions into a range:
+/// one pending release → "v1.0.27"; many → "v1.0.1 – v1.0.27".
+/// `releases` is newest-first (as the backend returns it).
+export function versionRangeLabel(releases: ReleaseNote[]): string {
+  const first = releases[0];
+  const last = releases[releases.length - 1];
+  if (!first || !last) return "";
+  const newest = first.version;
+  const oldest = last.version;
+  return newest === oldest ? `v${newest}` : `v${oldest} – v${newest}`;
+}
+
+/// Total parsed change count across every pending release.
+export function totalChangeCount(releases: ReleaseNote[]): number {
+  return releases.reduce((sum, r) => sum + r.changes.length, 0);
+}
+
+/// One-line summary for an item: "<scope>: <text>" when a scope is present,
+/// else just the text. Keeps scope info even though the type prefix is dropped.
+export function changeSummary(change: ChangeItem): string {
+  return change.scope ? `${change.scope}: ${change.text}` : change.text;
+}

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -236,6 +236,27 @@ describe("toasts + notifications cap", () => {
     // Oldest 5 dropped — first remaining is index 5.
     expect(s.notifications[0]?.id).toBe("n5");
   });
+
+  it("carries a routed toast's route into both the toast and the notification log", () => {
+    const routed: Toast = {
+      id: "upd",
+      tone: "info",
+      text: "update available",
+      durationMs: 0,
+      route: { section: "about", anchor: "about-whatsnew" },
+    };
+    useAppStore.getState().pushToast(routed);
+    const s = useAppStore.getState();
+    expect(s.toasts[0]?.route).toEqual({
+      section: "about",
+      anchor: "about-whatsnew",
+    });
+    // Survives in the log so the entry stays clickable after auto-dismiss.
+    expect(s.notifications[0]?.route).toEqual({
+      section: "about",
+      anchor: "about-whatsnew",
+    });
+  });
 });
 
 describe("modals queue", () => {

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -129,6 +129,10 @@ export type Toast = {
   body?: string;
   // 0 = sticky (no auto-dismiss). Anything > 0 auto-dismisses after that many ms.
   durationMs: number;
+  // Optional deep-link: clicking the toast (or its notification-log entry)
+  // opens Settings at this target instead of the notifications panel. Used by
+  // the "update available" toast to jump straight to About → What's new.
+  route?: SettingsTarget;
 };
 
 // Persistent in-memory copy of every toast ever pushed (per session). Toasts
@@ -140,6 +144,9 @@ export type Notification = {
   text: string;
   body?: string;
   createdAt: number;
+  // Mirrors `Toast.route` so a logged notification stays clickable after its
+  // toast auto-dismisses (e.g. the update notice deep-links to About).
+  route?: SettingsTarget;
 };
 
 export const NOTIFICATION_LOG_CAP = 50;
@@ -1166,6 +1173,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         text: toast.text,
         body: toast.body,
         createdAt: Date.now(),
+        route: toast.route,
       };
       const next = [...s.notifications, note];
       // Drop oldest if over the cap so the log stays bounded.

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -81,6 +81,38 @@ export type UpdateCheckOutcome =
   | { kind: "up_to_date"; latest_version: string; html_url: string }
   | { kind: "update_available"; release: ReleaseInfo };
 
+/// One parsed bullet from a release's "What's Changed" list. Mirrors
+/// `updater::ChangeItem`. `kind` is a conventional-commit type (feat/fix/…) or
+/// "other" when the PR title isn't conventional.
+export type ChangeItem = {
+  kind: string;
+  scope: string | null;
+  text: string;
+  pr: number | null;
+  author: string | null;
+};
+
+/// One release newer than the installed build. Mirrors `updater::ReleaseNote`.
+export type ReleaseNote = {
+  version: string;
+  tag: string;
+  name: string | null;
+  published_at: string | null;
+  html_url: string;
+  changes: ChangeItem[];
+};
+
+/// Dynamic "What's new" payload for the About panel. Mirrors
+/// `updater::ReleaseNotesBundle`. `releases` is newest-first and only contains
+/// versions strictly greater than `current_version`, so an up-to-date install
+/// yields an empty list.
+export type ReleaseNotesBundle = {
+  current_version: string;
+  latest_version: string | null;
+  releases: ReleaseNote[];
+  fetched_at: number;
+};
+
 export type ContextInfo = {
   /// Stable opaque id, e.g. "default::minikube" or "<sourceUuid>::prod-1".
   /// Use this as the cluster_id for every command. The display name is `name`.


### PR DESCRIPTION
Add a dynamic "What's new" panel to Settings → About that shows every release newer than the installed build, with skipped versions merged into a single range title (e.g. "What's new in v1.0.1 – v1.0.27").

Backend (updater.rs):
- Parse GitHub "## What's Changed" bodies into structured ChangeItem {kind, scope, text, pr, author}; total parser, tolerates missing sections (older releases ship empty bodies).
- fetch_release_notes(force): GET /releases?per_page=100, keep releases strictly newer than installed, skip drafts/prereleases, newest-first.
- Disk cache (release_notes.json next to prefs.json) with a 6h TTL and ETag/If-None-Match revalidation — one download per new release, 304s cost nothing.
- Dev affordance: debug builds (version 0.1.0) preview as if installed at the second-newest tag (shows just the newest release, not all of them) and use a separate release_notes.dev.json so testing never clobbers a released install's cache.
- get_release_notes_cmd Tauri command.

Frontend:
- ReleaseNotes.tsx: merged Features/Fixes/Other grouping with PR deep links, "Show per-version" toggle, loading/empty/error states. Scrolls inside the existing overflowY:auto settings tab body.
- Notification toast deep-links to About → What's new: Toast/Notification gain an optional `route`, HeaderToast opens Settings on click instead of the notifications panel; the entry stays clickable in the log.
- Re-fetch notes when the About "Check for updates" button changes the detected version (reloadKey); single canonical check button retained.

Tests: Rust parser/filter/dev-preview; releaseNotes helper unit; api command shape; store route propagation; ReleaseNotes render + reloadKey; HeaderToast routing.

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
