### PR TITLE
fix(clipboard): paste into Monaco find widget + correct terminal copy

### DIFF
--- a/ui/src/components/Dock.tsx
+++ b/ui/src/components/Dock.tsx
@@ -38,8 +38,13 @@ import { Btn, ErrorBlock, IconBtn, Icons, Select } from "./ui";
 import { MinimizedChatPill } from "./MinimizedChatPill";
 import { api } from "../api";
 import type { DocApplyResult } from "../types";
-import { latinLetter } from "../lib/keyboard";
-import { installClipboardShortcuts } from "../lib/monacoClipboard";
+import { IS_WINDOWS, latinLetter } from "../lib/keyboard";
+import {
+  installClipboardShortcuts,
+  readClipboard,
+  writeClipboard,
+} from "../lib/monacoClipboard";
+import { normalizeTerminalSelection } from "../lib/terminalCopy";
 import {
   YAML_TEMPLATES,
   YAML_TEMPLATE_CATEGORIES,
@@ -766,6 +771,8 @@ function DockTerminal({
     let term: Terminal | null = null;
     let fit: FitAddon | null = null;
     let fitRaf = 0;
+    let copyTimer: ReturnType<typeof setTimeout> | null = null;
+    let detachContextMenu: (() => void) | null = null;
 
     // Fit pipeline (cribbed from thermic's terminal.js):
     //   1. Bail if the host isn't visible yet — fit() against a hidden
@@ -901,32 +908,44 @@ function DockTerminal({
           return true;
         });
         term.open(host);
-        // Auto-copy on selection (terminal-style UX): the moment the
-        // operator finishes a drag-select / shift-arrow extension, the
-        // selected text lands on the system clipboard. xterm fires
-        // `onSelectionChange` for every extension *and* every clear, so
-        // we coalesce onto one rAF (avoid spamming clipboard.writeText
-        // mid-drag) and skip empty strings (clears shouldn't wipe the
-        // clipboard). Paste path is unchanged — Ctrl/Cmd+V still routes
-        // through xterm's default paste handler into the PTY.
-        let copyRaf = 0;
+        // Auto-copy on selection (terminal-style UX): once the operator
+        // finishes a drag-select / shift-arrow extension, the selected text
+        // lands on the system clipboard. xterm fires `onSelectionChange` for
+        // every extension *and* every clear, so we debounce on the trailing
+        // edge: one write per settled selection. A per-frame write raced —
+        // `writeClipboard` is async (Tauri IPC), so an earlier partial
+        // selection could resolve *after* the final one and win, truncating
+        // the copy. `normalizeTerminalSelection` collapses CRLF and drops the
+        // trailing newline (the shell auto-exec footgun). Empty selections are
+        // clears — don't wipe the clipboard. Paste still routes through xterm's
+        // default Ctrl/Cmd+V handler into the PTY, plus right-click below.
         term.onSelectionChange(() => {
-          if (copyRaf) return;
-          copyRaf = requestAnimationFrame(() => {
-            copyRaf = 0;
+          if (copyTimer) clearTimeout(copyTimer);
+          copyTimer = setTimeout(() => {
+            copyTimer = null;
             const sel = termRef.current?.getSelection();
             if (!sel) return;
-            // xterm returns multi-row selections with `\r\n` between rows;
-            // some paste targets (chat apps, GitHub markdown editors, …)
-            // treat the `\r` as part of the line and render the `\n`
-            // away, so multi-line copies arrive as one blob with spaces.
-            // Normalise to plain `\n` so paste matches the visual rows.
-            const normalised = sel.replace(/\r\n?/g, "\n");
-            navigator.clipboard?.writeText(normalised).catch(() => {
-              /* permission denied / non-secure context */
-            });
-          });
+            const text = normalizeTerminalSelection(
+              sel,
+              IS_WINDOWS ? "crlf" : "lf",
+            );
+            if (!text) return;
+            void writeClipboard(text);
+          }, 80);
         });
+        // Right-click paste (PuTTY / Lens convention): pull the system
+        // clipboard via Tauri and feed it through xterm's paste path (which
+        // handles bracketed paste). preventDefault suppresses the native
+        // context menu.
+        const onContextMenu = (e: MouseEvent) => {
+          e.preventDefault();
+          void readClipboard().then((text) => {
+            if (text) termRef.current?.paste(text);
+          });
+        };
+        host.addEventListener("contextmenu", onContextMenu);
+        detachContextMenu = () =>
+          host.removeEventListener("contextmenu", onContextMenu);
         // WebGL renderer was previously loaded here for GPU-accelerated
         // compositing. Removed: addon-webgl@0.19 references
         // `Terminal._core._store` which only exists on xterm 6.x; on 5.5
@@ -1045,6 +1064,8 @@ function DockTerminal({
     return () => {
       cancelled = true;
       if (fitRaf) cancelAnimationFrame(fitRaf);
+      if (copyTimer) clearTimeout(copyTimer);
+      detachContextMenu?.();
       window.removeEventListener("resize", scheduleFit);
       ro.disconnect();
       detachChannel?.();

--- a/ui/src/lib/keyboard.ts
+++ b/ui/src/lib/keyboard.ts
@@ -12,6 +12,12 @@ export const IS_MAC = (() => {
   return /Mac|iPhone|iPad/.test(p);
 })();
 
+export const IS_WINDOWS = (() => {
+  if (typeof navigator === "undefined") return false;
+  const p = navigator.platform || navigator.userAgent || "";
+  return /Win/.test(p);
+})();
+
 export const MOD_KEY = IS_MAC ? "⌘" : "Ctrl";
 export const SHIFT_KEY = IS_MAC ? "⇧" : "Shift";
 export const ALT_KEY = IS_MAC ? "⌥" : "Alt";

--- a/ui/src/lib/monacoClipboard.test.ts
+++ b/ui/src/lib/monacoClipboard.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { applyClipboardKeyToInput } from "./monacoClipboard";
+
+function makeInput(value: string, selStart: number, selEnd: number) {
+  const el = document.createElement("textarea");
+  el.value = value;
+  document.body.appendChild(el);
+  el.setSelectionRange(selStart, selEnd);
+  return el;
+}
+
+describe("applyClipboardKeyToInput", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("paste inserts clipboard text at the caret and fires input", async () => {
+    const el = makeInput("ab", 1, 1);
+    const onInput = vi.fn();
+    el.addEventListener("input", onInput);
+    const read = vi.fn().mockResolvedValue("XY");
+    const write = vi.fn();
+
+    const acted = await applyClipboardKeyToInput(el, "paste", { read, write });
+
+    expect(acted).toBe(true);
+    expect(read).toHaveBeenCalledOnce();
+    expect(el.value).toBe("aXYb");
+    expect(onInput).toHaveBeenCalledOnce();
+  });
+
+  it("paste replaces the current selection", async () => {
+    const el = makeInput("abcd", 1, 3); // selects "bc"
+    const acted = await applyClipboardKeyToInput(el, "paste", {
+      read: vi.fn().mockResolvedValue("X"),
+      write: vi.fn(),
+    });
+    expect(acted).toBe(true);
+    expect(el.value).toBe("aXd");
+  });
+
+  it("paste is a no-op when the clipboard is empty", async () => {
+    const el = makeInput("ab", 1, 1);
+    const acted = await applyClipboardKeyToInput(el, "paste", {
+      read: vi.fn().mockResolvedValue(""),
+      write: vi.fn(),
+    });
+    expect(acted).toBe(false);
+    expect(el.value).toBe("ab");
+  });
+
+  it("copy writes the selected substring without mutating the value", async () => {
+    const el = makeInput("hello world", 0, 5); // "hello"
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const acted = await applyClipboardKeyToInput(el, "copy", {
+      read: vi.fn(),
+      write,
+    });
+
+    expect(acted).toBe(true);
+    expect(write).toHaveBeenCalledWith("hello");
+    expect(el.value).toBe("hello world");
+  });
+
+  it("cut writes the selection then removes it", async () => {
+    const el = makeInput("hello world", 0, 6); // "hello "
+    const write = vi.fn().mockResolvedValue(undefined);
+
+    const acted = await applyClipboardKeyToInput(el, "cut", {
+      read: vi.fn(),
+      write,
+    });
+
+    expect(acted).toBe(true);
+    expect(write).toHaveBeenCalledWith("hello ");
+    expect(el.value).toBe("world");
+  });
+
+  it("copy/cut are no-ops without a selection", async () => {
+    const el = makeInput("abc", 2, 2);
+    const write = vi.fn();
+    expect(
+      await applyClipboardKeyToInput(el, "copy", { read: vi.fn(), write }),
+    ).toBe(false);
+    expect(
+      await applyClipboardKeyToInput(el, "cut", { read: vi.fn(), write }),
+    ).toBe(false);
+    expect(write).not.toHaveBeenCalled();
+    expect(el.value).toBe("abc");
+  });
+});

--- a/ui/src/lib/monacoClipboard.ts
+++ b/ui/src/lib/monacoClipboard.ts
@@ -100,7 +100,7 @@ function patchSystemClipboard() {
 
 patchSystemClipboard();
 
-async function readClipboard(): Promise<string> {
+export async function readClipboard(): Promise<string> {
   try {
     const text = await tauriReadText();
     return text ?? "";
@@ -116,7 +116,7 @@ async function readClipboard(): Promise<string> {
   }
 }
 
-async function writeClipboard(text: string): Promise<boolean> {
+export async function writeClipboard(text: string): Promise<boolean> {
   try {
     await tauriWriteText(text);
     return true;
@@ -131,6 +131,47 @@ async function writeClipboard(text: string): Promise<boolean> {
     }
     return false;
   }
+}
+
+export type ClipboardIO = {
+  read: () => Promise<string>;
+  write: (text: string) => Promise<unknown>;
+};
+
+// Apply a clipboard action to a plain `<input>`/`<textarea>` (e.g. Monaco's
+// find-widget input), routing through the injected clipboard IO instead of the
+// browser's native paste — which returns empty `clipboardData` on webkit2gtk
+// when the GTK/Tauri side owns the clipboard. Returns whether it acted; the
+// caller `preventDefault()`s only on a truthy result.
+//
+// Pure + dependency-injected so it's unit-testable under jsdom without a real
+// clipboard or a live Monaco instance.
+export async function applyClipboardKeyToInput(
+  el: HTMLInputElement | HTMLTextAreaElement,
+  action: "copy" | "cut" | "paste",
+  io: ClipboardIO,
+): Promise<boolean> {
+  const start = el.selectionStart ?? 0;
+  const end = el.selectionEnd ?? 0;
+  if (action === "paste") {
+    const text = await io.read();
+    if (!text) return false;
+    // Replaces the current selection (or inserts at the caret) and moves the
+    // caret to the end of the inserted run.
+    el.setRangeText(text, start, end, "end");
+    // Let Monaco's FindInput observe the change and re-run the search.
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+    return true;
+  }
+  // copy / cut only act on a real selection — an empty Ctrl+C is a no-op so the
+  // caller leaves the event alone.
+  if (start === end) return false;
+  await io.write(el.value.slice(start, end));
+  if (action === "cut") {
+    el.setRangeText("", start, end, "end");
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+  return true;
 }
 
 export function installClipboardShortcuts(
@@ -212,5 +253,46 @@ export function installClipboardShortcuts(
         { range: sel, text, forceMoveMarkers: true },
       ]);
     },
+  });
+
+  // The `addAction` keybindings above only fire while the editor *body* has
+  // focus — they never reach Monaco's find-widget <input>. There, Ctrl+V falls
+  // back to the browser's native paste, which on webkit2gtk reads an empty
+  // `event.clipboardData` whenever the GTK/Tauri side owns the clipboard, so
+  // paste-into-Find silently no-ops (microsoft/monaco-editor#4855, which
+  // Freelens patches at the Electron `before-input-event` layer). We patch it
+  // in the renderer: a capture-phase keydown that routes Ctrl/Cmd+C/X/V for the
+  // find input through the Tauri clipboard. Scoped to this editor's DOM and
+  // torn down on dispose so multiple editors don't double-handle.
+  const onWidgetClipboardKey = (e: KeyboardEvent) => {
+    if (!(e.ctrlKey || e.metaKey) || e.altKey) return;
+    const target = e.target;
+    if (
+      !(target instanceof HTMLInputElement) &&
+      !(target instanceof HTMLTextAreaElement)
+    )
+      return;
+    const dom = editor.getDomNode();
+    if (!dom || !dom.contains(target) || !target.closest(".find-widget")) return;
+    const action =
+      e.code === "KeyV"
+        ? "paste"
+        : e.code === "KeyC"
+          ? "copy"
+          : e.code === "KeyX"
+            ? "cut"
+            : null;
+    if (!action) return;
+    // Stop the broken native path (and Monaco's own handlers) before they run.
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    void applyClipboardKeyToInput(target, action, {
+      read: readClipboard,
+      write: writeClipboard,
+    });
+  };
+  document.addEventListener("keydown", onWidgetClipboardKey, true);
+  editor.onDidDispose(() => {
+    document.removeEventListener("keydown", onWidgetClipboardKey, true);
   });
 }

--- a/ui/src/lib/terminalCopy.test.ts
+++ b/ui/src/lib/terminalCopy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTerminalSelection } from "./terminalCopy";
+
+describe("normalizeTerminalSelection", () => {
+  it("returns empty string for empty input", () => {
+    expect(normalizeTerminalSelection("")).toBe("");
+  });
+
+  it("strips a trailing newline (the shell auto-exec footgun)", () => {
+    expect(normalizeTerminalSelection("kubectl get pods\n")).toBe(
+      "kubectl get pods",
+    );
+  });
+
+  it("collapses CRLF row separators to LF", () => {
+    expect(normalizeTerminalSelection("line1\r\nline2\r\n")).toBe(
+      "line1\nline2",
+    );
+  });
+
+  it("collapses a lone CR (carriage-return redraw) to LF", () => {
+    expect(normalizeTerminalSelection("a\rb")).toBe("a\nb");
+  });
+
+  it("preserves leading indentation of the first real line", () => {
+    expect(normalizeTerminalSelection("  spec:\n    replicas: 3  ")).toBe(
+      "  spec:\n    replicas: 3",
+    );
+  });
+
+  it("drops leading blank lines but keeps internal ones", () => {
+    expect(normalizeTerminalSelection("\n\nfirst\n\nsecond\n\n")).toBe(
+      "first\n\nsecond",
+    );
+  });
+
+  it("trims trailing spaces and tabs as well as newlines", () => {
+    expect(normalizeTerminalSelection("text \t\n  \n")).toBe("text");
+  });
+
+  it("leaves already-clean multi-line text untouched", () => {
+    expect(normalizeTerminalSelection("a\nb\nc")).toBe("a\nb\nc");
+  });
+
+  it("defaults to LF line endings", () => {
+    expect(normalizeTerminalSelection("a\r\nb", "lf")).toBe("a\nb");
+  });
+
+  describe("eol: crlf (Windows)", () => {
+    it("re-emits internal newlines as CRLF after trimming the trailing one", () => {
+      expect(normalizeTerminalSelection("line1\r\nline2\r\n", "crlf")).toBe(
+        "line1\r\nline2",
+      );
+    });
+
+    it("normalises lone CR to CRLF", () => {
+      expect(normalizeTerminalSelection("a\rb", "crlf")).toBe("a\r\nb");
+    });
+
+    it("preserves internal blank lines as CRLF", () => {
+      expect(normalizeTerminalSelection("a\n\nb", "crlf")).toBe("a\r\n\r\nb");
+    });
+
+    it("single-line copy carries no line ending", () => {
+      expect(normalizeTerminalSelection("kubectl get pods\n", "crlf")).toBe(
+        "kubectl get pods",
+      );
+    });
+  });
+});

--- a/ui/src/lib/terminalCopy.ts
+++ b/ui/src/lib/terminalCopy.ts
@@ -1,0 +1,32 @@
+// Normalises an xterm `getSelection()` string before it lands on the system
+// clipboard.
+//
+// On Linux/webkit2gtk xterm v6 already returns clean text: rows joined with
+// `\n`, soft-wrapped rows merged (no spurious newline), trailing whitespace
+// trimmed per line. The two things it does NOT do — and that bite operators —
+// are platform-consistent line endings and dropping the trailing newline:
+//
+//   * Windows joins rows with `\r\n`; some paste targets render the `\n` away
+//     and collapse multi-line copies onto one line. We collapse `\r\n` (and any
+//     lone `\r` from carriage-return redraws) to a single `\n`.
+//   * A selection that reaches the end of a line carries a trailing newline.
+//     Pasted into a shell that newline auto-executes the command; pasted into
+//     an editor it leaves a stray blank line. We strip trailing whitespace and
+//     leading blank lines, but preserve the first real line's indentation
+//     (matters when copying nested YAML / code out of a `kubectl` pager).
+//
+// `eol` controls the line ending of the result. We always normalise internally
+// to LF (so trimming is uniform), then re-emit CRLF on Windows so the copy
+// matches what native Windows apps expect — caller passes `"crlf"` when
+// `IS_WINDOWS`, `"lf"` (the default) on macOS / Linux.
+export function normalizeTerminalSelection(
+  sel: string,
+  eol: "lf" | "crlf" = "lf",
+): string {
+  if (!sel) return "";
+  const lf = sel
+    .replace(/\r\n?/g, "\n")
+    .replace(/^\n+/, "")
+    .replace(/\s+$/, "");
+  return eol === "crlf" ? lf.replace(/\n/g, "\r\n") : lf;
+}


### PR DESCRIPTION
Monaco find widget (Ctrl+F):
On webkit2gtk the find-widget <input> falls back to the browser's native paste, which reads empty clipboardData whenever the GTK/Tauri side owns the clipboard, so Ctrl+V into Find silently no-ops (right-click paste worked). The existing editor.addAction bindings only fire while the editor body has focus and never reach the find input. Add a capture-phase keydown handler in installClipboardShortcuts that routes Ctrl/Cmd+C/X/V for the find input through the Tauri clipboard via the new pure applyClipboardKeyToInput helper. Scoped to the editor DOM, torn down on dispose. Same class of bug Freelens patches at Electron's before-input-event (microsoft/monaco-editor#4855).

Terminal copy:
The old sel.replace(/\r\n?/g,"\n") was a no-op on Linux (xterm v6 already joins rows with \n) and the real issues were untrimmed trailing newlines (shell auto-exec footgun) and an async write race: writeClipboard is async (Tauri IPC) and fired per rAF frame during a drag, so a stale partial selection could resolve last and win. Replace with normalizeTerminalSelection (CRLF->LF, drop trailing whitespace / leading blank lines, keep first-line indent; re-emits CRLF on Windows) and a single trailing-edge debounce so one write lands per settled selection. Add right-click paste (PuTTY/Lens convention) on all platforms.

Tests: terminalCopy.test.ts (LF + Windows CRLF cases), monacoClipboard.test.ts (applyClipboardKeyToInput copy/cut/paste).

<!--
Thanks for opening a pull request! A short description plus the checklist below
makes review faster. See CONTRIBUTING.md for the full guidance.
-->

## Summary

<!-- What does this PR do, and why? One or two sentences is usually enough. -->

## Related issues

<!-- Closes #123, refs #456. Leave blank if unrelated. -->

## Type of change

<!-- Tick the one that fits. -->

- [ ] Bug fix (non-breaking change that resolves a defect)
- [ ] Feature (non-breaking change that adds capability)
- [ ] Refactor (no functional change)
- [ ] Documentation
- [ ] Build / CI / packaging
- [ ] Other (describe below)

## How was this tested?

<!--
Describe the tests you added or ran. For UI changes, mention the cluster shape
and steps you reproduced (`make dev`, `kind` cluster, etc.). For backend, list
the affected unit / integration tests.
-->

## Screenshots / recordings (UI changes only)

<!-- Drop them here if relevant. Otherwise, delete this section. -->

## Checklist

<!-- All boxes should be ticked before review. -->

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:` …).
- [ ] `cargo fmt --all -- --check` is clean.
- [ ] `make clippy` is clean (`-D warnings`).
- [ ] `make test` passes; `make test-frontend` passes if I touched `ui/`.
- [ ] No `unwrap()` outside `#[cfg(test)]`.
- [ ] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [ ] Architectural rules from `README.md` / `CLAUDE.md` are satisfied (one reflector per `(cluster, kind)`, lazy lifecycle, `core` has no Tauri dep, SSA with `"ferrisscope"` field manager).
- [ ] If I added a Tauri command, it is registered in `main.rs` and typed in `ui/src/api.ts`.
- [ ] If I added a kind detail panel, I composed existing primitives — no fork.
- [ ] If I added an agent tool, the name follows `fs_<area>_<verb>`, `category()` is correct, and `on_chat_close` cleans up any external state.
- [ ] I am the author of these changes (or have permission), and I agree to release them under Apache-2.0.

## Notes for reviewers

<!--
Anything that would help review: trade-offs you considered, follow-ups you
deliberately deferred, areas you'd like a second opinion on.
-->
