### PR TITLE
feat(connection): silent auto-reconnect + interactive degraded table

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -14,6 +14,7 @@ import { api, onPortForwardStatus, onResourceDelta } from "./api";
 import {
   buildPrefsPayload,
   selectActiveClusterIds,
+  selectClusterDegraded,
   useActiveClusterIds,
   useAppStore,
   useResolvedTheme,
@@ -191,6 +192,23 @@ export default function App() {
 
   const selection = useAppStore((s) => s.selection);
   const clearSelection = useAppStore((s) => s.clearSelection);
+  const bulkClusterHealth = useAppStore((s) => s.clusterHealth);
+  const bulkClusterReconnecting = useAppStore((s) => s.clusterReconnecting);
+  // True when the current selection touches any degraded cluster. Mutating
+  // bulk actions disable; read actions (Copy/Compare/Observe) stay live.
+  const selectionDegraded = useMemo(
+    () =>
+      Array.from(selection.values()).some((m) =>
+        selectClusterDegraded(
+          {
+            clusterHealth: bulkClusterHealth,
+            clusterReconnecting: bulkClusterReconnecting,
+          },
+          m.clusterId,
+        ),
+      ),
+    [selection, bulkClusterHealth, bulkClusterReconnecting],
+  );
   const confirmDestructive = useAppStore((s) => s.settings.confirmDestructive);
   // Display name for a cluster id in bulk-failure prefixes. Imperative read —
   // resolved inside click handlers, so no store subscription is needed.
@@ -953,6 +971,7 @@ export default function App() {
               confirmDestructive,
               clearSelection,
               clusterLabelFor,
+              selectionDegraded,
             ),
           ]}
         />
@@ -972,6 +991,7 @@ export default function App() {
                 selection,
                 clearSelection,
                 clusterLabelFor,
+                selectionDegraded,
               ),
             ]}
           />
@@ -999,6 +1019,7 @@ export default function App() {
                 confirmDestructive,
                 clearSelection,
                 clusterLabelFor,
+                selectionDegraded,
               ),
             ]}
           />
@@ -1092,6 +1113,7 @@ function buildPodBulkActions(
   confirmDestructive: boolean,
   clearSelection: () => void,
   labelFor: (clusterId: string) => string,
+  degraded: boolean,
 ) {
   const entries = Array.from(selection.entries());
   const count = entries.length;
@@ -1139,6 +1161,7 @@ function buildPodBulkActions(
     {
       icon: Icons.refresh,
       label: "Restart",
+      disabled: degraded,
       onClick: () => {
         void (async () => {
           if (confirmDestructive) {
@@ -1225,6 +1248,7 @@ function buildPodBulkActions(
     {
       icon: Icons.trash,
       label: "Delete",
+      disabled: degraded,
       separatorBefore: true,
       danger: true,
       onClick: () => {
@@ -1256,6 +1280,7 @@ function buildNodeBulkActions(
   selection: Map<string, SelectionMeta>,
   clearSelection: () => void,
   labelFor: (clusterId: string) => string,
+  degraded: boolean,
 ) {
   const entries = Array.from(selection.entries());
   const count = entries.length;
@@ -1329,6 +1354,7 @@ function buildNodeBulkActions(
     {
       icon: Icons.eye,
       label: "Cordon",
+      disabled: degraded,
       onClick: () => {
         void (async () => {
           const ok = await confirm({
@@ -1346,6 +1372,7 @@ function buildNodeBulkActions(
     {
       icon: Icons.check,
       label: "Uncordon",
+      disabled: degraded,
       onClick: () => {
         void runForAll("Uncordon", (m) =>
           api.cordonNode(m.clusterId, m.name, false),
@@ -1355,6 +1382,7 @@ function buildNodeBulkActions(
     {
       icon: Icons.refresh,
       label: "Drain",
+      disabled: degraded,
       onClick: () => {
         void (async () => {
           const ok = await confirm({
@@ -1384,6 +1412,7 @@ function buildNodeBulkActions(
     {
       icon: Icons.trash,
       label: "Delete",
+      disabled: degraded,
       separatorBefore: true,
       danger: true,
       onClick: () => {
@@ -1421,6 +1450,7 @@ function buildGenericBulkActions(
   confirmDestructive: boolean,
   clearSelection: () => void,
   labelFor: (clusterId: string) => string,
+  degraded: boolean,
 ) {
   const entries = Array.from(selection.entries());
   const count = entries.length;
@@ -1442,6 +1472,7 @@ function buildGenericBulkActions(
     actions.push({
       icon: Icons.refresh,
       label: "Restart",
+      disabled: degraded,
       onClick: () => {
         void (async () => {
           if (confirmDestructive) {
@@ -1519,6 +1550,7 @@ function buildGenericBulkActions(
     {
       icon: Icons.trash,
       label: "Delete",
+      disabled: degraded,
       separatorBefore: true,
       danger: true,
       onClick: () => {

--- a/ui/src/components/BulkBar.test.tsx
+++ b/ui/src/components/BulkBar.test.tsx
@@ -4,8 +4,8 @@
 // dock's single-row design. We pin that every action button stays on one
 // line (whiteSpace: nowrap) and refuses to shrink (flexShrink: 0).
 
-import { describe, it, expect, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { BulkBar } from "./BulkBar";
 
 afterEach(cleanup);
@@ -28,5 +28,21 @@ describe("BulkBar", () => {
       expect(btn!.style.whiteSpace).toBe("nowrap");
       expect(btn!.style.flexShrink).toBe("0");
     }
+  });
+
+  it("renders a disabled action and swallows its click", () => {
+    const onClick = vi.fn();
+    render(
+      <BulkBar
+        mode="dark"
+        count={2}
+        onClear={() => {}}
+        actions={[{ icon: null, label: "Delete", onClick, disabled: true }]}
+      />,
+    );
+    const btn = screen.getByText("Delete").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/BulkBar.tsx
+++ b/ui/src/components/BulkBar.tsx
@@ -9,6 +9,9 @@ export type BulkAction = {
   onClick: () => void;
   danger?: boolean;
   separatorBefore?: boolean;
+  // Disabled when the selection spans a degraded cluster (unavailable / mid
+  // auto-reconnect). Read actions (Copy/Compare/Observe) leave this unset.
+  disabled?: boolean;
 };
 type Action = BulkAction;
 
@@ -95,6 +98,7 @@ export function BulkBar({ count, actions, onClear, children }: Props) {
             label={a.label}
             onClick={a.onClick}
             danger={a.danger}
+            disabled={a.disabled}
           />
         </span>
       ))}
@@ -140,17 +144,22 @@ function BulkActionButton({
   label,
   onClick,
   danger,
+  disabled = false,
 }: {
   icon: ReactNode;
   label: string;
   onClick: () => void;
   danger?: boolean;
+  disabled?: boolean;
 }) {
   const [hover, setHover] = useState(false);
+  const showHover = hover && !disabled;
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
+      title={disabled ? "Cluster unavailable — reconnect to run this" : undefined}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       style={{
@@ -163,16 +172,17 @@ function BulkActionButton({
         whiteSpace: "nowrap",
         borderRadius: R_MD,
         border: "none",
-        background: hover
+        background: showHover
           ? danger
             ? "rgba(244,63,94,0.18)"
             : "rgba(255,255,255,0.10)"
           : "transparent",
-        color: danger ? (hover ? "#fca5a5" : "#f87171") : "#ffffff",
+        color: danger ? (showHover ? "#fca5a5" : "#f87171") : "#ffffff",
         fontFamily: "inherit",
         fontSize: FS_MD,
         fontWeight: 500,
-        cursor: "pointer",
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.4 : 1,
         transition: "background .12s, color .12s",
       }}
     >

--- a/ui/src/components/ClusterPanel.test.tsx
+++ b/ui/src/components/ClusterPanel.test.tsx
@@ -1,0 +1,99 @@
+// UnavailableOverlay + ReconnectBanner: behaviour when a cluster's heartbeat
+// flips. The load-bearing regression is that the dimmed table stays
+// INTERACTIVE (no pointer-events:none) so the operator can still click a row
+// into its detail panel while disconnected — and that an active auto-reconnect
+// shows the busy progress banner instead of the terminal one.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { UnavailableOverlay, ReconnectBanner } from "./ClusterPanel";
+
+afterEach(cleanup);
+
+describe("UnavailableOverlay", () => {
+  it("keeps the table interactive (dim, but no pointer-events:none)", () => {
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable
+        reason="apiserver gone"
+        onReconnect={() => {}}
+        autoReconnect={null}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    const wrapper = screen.getByTestId("row").parentElement as HTMLElement;
+    expect(wrapper.style.opacity).toBe("0.5");
+    expect(wrapper.style.pointerEvents).not.toBe("none");
+    // Manual banner is shown when not auto-reconnecting.
+    expect(screen.getByText("Cluster unavailable")).toBeTruthy();
+  });
+
+  it("passes children straight through when healthy and not reconnecting", () => {
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable={false}
+        reason={null}
+        onReconnect={() => {}}
+        autoReconnect={null}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    // No overlay wrapper, no banner.
+    expect(screen.queryByText("Cluster unavailable")).toBeNull();
+    expect(screen.getByTestId("row")).toBeTruthy();
+  });
+
+  it("shows the busy progress banner while auto-reconnecting", () => {
+    const onReconnect = vi.fn();
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable
+        reason="timeout"
+        onReconnect={onReconnect}
+        autoReconnect={{ attempt: 2, max: 3 }}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    expect(screen.getByText("Reconnecting…")).toBeTruthy();
+    expect(screen.getByText("(2/3)")).toBeTruthy();
+    expect(screen.queryByText("Cluster unavailable")).toBeNull();
+    fireEvent.click(screen.getByText("Reconnect now"));
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ReconnectBanner", () => {
+  it("renders the plain Reconnect button by default", () => {
+    render(
+      <ReconnectBanner
+        mode="dark"
+        title="Cluster unavailable"
+        reason={null}
+        onReconnect={() => {}}
+      />,
+    );
+    expect(screen.getByText("Reconnect")).toBeTruthy();
+    expect(screen.queryByText("Reconnect now")).toBeNull();
+  });
+
+  it("renders busy progress + Reconnect now when busy", () => {
+    render(
+      <ReconnectBanner
+        mode="dark"
+        title="Reconnecting…"
+        reason={null}
+        onReconnect={() => {}}
+        busy
+        progress={{ attempt: 3, max: 3 }}
+      />,
+    );
+    expect(screen.getByText("(3/3)")).toBeTruthy();
+    expect(screen.getByText("Reconnect now")).toBeTruthy();
+  });
+});

--- a/ui/src/components/ClusterPanel.tsx
+++ b/ui/src/components/ClusterPanel.tsx
@@ -22,7 +22,8 @@ type Props = {
 // with VirtualClusterPanel, which runs one per member).
 export function ClusterPanel({ mode, context }: Props) {
   const t = useResolvedTheme().tokens;
-  const { state, cancel, reconnect } = useClusterConnection(context);
+  const { state, cancel, reconnect, autoReconnect } =
+    useClusterConnection(context);
   const selectedKind = useAppStore((s) =>
     s.kinds.find((k) => k.id === s.selectedKindId) ?? null,
   );
@@ -59,6 +60,7 @@ export function ClusterPanel({ mode, context }: Props) {
             unavailable={healthStatus === "unavailable"}
             reason={healthReason}
             onReconnect={reconnect}
+            autoReconnect={autoReconnect}
           >
             {selectedKind ? (
               <ResourceTable
@@ -76,13 +78,27 @@ export function ClusterPanel({ mode, context }: Props) {
             )}
           </UnavailableOverlay>
         ) : state.status === "error" ? (
-          <ReconnectBanner
-            mode={mode}
-            title="Could not connect to this cluster"
-            reason={state.message}
-            onReconnect={reconnect}
-            diagnoseContext={context}
-          />
+          autoReconnect ? (
+            // Hard-down mid auto-reconnect: the connect itself is failing, so
+            // there's no table to keep alive — show the silent-retry progress
+            // instead of the terminal "could not connect" banner.
+            <ReconnectBanner
+              mode={mode}
+              title="Reconnecting…"
+              reason={state.message}
+              onReconnect={reconnect}
+              busy
+              progress={autoReconnect}
+            />
+          ) : (
+            <ReconnectBanner
+              mode={mode}
+              title="Could not connect to this cluster"
+              reason={state.message}
+              onReconnect={reconnect}
+              diagnoseContext={context}
+            />
+          )
         ) : state.status === "cancelled" ? (
           <ReconnectBanner
             mode={mode}
@@ -156,6 +172,8 @@ export function ReconnectBanner({
   reason,
   onReconnect,
   diagnoseContext,
+  busy = false,
+  progress,
 }: {
   mode: ThemeMode;
   title: string;
@@ -165,6 +183,14 @@ export function ReconnectBanner({
   /// diagnostics for this context. Omitted where diagnosis makes no sense
   /// (a healthy cluster gone temporarily unavailable, a cancelled connect).
   diagnoseContext?: ContextInfo;
+  /// True while a silent auto-reconnect session is mid-retry. Switches the
+  /// dot to a pulsing animation and relabels the primary button to
+  /// "Reconnect now" (force an immediate attempt without waiting out the
+  /// backoff). The same banner shape is reused — not forked.
+  busy?: boolean;
+  /// `{attempt, max}` of the active auto-reconnect session, rendered as a
+  /// "(2/3)" suffix next to the title when `busy`.
+  progress?: { attempt: number; max: number };
 }) {
   const t = useResolvedTheme().tokens;
   const [showDiag, setShowDiag] = useState(false);
@@ -183,6 +209,7 @@ export function ReconnectBanner({
     >
       <span
         aria-hidden
+        className={busy ? "fs-pulse-dot" : undefined}
         style={{
           display: "inline-block",
           width: 8,
@@ -195,6 +222,11 @@ export function ReconnectBanner({
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ color: t.text, fontSize: FS_MD, fontWeight: 600 }}>
           {title}
+          {busy && progress && (
+            <span style={{ marginLeft: 6, color: t.textDim, fontWeight: 400 }}>
+              ({progress.attempt}/{progress.max})
+            </span>
+          )}
         </div>
         {reason && (
           <div style={{ marginTop: 2 }} title={reason}>
@@ -218,7 +250,7 @@ export function ReconnectBanner({
         </Btn>
       )}
       <Btn t={t} variant="primary" size="sm" onClick={onReconnect}>
-        Reconnect
+        {busy ? "Reconnect now" : "Reconnect"}
       </Btn>
       {diagnoseContext && showDiag && (
         <ConnectionDiagnosticsModal
@@ -233,24 +265,34 @@ export function ReconnectBanner({
 }
 
 // Renders the resource table with a `ReconnectBanner` on top when the
-// cluster's heartbeat probe has flipped to unavailable. Last-known rows
-// stay rendered (dimmed) so the operator's in-flight inspection isn't
-// jarringly cleared — but data is stale and any new subscribe call
-// returns an "unavailable" error from the backend until Reconnect lands.
-function UnavailableOverlay({
+// cluster's heartbeat probe has flipped to unavailable (or while we're
+// silently auto-reconnecting). Last-known rows stay rendered (dimmed) so the
+// operator's in-flight inspection isn't jarringly cleared — data is stale, but
+// the table stays *interactive* on purpose: clicking a row opens its detail
+// (cached row + a best-effort live fetch) and cross-kind navigation still
+// works. Write affordances self-gate to read-only via `selectClusterDegraded`
+// (see store.ts) — so we deliberately do NOT kill pointer events here.
+export function UnavailableOverlay({
   mode,
   unavailable,
   reason,
   onReconnect,
+  autoReconnect,
   children,
 }: {
   mode: ThemeMode;
   unavailable: boolean;
   reason: string | null;
   onReconnect: () => void;
+  /// Non-null while a silent auto-reconnect session is retrying — swaps the
+  /// terminal "Cluster unavailable" banner for the busy progress variant.
+  autoReconnect: { attempt: number; max: number } | null;
   children: ReactNode;
 }) {
-  if (!unavailable) return <>{children}</>;
+  // Show the overlay through the whole session: a wedged cluster's retry may
+  // momentarily reconnect (health reads healthy) between attempts, but we keep
+  // the dim + busy banner until the session ends so the UI doesn't flicker.
+  if (!unavailable && !autoReconnect) return <>{children}</>;
   return (
     <div
       style={{
@@ -261,21 +303,34 @@ function UnavailableOverlay({
         minHeight: 0,
       }}
     >
-      <ReconnectBanner
-        mode={mode}
-        title="Cluster unavailable"
-        reason={
-          reason ??
-          "No response from the apiserver for 30s. Watchers and metrics have been torn down."
-        }
-        onReconnect={onReconnect}
-      />
+      {autoReconnect ? (
+        <ReconnectBanner
+          mode={mode}
+          title="Reconnecting…"
+          reason={
+            reason ??
+            "Lost contact with the apiserver. Retrying with a fresh connection."
+          }
+          onReconnect={onReconnect}
+          busy
+          progress={autoReconnect}
+        />
+      ) : (
+        <ReconnectBanner
+          mode={mode}
+          title="Cluster unavailable"
+          reason={
+            reason ??
+            "No response from the apiserver for 30s. Watchers and metrics have been torn down."
+          }
+          onReconnect={onReconnect}
+        />
+      )}
       <div
         style={{
           flex: 1,
           minHeight: 0,
           opacity: 0.5,
-          pointerEvents: "none",
         }}
       >
         {children}

--- a/ui/src/components/DetailPanel.tsx
+++ b/ui/src/components/DetailPanel.tsx
@@ -2,7 +2,7 @@ import { logErr } from "../lib/log";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api, onResourceDelta } from "../api";
 import { parseYaml, stripYaml, type Json } from "../lib/yamlEdit";
-import { useAppStore, useResolvedTheme } from "../store";
+import { selectClusterDegraded, useAppStore, useResolvedTheme } from "../store";
 import type {
   ContainerDetail,
   ContainerLastState,
@@ -392,6 +392,10 @@ export function DetailPanel({
   const detailBack = useAppStore((s) => s.detailBack);
   const detailForward = useAppStore((s) => s.detailForward);
   const confirmDestructive = useAppStore((s) => s.settings.confirmDestructive);
+  // Cluster can't take writes (unavailable / mid auto-reconnect). Disables
+  // every mutating action + exec/forward in the title bar and forces the YAML
+  // tab read-only, while reads/navigation/copy stay live.
+  const degraded = useAppStore((s) => selectClusterDegraded(s, clusterId));
   const canBack = detailIndex > 0;
   const canForward = detailIndex >= 0 && detailIndex < detailHistory.length - 1;
   const prevEntry = canBack ? detailHistory[detailIndex - 1] : null;
@@ -897,7 +901,7 @@ export function DetailPanel({
                       ? `Open shell (${podContainers[0]})`
                       : "Open shell…"
                 }
-                disabled={podContainers.length === 0 || !onOpenExec}
+                disabled={podContainers.length === 0 || !onOpenExec || degraded}
                 active={actionMenu?.kind === "shell"}
                 onClick={() => {
                   if (!onOpenExec) return;
@@ -915,7 +919,7 @@ export function DetailPanel({
                 t={t}
                 size="lg"
                 title="Rollout restart owner workload"
-                disabled={restarting || !target.namespace}
+                disabled={restarting || !target.namespace || degraded}
                 onClick={runRestart}
               >
                 {Icons.refresh}
@@ -926,7 +930,7 @@ export function DetailPanel({
                 size="lg"
                 title="Delete…"
                 danger
-                disabled={deleting}
+                disabled={deleting || degraded}
                 active={actionMenu?.kind === "delete"}
                 onClick={() =>
                   openActionMenu("delete", deleteBtnRef.current)
@@ -963,7 +967,7 @@ export function DetailPanel({
                 t={t}
                 size="lg"
                 title={`Open shell on node (kubectl debug node/${target.name})`}
-                disabled={!onOpenExec}
+                disabled={!onOpenExec || degraded}
                 onClick={() => onOpenExec?.(null)}
               >
                 {Icons.shell}
@@ -977,7 +981,7 @@ export function DetailPanel({
                     ? "Uncordon node — re-enable scheduling"
                     : "Cordon node — block new scheduling"
                 }
-                disabled={cordoning}
+                disabled={cordoning || degraded}
                 onClick={runCordon}
               >
                 {nodeCordoned ? Icons.nodeUncordon : Icons.nodeCordon}
@@ -987,7 +991,7 @@ export function DetailPanel({
                 t={t}
                 size="lg"
                 title="Drain node — cordon and evict pods"
-                disabled={draining}
+                disabled={draining || degraded}
                 onClick={runDrain}
               >
                 {Icons.nodeDrain}
@@ -998,7 +1002,7 @@ export function DetailPanel({
                 size="lg"
                 title="Delete…"
                 danger
-                disabled={deleting}
+                disabled={deleting || degraded}
                 active={actionMenu?.kind === "delete"}
                 onClick={() =>
                   openActionMenu("delete", deleteBtnRef.current)
@@ -1039,7 +1043,7 @@ export function DetailPanel({
                   t={t}
                   size="lg"
                   title={`Rollout restart ${kind.kind.toLowerCase()}`}
-                  disabled={restarting || !target.namespace}
+                  disabled={restarting || !target.namespace || degraded}
                   onClick={runRestartWorkload}
                 >
                   {Icons.refresh}
@@ -1050,6 +1054,7 @@ export function DetailPanel({
                   t={t}
                   clusterId={clusterId}
                   namespace={target.name}
+                  disabled={degraded}
                 />
               )}
               <IconBtn
@@ -1058,7 +1063,7 @@ export function DetailPanel({
                 size="lg"
                 title="Delete…"
                 danger
-                disabled={deleting}
+                disabled={deleting || degraded}
                 active={actionMenu?.kind === "delete"}
                 onClick={() =>
                   openActionMenu("delete", deleteBtnRef.current)
@@ -1226,6 +1231,7 @@ export function DetailPanel({
                 kindLabel={kind.kind.toLowerCase()}
                 namespace={target.namespace}
                 name={target.name}
+                readOnly={degraded}
                 buffer={yamlBuffer}
                 setBuffer={setYamlBuffer}
                 saving={yamlSaving}

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -23,7 +23,7 @@ import {
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { api, onResourceDelta } from "../api";
-import { useAppStore, useResolvedTheme } from "../store";
+import { selectClusterDegraded, useAppStore, useResolvedTheme } from "../store";
 import { formatQuantity } from "./detail";
 import type {
   ColumnDef,
@@ -283,6 +283,7 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
   // via ClusterPanel's UnavailableOverlay instead). Record identity only
   // changes on health transitions, so this subscription is near-free.
   const clusterHealth = useAppStore((s) => s.clusterHealth);
+  const clusterReconnecting = useAppStore((s) => s.clusterReconnecting);
   const confirmDestructive = useAppStore((s) => s.settings.confirmDestructive);
   const density = useAppStore((s) => s.settings.density);
   const monoTables = useAppStore((s) => s.settings.monoTables);
@@ -1702,6 +1703,12 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
                 },
               },
             ),
+            {
+              readOnly: selectClusterDegraded(
+                { clusterHealth, clusterReconnecting },
+                menu.row.__clusterId,
+              ),
+            },
           )}
         />
       )}

--- a/ui/src/components/VirtualClusterPanel.test.tsx
+++ b/ui/src/components/VirtualClusterPanel.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { render, cleanup, act, screen, fireEvent } from "@testing-library/react";
 import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
-import { resetEventMock } from "../test/tauri-event-mock";
+import { resetEventMock, emitMock } from "../test/tauri-event-mock";
 import { useAppStore } from "../store";
 import { VirtualClusterPanel } from "./VirtualClusterPanel";
 import type { ContextInfo } from "../types";
@@ -111,6 +111,47 @@ describe("VirtualClusterPanel", () => {
     expect(screen.getByText("prod-us: could not connect")).toBeTruthy();
     expect(screen.getByText("Reconnect")).toBeTruthy();
     // The healthy member still drives the main pane (no kind → hint).
+    expect(screen.getByText("Pick a resource kind")).toBeTruthy();
+  });
+
+  it("a member mid auto-reconnect shows a busy strip, not the failed one", async () => {
+    setMockInvoke((cmd) => {
+      switch (cmd) {
+        case "connect_context":
+          return { server_version: "1.30", node_count: 1 };
+        case "subscribe_resource":
+          return { rows: [], init_done: true };
+        default:
+          return undefined;
+      }
+    });
+    await act(async () => {
+      render(
+        <VirtualClusterPanel
+          mode="dark"
+          title="prod fleet"
+          viewScopeId="vctx:t1"
+          contexts={MEMBERS}
+        />,
+      );
+    });
+    await act(async () => {});
+
+    // The health probe declares prod-us unavailable. The hook arms an
+    // auto-reconnect session synchronously (autoReconnect is set before the
+    // backoff timer fires), so the busy strip renders immediately.
+    act(() => {
+      emitMock("cluster-health://default::prod-us", {
+        status: "unavailable",
+        reason: "timeout",
+      });
+    });
+
+    expect(screen.getByText("prod-us: reconnecting…")).toBeTruthy();
+    expect(screen.getByText("(1/10)")).toBeTruthy();
+    expect(screen.getByText("Reconnect now")).toBeTruthy();
+    // Not the terminal banner — and the healthy member still drives the pane.
+    expect(screen.queryByText("prod-us: unavailable")).toBeNull();
     expect(screen.getByText("Pick a resource kind")).toBeTruthy();
   });
 

--- a/ui/src/components/VirtualClusterPanel.tsx
+++ b/ui/src/components/VirtualClusterPanel.tsx
@@ -21,6 +21,7 @@ type MemberConn = {
   state: ConnectState;
   cancel: () => void;
   reconnect: () => void;
+  autoReconnect: { attempt: number; max: number } | null;
 };
 
 type Props = {
@@ -46,13 +47,14 @@ function MemberConnection({
   context: ContextInfo;
   onUpdate: (id: string, conn: MemberConn) => void;
 }) {
-  const { state, cancel, reconnect } = useClusterConnection(context);
+  const { state, cancel, reconnect, autoReconnect } =
+    useClusterConnection(context);
   useEffect(() => {
-    onUpdate(context.id, { state, cancel, reconnect });
-    // cancel/reconnect are fresh closures each render; state identity is
-    // what actually drives meaningful updates.
+    onUpdate(context.id, { state, cancel, reconnect, autoReconnect });
+    // cancel/reconnect are fresh closures each render; state identity +
+    // autoReconnect identity are what drive meaningful updates.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [context.id, state, onUpdate]);
+  }, [context.id, state, autoReconnect, onUpdate]);
   return null;
 }
 
@@ -107,12 +109,19 @@ export function VirtualClusterPanel({ mode, title, viewScopeId, contexts }: Prop
     [contexts, conns, colorIdx],
   );
 
+  // Members mid silent auto-reconnect. Takes precedence over failed/unavailable
+  // so a member shows exactly one strip (the busy one) while retrying — it can
+  // be in `error` (hard-down) or `ok`+unavailable (wedged) underneath.
+  const reconnecting = contexts.filter((c) => conns[c.id]?.autoReconnect != null);
+  const reconnectingIds = new Set(reconnecting.map((c) => c.id));
   const failed = contexts.filter((c) => {
+    if (reconnectingIds.has(c.id)) return false;
     const st = conns[c.id]?.state.status;
     return st === "error" || st === "cancelled";
   });
   const unavailable = contexts.filter(
     (c) =>
+      !reconnectingIds.has(c.id) &&
       conns[c.id]?.state.status === "ok" &&
       clusterHealth[c.id] === "unavailable",
   );
@@ -141,6 +150,25 @@ export function VirtualClusterPanel({ mode, title, viewScopeId, contexts }: Prop
         conns={conns}
         colorIdx={colorIdx}
       />
+
+      {/* Per-member silent auto-reconnect strips, shown first (precedence over
+          failed/unavailable). "Reconnect now" forces an immediate attempt. */}
+      {reconnecting.map((c) => (
+        <ReconnectBanner
+          key={c.id}
+          mode={mode}
+          title={`${c.name}: reconnecting…`}
+          reason={
+            clusterHealthReason[c.id] ??
+            (conns[c.id]?.state.status === "error"
+              ? (conns[c.id]?.state as { message: string }).message
+              : "Lost contact with the apiserver. Retrying with a fresh connection.")
+          }
+          onReconnect={() => conns[c.id]?.reconnect()}
+          busy
+          progress={conns[c.id]?.autoReconnect ?? undefined}
+        />
+      ))}
 
       {/* Per-member failure strips. One row per broken member with its own
           Reconnect; the table below keeps rendering the healthy members. */}
@@ -312,6 +340,11 @@ function VirtualClusterBar({
   };
 
   const stateDot = (c: ContextInfo): { color: string; label: string } => {
+    // Auto-reconnecting wins over the underlying error/unavailable state so the
+    // dot matches the single "reconnecting…" strip the operator sees.
+    if (conns[c.id]?.autoReconnect != null) {
+      return { color: t.warn, label: "reconnecting" };
+    }
     const st = conns[c.id]?.state.status;
     if (st === "ok") {
       return clusterHealth[c.id] === "unavailable"

--- a/ui/src/components/detail/YamlTab.test.tsx
+++ b/ui/src/components/detail/YamlTab.test.tsx
@@ -52,11 +52,13 @@ function Host({
   serverYaml = BASE_YAML,
   serverRv = "42",
   refreshedAt = 1000,
+  readOnly = false,
 }: {
   onResync?: () => void;
   serverYaml?: string;
   serverRv?: string;
   refreshedAt?: number;
+  readOnly?: boolean;
 }) {
   const [buffer, setBuffer] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -88,6 +90,7 @@ function Host({
         setBuffer(null);
         onResync();
       }}
+      readOnly={readOnly}
     />
   );
 }
@@ -104,6 +107,20 @@ describe("YamlTab", () => {
     // Save is present but inert until something changes.
     const save = screen.getByRole("button", { name: /^save$/i });
     expect(save).toBeDisabled();
+  });
+
+  it("readOnly (degraded cluster) forces the editor read-only and disables Save", () => {
+    render(<Host readOnly />);
+    const editor = screen.getByTestId("editor") as HTMLTextAreaElement;
+    expect(editor.readOnly).toBe(true);
+
+    // The draft is still kept if the operator already typed, but Save never
+    // enables and the status line explains why.
+    fireEvent.change(editor, { target: { value: EDITED_YAML } });
+    expect(
+      screen.getByText(/read-only · cluster unavailable/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
   });
 
   it("Save ships the merge patch + resourceVersion once the doc diverges", async () => {

--- a/ui/src/components/detail/YamlTab.tsx
+++ b/ui/src/components/detail/YamlTab.tsx
@@ -66,6 +66,11 @@ type Props = {
   // Clear local draft/stale/error and refetch the live object. Used after a
   // successful save and on an explicit Reload.
   onResync: () => void;
+  // True when the cluster is unavailable / mid auto-reconnect. Forces the
+  // editor read-only and blocks Save + Apply-anyway (the draft is preserved so
+  // it can be saved once reconnected). Viewing, Discard, and the server-fields
+  // toggle stay live.
+  readOnly?: boolean;
 };
 
 export function YamlTab({
@@ -90,6 +95,7 @@ export function YamlTab({
   error,
   setError,
   onResync,
+  readOnly = false,
 }: Props) {
   const monoFont = useResolvedTheme().typography.fontMono;
 
@@ -136,7 +142,7 @@ export function YamlTab({
 
   const editable = baseline.original != null;
   const dirty = buffer !== null && !diff.empty && !diff.parseError;
-  const canSave = editable && dirty && !saving && !showRaw;
+  const canSave = editable && dirty && !saving && !showRaw && !readOnly;
 
   const save = async (ignoreVersion: boolean) => {
     if (baseline.original == null) {
@@ -196,6 +202,11 @@ export function YamlTab({
   let statusTone: "muted" | "accent" | "bad" = "muted";
   if (showRaw) {
     statusText = "read-only · all server fields shown";
+  } else if (readOnly) {
+    statusText = dirty
+      ? "read-only · cluster unavailable · changes kept"
+      : "read-only · cluster unavailable";
+    statusTone = "bad";
   } else if (!editable) {
     statusText = "read-only · server YAML could not be parsed";
     statusTone = "bad";
@@ -350,6 +361,7 @@ export function YamlTab({
             t={t}
             message={stale.message}
             saving={saving}
+            applyDisabled={readOnly}
             onReload={reload}
             onApplyAnyway={() => save(true)}
           />
@@ -363,12 +375,12 @@ export function YamlTab({
           theme={mode === "dark" ? "vs-dark" : "light"}
           value={value}
           onChange={(next) => {
-            if (showRaw || saving) return;
+            if (showRaw || saving || readOnly) return;
             setBuffer(next ?? "");
           }}
           onMount={installClipboardShortcuts}
           options={{
-            readOnly: showRaw || saving || !editable,
+            readOnly: showRaw || saving || !editable || readOnly,
             minimap: { enabled: false },
             fontSize: 12.5,
             fontFamily: monoFont,
@@ -392,12 +404,16 @@ function StaleBanner({
   t,
   message,
   saving,
+  applyDisabled = false,
   onReload,
   onApplyAnyway,
 }: {
   t: Tokens;
   message: string;
   saving: boolean;
+  // Blocks "Apply my changes anyway" when the cluster is degraded (it's a
+  // write). Reload stays enabled — it's a read that refetches the live object.
+  applyDisabled?: boolean;
   onReload: () => void;
   onApplyAnyway: () => void;
 }) {
@@ -444,9 +460,9 @@ function StaleBanner({
         <button
           type="button"
           onClick={onApplyAnyway}
-          disabled={saving}
+          disabled={saving || applyDisabled}
           style={{
-            ...chipBtnStyle(t, "ghost", saving),
+            ...chipBtnStyle(t, "ghost", saving || applyDisabled),
             background: "rgba(244,63,94,0.16)",
             color: t.bad,
           }}

--- a/ui/src/components/detail/edit.tsx
+++ b/ui/src/components/detail/edit.tsx
@@ -18,6 +18,7 @@ import {
   type ReactNode,
 } from "react";
 import { FF_MONO, type Tokens, R_SM, FS_MD, FS_SM } from "../../theme";
+import { useEditSession } from "./editSession";
 import { Icons } from "../ui";
 
 export type ApplyTarget = {
@@ -58,6 +59,10 @@ export function EditModeChrome({
   // Optional content rendered before the edit controls (e.g. "5 total").
   rightExtra?: ReactNode;
 }) {
+  // Pencil self-disables when the cluster can't take writes. Reads the session
+  // directly so no editor has to thread the flag through; degrades to enabled
+  // when rendered outside a provider (session is null).
+  const readOnly = useEditSession()?.readOnly ?? false;
   if (!editing) {
     return (
       <span
@@ -85,10 +90,12 @@ export function EditModeChrome({
         <button
           type="button"
           onClick={onEnter}
-          title="Edit"
+          disabled={readOnly}
+          title={readOnly ? "Cluster unavailable — reconnect to edit" : "Edit"}
           style={{
             ...iconBtnStyle(t),
-            color: t.textDim,
+            color: readOnly ? t.textMuted : t.textDim,
+            cursor: readOnly ? "not-allowed" : "pointer",
           }}
         >
           {Icons.pencil}

--- a/ui/src/components/detail/editSession.readonly.test.tsx
+++ b/ui/src/components/detail/editSession.readonly.test.tsx
@@ -1,0 +1,131 @@
+// Read-only gating: when the cluster is unavailable / mid auto-reconnect, the
+// edit session must (a) refuse to open a pencil, (b) disable the global Save,
+// and (c) hard-stop saveAll even if a row was already dirty when health
+// flipped — so no doomed SSA apply is fired at a dead apiserver.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+import {
+  EditSessionProvider,
+  useEditField,
+  useEditSession,
+} from "./editSession";
+import { GlobalSaveBar } from "./globalSaveBar";
+import type { ApplyTarget } from "./edit";
+import { tokens } from "../../theme";
+import { useAppStore } from "../../store";
+import { setMockInvoke, resetMockInvoke } from "../../test/tauri-mock";
+
+const t = tokens("dark");
+const TARGET: ApplyTarget = {
+  clusterId: "ctx",
+  kindId: "configmaps",
+  namespace: "default",
+  name: "hello",
+};
+
+const storeInitial = useAppStore.getState();
+
+beforeEach(() => {
+  resetMockInvoke();
+  useAppStore.setState({
+    ...storeInitial,
+    clusterHealth: {},
+    clusterHealthReason: {},
+    clusterReconnecting: {},
+  });
+});
+
+function setDegraded(value: boolean) {
+  act(() => {
+    useAppStore
+      .getState()
+      .applyClusterHealth("ctx", value ? "unavailable" : "healthy", null);
+  });
+}
+
+function Editor() {
+  const field = useEditField<{ value: string }>({
+    id: "e1",
+    initial: () => ({ value: "" }),
+    serialize: (b) => ({ data: { k: b.value } }),
+    dirtyCount: (b) => (b.value === "" ? 0 : 1),
+  });
+  return (
+    <div>
+      <span data-testid="editing">{String(field.editing)}</span>
+      <span data-testid="dirty">{field.dirty}</span>
+      <span data-testid="readonly">{String(field.readOnly)}</span>
+      <button data-testid="enter" onClick={field.enter} />
+      <button
+        data-testid="set"
+        onClick={() => field.setBuffer({ value: "new" })}
+      />
+    </div>
+  );
+}
+
+// Exposes the session-level saveAll so a test can call it directly (the
+// GlobalSaveBar button is disabled when degraded, so we can't reach saveAll
+// through it — this proves the internal guard, not just the UI gate).
+function DirectSave() {
+  const session = useEditSession();
+  return (
+    <button data-testid="direct-save" onClick={() => void session?.saveAll()} />
+  );
+}
+
+function renderPanel() {
+  return render(
+    <EditSessionProvider target={TARGET} onSaved={() => {}}>
+      <Editor />
+      <DirectSave />
+      <GlobalSaveBar t={t} />
+    </EditSessionProvider>,
+  );
+}
+
+describe("edit session read-only gating", () => {
+  it("pencil enter() no-ops while the cluster is degraded", () => {
+    setDegraded(true);
+    const { getByTestId } = renderPanel();
+    expect(getByTestId("readonly").textContent).toBe("true");
+    fireEvent.click(getByTestId("enter"));
+    expect(getByTestId("editing").textContent).toBe("false");
+  });
+
+  it("disables Save and shows the unavailable note when health flips mid-edit", () => {
+    const { getByTestId, container } = renderPanel();
+    // Dirty the row while healthy.
+    fireEvent.click(getByTestId("enter"));
+    fireEvent.click(getByTestId("set"));
+    expect(getByTestId("dirty").textContent).toBe("1");
+
+    // Cluster goes unavailable — the bar must disable Save and explain why.
+    setDegraded(true);
+    const save = Array.from(container.querySelectorAll("button")).find((b) =>
+      /Save \(\d+\)/.test(b.textContent ?? ""),
+    ) as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    expect(container.textContent ?? "").toMatch(/Cluster unavailable/);
+  });
+
+  it("saveAll hard-stops while degraded — no apply_resource_cmd fires", async () => {
+    const invokeSpy = vi.fn(() => ({ kind: "applied", resource_version: "1" }));
+    setMockInvoke(invokeSpy);
+    const { getByTestId, container } = renderPanel();
+
+    fireEvent.click(getByTestId("enter"));
+    fireEvent.click(getByTestId("set"));
+    setDegraded(true);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("direct-save"));
+    });
+
+    expect(invokeSpy).not.toHaveBeenCalled();
+    expect(container.textContent ?? "").toMatch(
+      /Cluster unavailable — reconnect to save/,
+    );
+  });
+});

--- a/ui/src/components/detail/editSession.tsx
+++ b/ui/src/components/detail/editSession.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import type { ReactNode } from "react";
 import { api } from "../../api";
+import { selectClusterDegraded, useAppStore } from "../../store";
 import type { ApplyResult } from "../../types";
 import type { ApplyTarget } from "./edit";
 
@@ -50,6 +51,11 @@ type EditingMap = Record<string, boolean>;
 
 type SessionApi = {
   target: ApplyTarget;
+  // True when the cluster is unavailable / mid auto-reconnect. Editors keep
+  // rendering their *current* values (read-only) but pencils won't open and
+  // the global Save is blocked — a doomed SSA against a dead apiserver helps
+  // no one. Cleared automatically when the cluster reconnects.
+  readOnly: boolean;
   // Editor-side: register callbacks (mount/unmount). Returns unregister.
   register(id: string, field: RegisteredField): () => void;
   // Editor-side: tell the session whether this field is currently dirty.
@@ -100,6 +106,14 @@ export function EditSessionProvider({
     }),
     [targetProp.clusterId, targetProp.kindId, targetProp.namespace, targetProp.name],
   );
+
+  // Read-only when the cluster can't take writes (unavailable / mid
+  // auto-reconnect). Reactive so editors collapse their pencils the moment the
+  // health probe flips. Mirrored into a ref so `saveAll` can bail without
+  // taking `readOnly` as a dependency (which would churn its identity).
+  const readOnly = useAppStore((s) => selectClusterDegraded(s, target.clusterId));
+  const readOnlyRef = useRef(readOnly);
+  readOnlyRef.current = readOnly;
 
   // Mutable callback registry — editors stash fresh closures here every
   // render so the session always sees the latest serialize / reset /
@@ -175,6 +189,18 @@ export function EditSessionProvider({
 
   const saveAll = useCallback(
     async (force = false) => {
+      // Hard stop if the cluster went unavailable while a row was mid-edit.
+      // The buffer is kept (operator can save once reconnected); we just don't
+      // fire the doomed apply. GlobalSaveBar also disables Save, but a row can
+      // already be dirty when health flips, so guard here too.
+      if (readOnlyRef.current) {
+        setState({
+          saving: false,
+          conflict: null,
+          error: "Cluster unavailable — reconnect to save.",
+        });
+        return;
+      }
       const dirtyIds = Object.entries(dirtyMapRef.current)
         .filter(([, v]) => v)
         .map(([k]) => k);
@@ -264,6 +290,7 @@ export function EditSessionProvider({
   const value = useMemo<SessionApi>(
     () => ({
       target,
+      readOnly,
       register,
       setDirty,
       dirty,
@@ -278,6 +305,7 @@ export function EditSessionProvider({
     }),
     [
       target,
+      readOnly,
       register,
       setDirty,
       dirty,
@@ -352,7 +380,9 @@ export function useEditField<B>(opts: {
   const editing = session?.isEditing(opts.id) ?? false;
 
   const enter = useCallback(() => {
-    if (!session) return;
+    // Don't open the editor for a degraded cluster — the operator would type
+    // into a field they can't save. The pencil renders disabled (see below).
+    if (!session || session.readOnly) return;
     setBuffer(initialRef.current());
     session.setEditing(opts.id, true);
   }, [session, opts.id]);
@@ -375,6 +405,9 @@ export function useEditField<B>(opts: {
     saving: session?.saving ?? false,
     conflict: session?.conflict ?? null,
     error: session?.error ?? null,
+    // True when the cluster can't take writes. `enter` already no-ops; editors
+    // pass this to EditModeChrome so the pencil renders disabled with a hint.
+    readOnly: session?.readOnly ?? false,
   };
 }
 

--- a/ui/src/components/detail/globalSaveBar.tsx
+++ b/ui/src/components/detail/globalSaveBar.tsx
@@ -15,7 +15,8 @@ import { useEditSession } from "./editSession";
 export function GlobalSaveBar({ t }: { t: Tokens }) {
   const session = useEditSession();
   if (!session) return null;
-  const { dirty, saving, conflict, error, saveAll, cancelAll } = session;
+  const { dirty, saving, conflict, error, saveAll, cancelAll, readOnly } =
+    session;
   if (dirty === 0 && !conflict && !error) return null;
   return (
     <div
@@ -49,11 +50,13 @@ export function GlobalSaveBar({ t }: { t: Tokens }) {
             color: t.textDim,
           }}
         >
-          {dirty > 0
-            ? `${dirty} pending change${dirty === 1 ? "" : "s"}`
-            : conflict
-              ? "Save conflicted"
-              : "Save failed"}
+          {readOnly
+            ? "Cluster unavailable — reconnect to save"
+            : dirty > 0
+              ? `${dirty} pending change${dirty === 1 ? "" : "s"}`
+              : conflict
+                ? "Save conflicted"
+                : "Save failed"}
         </span>
         <span style={{ flex: 1 }} />
         <Btn
@@ -71,7 +74,7 @@ export function GlobalSaveBar({ t }: { t: Tokens }) {
             variant="primary"
             size="sm"
             onClick={() => saveAll(true)}
-            disabled={saving}
+            disabled={saving || readOnly}
             kbd="Force"
           >
             Force takeover
@@ -82,7 +85,7 @@ export function GlobalSaveBar({ t }: { t: Tokens }) {
             variant="primary"
             size="sm"
             onClick={() => saveAll(false)}
-            disabled={saving || dirty === 0}
+            disabled={saving || dirty === 0 || readOnly}
             kbd={saving ? "…" : "↵"}
           >
             Save ({dirty})

--- a/ui/src/components/detail/helm/chart.tsx
+++ b/ui/src/components/detail/helm/chart.tsx
@@ -14,7 +14,11 @@
 // dispatch so we can recover both halves here.
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useResolvedTheme } from "../../../store";
+import {
+  selectClusterDegraded,
+  useAppStore,
+  useResolvedTheme,
+} from "../../../store";
 import Editor from "@monaco-editor/react";
 import { api } from "../../../api";
 import { FF_MONO, type ThemeMode, type Tokens, R_MD, FS_MD, FS_SM, FS_XS } from "../../../theme";
@@ -185,8 +189,14 @@ export function HelmChartSummary(props: {
     return <ErrorBlock t={t} message={state.message} kindLabel="helm chart" />;
 
   const d = state.detail;
+  // Cluster degraded (unavailable / mid auto-reconnect): block install (a
+  // doomed helm write) while leaving the chart browseable.
+  const degraded = useAppStore((s) =>
+    selectClusterDegraded(s, props.clusterId),
+  );
   const canInstall =
     d.helm_available &&
+    !degraded &&
     namespace.trim().length > 0 &&
     releaseName.trim().length > 0 &&
     installStatus.kind !== "saving";
@@ -455,7 +465,9 @@ export function HelmChartSummary(props: {
           value={valuesBuffer}
           onChange={setValuesBuffer}
           height={360}
-          disabled={!d.helm_available || installStatus.kind === "saving"}
+          disabled={
+            !d.helm_available || installStatus.kind === "saving" || degraded
+          }
         />
       </div>
 

--- a/ui/src/components/detail/helm/index.tsx
+++ b/ui/src/components/detail/helm/index.tsx
@@ -10,7 +10,7 @@
 // out of scope for this app for now.
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { useResolvedTheme } from "../../../store";
+import { selectClusterDegraded, useAppStore, useResolvedTheme } from "../../../store";
 import Editor from "@monaco-editor/react";
 import { api } from "../../../api";
 import { FF_MONO, type ThemeMode, type Tokens, R_MD, FS_MD, FS_SM, FS_XS } from "../../../theme";
@@ -395,7 +395,10 @@ function HelmReleaseView({
   // text. Operators don't need precise diffs here; non-zero is enough
   // for the Save chip's "(N)" badge.
   const dirty = editing ? approxLineDiff(userText, buffer!) : 0;
-  const canEdit = d.helm_available;
+  // Cluster degraded (unavailable / mid auto-reconnect): block upgrades (a
+  // doomed helm write) while leaving the release detail fully readable.
+  const degraded = useAppStore((s) => selectClusterDegraded(s, clusterId));
+  const canEdit = d.helm_available && !degraded;
 
   const onEnter = () => {
     setUpgradeStatus({ kind: "idle" });
@@ -729,10 +732,16 @@ function HelmReleaseView({
                 />
               ) : (
                 <span
-                  title="Install helm CLI to enable upgrade"
+                  title={
+                    degraded
+                      ? "Cluster unavailable — reconnect to upgrade"
+                      : "Install helm CLI to enable upgrade"
+                  }
                   style={{ fontSize: FS_XS, color: t.textMuted }}
                 >
-                  read-only · helm CLI not found
+                  {degraded
+                    ? "read-only · cluster unavailable"
+                    : "read-only · helm CLI not found"}
                 </span>
               ))}
           </div>
@@ -743,7 +752,10 @@ function HelmReleaseView({
           helm upgrade with that version while preserving any pending
           value edits. Hidden during an in-flight save to avoid two
           competing actions on screen. */}
-      {valuesTab === "user" && d.update_available && upgradeStatus.kind !== "saving" ? (
+      {valuesTab === "user" &&
+      d.update_available &&
+      upgradeStatus.kind !== "saving" &&
+      !degraded ? (
         <UpdateAvailableBanner
           t={t}
           current={d.chart_version}
@@ -782,7 +794,7 @@ function HelmReleaseView({
             value={buffer!}
             onChange={(next) => setBuffer(next)}
             height={320}
-            disabled={upgradeStatus.kind === "saving"}
+            disabled={upgradeStatus.kind === "saving" || degraded}
           />
         ) : (
           <YamlViewer

--- a/ui/src/components/forwards/NamespaceForwardButton.tsx
+++ b/ui/src/components/forwards/NamespaceForwardButton.tsx
@@ -18,10 +18,15 @@ export function NamespaceForwardButton({
   t,
   clusterId,
   namespace,
+  disabled = false,
 }: {
   t: Tokens;
   clusterId: string;
   namespace: string;
+  // True when the cluster is degraded — blocks *starting* a new forward (a
+  // doomed connect). Stopping an existing session stays allowed so the
+  // operator can still tear down a now-dead forward.
+  disabled?: boolean;
 }) {
   const globalForwards = useAppStore((s) => s.globalForwards);
   const upsertGlobalForward = useAppStore((s) => s.upsertGlobalForward);
@@ -75,7 +80,7 @@ export function NamespaceForwardButton({
       size="lg"
       title={title}
       active={!!session}
-      disabled={busy}
+      disabled={busy || (disabled && !session)}
       onClick={toggle}
     >
       {Icons.forward}

--- a/ui/src/components/rowActions.test.ts
+++ b/ui/src/components/rowActions.test.ts
@@ -85,3 +85,48 @@ describe("actionsForRow — View logs availability", () => {
     expect(ctx.openLogs).toHaveBeenCalledOnce();
   });
 });
+
+describe("actionsForRow — read-only gating", () => {
+  // A pod ctx wired with every optional write callback so all mutating items
+  // are present in the menu (they're only pushed when their callback exists).
+  const podCtx = (): RowActionContext => ({
+    ...ctxFor(kindOf("pods", "Pod"), { containers: ["app"] }),
+    openExec: vi.fn(),
+    openYamlEdit: vi.fn(),
+    openPortForward: vi.fn(),
+    restart: vi.fn(),
+    delete: vi.fn(),
+  });
+
+  const disabledFor = (label: string, readOnly: boolean): boolean | undefined => {
+    const item = actionsForRow(podCtx(), { readOnly }).find(
+      (i) => i.kind === "item" && i.label === label,
+    );
+    return item?.kind === "item" ? item.disabled : undefined;
+  };
+
+  it("disables every write action when readOnly", () => {
+    for (const label of [
+      "Delete pod",
+      "Restart pod",
+      "Exec shell",
+      "Edit YAML",
+      "Port forward",
+    ]) {
+      expect(disabledFor(label, true)).toBe(true);
+      expect(disabledFor(label, false)).toBeFalsy();
+    }
+  });
+
+  it("keeps read/navigation actions enabled when readOnly", () => {
+    // Namespaced row → the copy item is labelled "Copy namespace/name".
+    for (const label of [
+      "View details",
+      "View logs",
+      "Copy namespace/name",
+      "Copy UID",
+    ]) {
+      expect(disabledFor(label, true)).toBeFalsy();
+    }
+  });
+});

--- a/ui/src/components/rowActions.ts
+++ b/ui/src/components/rowActions.ts
@@ -22,7 +22,10 @@ export type RowActionContext = {
 
 // Per HV2PodMenu, pod actions surface in this order with destructive items
 // (Delete) trailing — R-04: never the default action of the group.
-export function actionsForRow(ctx: RowActionContext): MenuItem[] {
+export function actionsForRow(
+  ctx: RowActionContext,
+  opts?: { readOnly?: boolean },
+): MenuItem[] {
   const {
     kind,
     row,
@@ -33,6 +36,9 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
     openPortForward,
     restart,
   } = ctx;
+  // Cluster degraded (unavailable / mid auto-reconnect): every mutating item
+  // disables, but View details / View logs / Copy stay live.
+  const readOnly = opts?.readOnly ?? false;
   const name = String(row.name ?? "");
   const ns = typeof row.namespace === "string" ? row.namespace : null;
   const qualified = ns ? `${ns}/${name}` : name;
@@ -56,21 +62,32 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
         kind: "item",
         label: "Exec shell",
         onClick: openExec,
-        disabled: containers.length === 0,
+        disabled: containers.length === 0 || readOnly,
       });
     if (openYamlEdit)
-      items.push({ kind: "item", label: "Edit YAML", onClick: openYamlEdit });
+      items.push({
+        kind: "item",
+        label: "Edit YAML",
+        onClick: openYamlEdit,
+        disabled: readOnly,
+      });
     if (openPortForward)
       items.push({
         kind: "item",
         label: "Port forward",
         onClick: openPortForward,
+        disabled: readOnly,
       });
   } else if (kind.id === "deployments" || kind.id === "statefulsets") {
     // Aggregated logs over the workload's pods (resolved via its selector).
     items.push({ kind: "item", label: "View logs", onClick: openLogs });
     if (openYamlEdit)
-      items.push({ kind: "item", label: "Edit YAML", onClick: openYamlEdit });
+      items.push({
+        kind: "item",
+        label: "Edit YAML",
+        onClick: openYamlEdit,
+        disabled: readOnly,
+      });
   } else if (
     kind.id === "daemonsets" ||
     kind.id === "replicasets" ||
@@ -79,17 +96,33 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
     items.push({ kind: "item", label: "View logs", onClick: openLogs });
   } else if (kind.id === "nodes") {
     if (openExec)
-      items.push({ kind: "item", label: "Node shell (debug)", onClick: openExec });
+      items.push({
+        kind: "item",
+        label: "Node shell (debug)",
+        onClick: openExec,
+        disabled: readOnly,
+      });
     if (ctx.cordonTo)
       items.push({
         kind: "item",
         label: ctx.cordonTo.target ? "Cordon" : "Uncordon",
         onClick: ctx.cordonTo.run,
+        disabled: readOnly,
       });
     if (ctx.drain)
-      items.push({ kind: "item", label: "Drain", onClick: ctx.drain });
+      items.push({
+        kind: "item",
+        label: "Drain",
+        onClick: ctx.drain,
+        disabled: readOnly,
+      });
     if (openYamlEdit)
-      items.push({ kind: "item", label: "Edit YAML", onClick: openYamlEdit });
+      items.push({
+        kind: "item",
+        label: "Edit YAML",
+        onClick: openYamlEdit,
+        disabled: readOnly,
+      });
   }
 
   items.push({ kind: "separator" });
@@ -119,6 +152,7 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
         kind: "item",
         label: "Restart pod",
         onClick: restart,
+        disabled: readOnly,
       });
     if (ctx.delete)
       items.push({
@@ -126,6 +160,7 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
         label: "Delete pod",
         onClick: ctx.delete,
         danger: true,
+        disabled: readOnly,
       });
   } else if (kind.id === "nodes" && ctx.delete) {
     items.push({ kind: "separator" });
@@ -134,6 +169,7 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
       label: "Delete node",
       onClick: ctx.delete,
       danger: true,
+      disabled: readOnly,
     });
   } else if (kind.id === "helm_charts") {
     // Helm chart rows are synthetic catalog entries — there's no single
@@ -151,6 +187,7 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
       label: "Uninstall release",
       onClick: ctx.delete,
       danger: true,
+      disabled: readOnly,
     });
   } else if (kind.id !== "pods" && kind.id !== "nodes" && ctx.delete) {
     // Generic Delete for every other kind. The dynamic API in
@@ -163,6 +200,7 @@ export function actionsForRow(ctx: RowActionContext): MenuItem[] {
       label: `Delete ${kind.kind.toLowerCase()}`,
       onClick: ctx.delete,
       danger: true,
+      disabled: readOnly,
     });
   }
 

--- a/ui/src/lib/useClusterConnection.test.ts
+++ b/ui/src/lib/useClusterConnection.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { ClusterHealthEvent, ContextInfo } from "../types";
+
+// Capture the wrapped handlers the hook installs so a test can fire fake
+// backend events at them. Reassigned on every connect-effect re-run, so they
+// always point at the latest (live) closure.
+let healthHandler: ((evt: ClusterHealthEvent) => void) | null = null;
+
+const connectContext = vi.fn();
+const cancelConnect = vi.fn().mockResolvedValue(undefined);
+const reconnectCluster = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../api", () => ({
+  api: {
+    connectContext: (...a: unknown[]) => connectContext(...a),
+    cancelConnect: (...a: unknown[]) => cancelConnect(...a),
+    reconnectCluster: (...a: unknown[]) => reconnectCluster(...a),
+  },
+  onClusterHealth: vi.fn((_id: string, h: (e: ClusterHealthEvent) => void) => {
+    healthHandler = h;
+    return Promise.resolve(() => {});
+  }),
+  onClusterInfoChanged: vi.fn((_id: string, _h: (i: unknown) => void) =>
+    Promise.resolve(() => {}),
+  ),
+}));
+
+import { useClusterConnection } from "./useClusterConnection";
+import { useAppStore } from "../store";
+
+const CTX: ContextInfo = {
+  id: "src::test-cluster",
+  name: "test-cluster",
+  cluster: "test-cluster",
+  user: "u",
+  namespace: null,
+  is_current: true,
+  group: "g",
+  source_id: "src",
+  source_path: null,
+};
+
+const initial = useAppStore.getState();
+
+// Flush both pending microtasks (promise .then/.finally chains) and any timers
+// up to `ms`. `advanceTimersByTimeAsync` yields to the microtask queue between
+// timer callbacks, which is exactly what our reconnect→setAttempt→connect
+// chain needs to settle.
+async function flush(ms = 0) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+function fireHealth(evt: ClusterHealthEvent) {
+  act(() => {
+    healthHandler?.(evt);
+  });
+}
+
+const UNAVAIL: ClusterHealthEvent = { status: "unavailable", reason: "timeout" };
+const MAX = 10;
+// Mirror of the hook's capped exponential backoff: 2,4,8,16,30,30,…
+const backoff = (idx: number) => Math.min(2000 * 2 ** idx, 30_000);
+
+describe("useClusterConnection auto-reconnect", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    healthHandler = null;
+    connectContext.mockReset().mockResolvedValue({ server_version: "v1" });
+    cancelConnect.mockClear();
+    reconnectCluster.mockClear().mockResolvedValue(undefined);
+    useAppStore.setState({
+      ...initial,
+      clusterHealth: {},
+      clusterHealthReason: {},
+      clusterReconnecting: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("connects on mount with no auto-reconnect session", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+    expect(connectContext).toHaveBeenCalledTimes(1);
+    expect(result.current.state.status).toBe("ok");
+    expect(result.current.autoReconnect).toBeNull();
+    expect(reconnectCluster).not.toHaveBeenCalled();
+  });
+
+  it("on unavailable, schedules the first retry at exactly 2000ms", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    fireHealth(UNAVAIL);
+    // Store reflects reality immediately; session is armed but not yet firing.
+    expect(useAppStore.getState().clusterHealth[CTX.id]).toBe("unavailable");
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBe(true);
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+
+    await flush(1999);
+    expect(reconnectCluster).not.toHaveBeenCalled();
+    await flush(1);
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+    // The reconnect bumps the attempt, which re-runs the connect effect.
+    expect(connectContext).toHaveBeenCalledTimes(2);
+  });
+
+  it("wedged cluster: retries MAX times with capped backoff, then manual banner", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    // connectContext keeps resolving ok (wedged: reconnect appears to succeed
+    // but the probe re-flags shortly after each one). Each unavailable arms the
+    // next attempt; advancing its backoff fires it.
+    for (let k = 1; k <= MAX; k++) {
+      fireHealth(UNAVAIL);
+      expect(result.current.autoReconnect).toEqual({ attempt: k, max: MAX });
+      await flush(backoff(k - 1));
+      expect(reconnectCluster).toHaveBeenCalledTimes(k);
+    }
+
+    // Budget exhausted: the next unavailable ends the session and hands off to
+    // the manual banner. Health stays unavailable in the store.
+    fireHealth(UNAVAIL);
+    expect(result.current.autoReconnect).toBeNull();
+    expect(reconnectCluster).toHaveBeenCalledTimes(MAX);
+    expect(useAppStore.getState().clusterHealth[CTX.id]).toBe("unavailable");
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBeUndefined();
+  });
+
+  it("hard-down cluster: connect-error auto-advances the retry loop to exhaustion", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    // From here every connect fails — the apiserver is gone. Each failed
+    // connect schedules the next attempt on its own (no unavailable events
+    // arrive once there's no live probe). Step through one backoff at a time so
+    // each reconnect→error→reschedule cycle settles before the next fires.
+    connectContext.mockRejectedValue(new Error("connection refused"));
+
+    fireHealth(UNAVAIL);
+    for (let k = 1; k <= MAX; k++) {
+      await flush(backoff(k - 1));
+      expect(reconnectCluster).toHaveBeenCalledTimes(k);
+    }
+
+    // 11th cycle would exceed the budget — session ends into the error banner.
+    await flush(backoff(MAX));
+    expect(reconnectCluster).toHaveBeenCalledTimes(MAX);
+    expect(result.current.state.status).toBe("error");
+    expect(result.current.autoReconnect).toBeNull();
+  });
+
+  it("manual reconnect cancels a pending auto retry and resets the counter", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    fireHealth(UNAVAIL);
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+
+    act(() => result.current.reconnect());
+    expect(result.current.autoReconnect).toBeNull();
+    // The manual reconnect itself calls reconnectCluster once.
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+
+    // The pending 2s auto timer must have been cleared — no further calls.
+    await flush(8000);
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovery dwell: a sustained reconnect ends the session and re-arms fresh", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    fireHealth(UNAVAIL);
+    await flush(2000); // attempt 1 fires, connect resolves ok
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+
+    // 60s with no further unavailable -> declared recovered.
+    await flush(60_000);
+    expect(result.current.autoReconnect).toBeNull();
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBeUndefined();
+
+    // A fresh outage starts a brand-new session at attempt 1 (counter reset).
+    fireHealth(UNAVAIL);
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+  });
+
+  it("unmount mid-backoff fires no further reconnects", async () => {
+    const { unmount } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    fireHealth(UNAVAIL); // arms the 2s timer
+    unmount();
+    await flush(8000);
+    expect(reconnectCluster).not.toHaveBeenCalled();
+    // Cleanup also clears the per-cluster reconnecting flag.
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBeUndefined();
+  });
+});

--- a/ui/src/lib/useClusterConnection.ts
+++ b/ui/src/lib/useClusterConnection.ts
@@ -10,6 +10,29 @@ export type ConnectState =
   | { status: "cancelled" }
   | { status: "error"; message: string };
 
+/// Progress of an in-flight silent auto-reconnect session. `null` when no
+/// session is retrying (cold, or exhausted into the manual banner).
+export type AutoReconnect = { attempt: number; max: number };
+
+// How many silent reconnect attempts we make after the cluster is declared
+// unavailable before falling through to the manual ReconnectBanner. Each
+// attempt is a full reconnect_cluster + connect_context, i.e. a *fresh client*
+// — which is exactly the recovery the backend health probe documents as the
+// only clean path out of a wedged HTTP/2 pool (crates/core/src/health.rs).
+const MAX_AUTO = 10;
+// Exponential backoff before each attempt, capped so the later retries in a
+// long session settle into a steady poll instead of growing unbounded.
+// Indexed by attempts-already-used: 2s, 4s, 8s, 16s, then 30s flat.
+const BACKOFF_BASE_MS = 2000;
+const BACKOFF_CAP_MS = 30_000;
+function backoffMs(attemptIdx: number): number {
+  return Math.min(BACKOFF_BASE_MS * 2 ** attemptIdx, BACKOFF_CAP_MS);
+}
+// After an auto attempt connects, the cluster may still be wedged and re-flag
+// ~30s later (the probe's unhealthy window). We only consider a session truly
+// recovered once it's stayed connected this long with no new unavailable.
+const RECOVERY_DWELL_MS = 60_000;
+
 // Generate a unique connect_id per attempt. crypto.randomUUID is available
 // in Tauri's WebKit; fall back to a timestamp-based id if it ever isn't.
 function newConnectId(): string {
@@ -31,13 +54,25 @@ function newConnectId(): string {
 //     a new one, so a slow first connect can't clobber a fast second one.
 //   - The backend also enforces a 15s wall-clock timeout — a wedged auth
 //     plugin or unreachable apiserver still resolves with an error.
+//
+// Auto-reconnect: when the background health probe declares the cluster
+// unavailable (or an auto attempt's connect fails outright), we silently retry
+// up to MAX_AUTO times with exponential backoff before surfacing the manual
+// banner. The retry IS a programmatic press of the same Reconnect button, so
+// it rebuilds a fresh client each time — honoring the backend's "recovery
+// requires a rebuilt client" contract without any backend change. All session
+// state lives in refs (not state) so our own `setAttempt` bumps — which re-run
+// the connect effect — can't reset the counter mid-session.
 export function useClusterConnection(context: ContextInfo): {
   state: ConnectState;
   /// Abort an in-flight connect. No-op outside `connecting`.
   cancel: () => void;
   /// Drop the cached backend ClusterEntry, clear the health flag, and re-run
-  /// the connect from a clean slate. Used by every ReconnectBanner.
+  /// the connect from a clean slate. Used by every ReconnectBanner. Cancels
+  /// any active auto-reconnect session and resets its counter.
   reconnect: () => void;
+  /// Non-null while a silent auto-reconnect session is actively retrying.
+  autoReconnect: AutoReconnect | null;
 } {
   // Initialise straight to "connecting" so the first paint already renders
   // the Cancel-button-bearing layout. The placeholder connectId is replaced
@@ -49,9 +84,165 @@ export function useClusterConnection(context: ContextInfo): {
     connectId: "",
   }));
   const [attempt, setAttempt] = useState(0);
+  const [autoReconnect, setAutoReconnect] = useState<AutoReconnect | null>(null);
   const reqId = useRef(0);
   const applyClusterHealth = useAppStore((s) => s.applyClusterHealth);
   const clearClusterHealth = useAppStore((s) => s.clearClusterHealth);
+  const setClusterReconnecting = useAppStore((s) => s.setClusterReconnecting);
+
+  // Mutable auto-reconnect session state. Refs, not state, so re-running the
+  // connect effect (via setAttempt) never clobbers them.
+  const attemptsUsedRef = useRef(0); // auto attempts consumed this session (0..MAX_AUTO)
+  const sessionActiveRef = useRef(false);
+  const attemptInFlightRef = useRef(false); // an auto attempt's connect is mid-flight
+  const backoffTimerRef = useRef<number | null>(null);
+  const dwellTimerRef = useRef<number | null>(null);
+  const mountedRef = useRef(true);
+  // Current context id, readable from controller methods that outlive a render.
+  const cidRef = useRef(context.id);
+  cidRef.current = context.id;
+
+  // Build the auto-reconnect controller once. It closes over the stable refs +
+  // setters above (React state setters and zustand actions are referentially
+  // stable), and reads the *current* context id through cidRef.
+  const ctlRef = useRef<{
+    onUnavailable: () => void;
+    onConnectResolved: (result: "ok" | "error") => void;
+    reset: (resetCounter: boolean) => void;
+  } | null>(null);
+  if (ctlRef.current === null) {
+    const clearTimers = () => {
+      if (backoffTimerRef.current != null) {
+        window.clearTimeout(backoffTimerRef.current);
+        backoffTimerRef.current = null;
+      }
+      if (dwellTimerRef.current != null) {
+        window.clearTimeout(dwellTimerRef.current);
+        dwellTimerRef.current = null;
+      }
+    };
+
+    const endSession = (resetCounter: boolean) => {
+      clearTimers();
+      sessionActiveRef.current = false;
+      attemptInFlightRef.current = false;
+      if (resetCounter) attemptsUsedRef.current = 0;
+      setClusterReconnecting(cidRef.current, false);
+      if (mountedRef.current) setAutoReconnect(null);
+    };
+
+    // Fire the reconnect mechanics for one auto attempt. NOT the public
+    // reconnect() — that resets the counter, which would loop forever.
+    const runAttempt = () => {
+      backoffTimerRef.current = null;
+      attemptsUsedRef.current += 1;
+      attemptInFlightRef.current = true;
+      // Pin the cluster id for the whole async chain. If the context switches
+      // while reconnectCluster is in flight, cidRef advances to the new id —
+      // the .finally must still clear health for the cluster we reconnected,
+      // not the one we just switched to. (Mirrors manual reconnect().)
+      const contextId = cidRef.current;
+      api
+        .reconnectCluster(contextId)
+        .catch(logErr("cluster-connect"))
+        .finally(() => {
+          clearClusterHealth(contextId);
+          setAttempt((n) => n + 1); // re-runs the connect effect with a fresh client
+        });
+    };
+
+    const scheduleNext = () => {
+      // Dedupe: one pending backoff or in-flight attempt at a time.
+      if (backoffTimerRef.current != null || attemptInFlightRef.current) return;
+      if (attemptsUsedRef.current >= MAX_AUTO) {
+        // Out of budget — drop the session and leave health/connect state as-is
+        // so the existing manual banner takes over.
+        endSession(false);
+        return;
+      }
+      sessionActiveRef.current = true;
+      setClusterReconnecting(cidRef.current, true);
+      const idx = attemptsUsedRef.current; // backoff index + display attempt n
+      if (mountedRef.current) setAutoReconnect({ attempt: idx + 1, max: MAX_AUTO });
+      backoffTimerRef.current = window.setTimeout(runAttempt, backoffMs(idx));
+    };
+
+    ctlRef.current = {
+      onUnavailable() {
+        // A wedged cluster re-flagging cancels any pending recovery dwell.
+        if (dwellTimerRef.current != null) {
+          window.clearTimeout(dwellTimerRef.current);
+          dwellTimerRef.current = null;
+        }
+        scheduleNext(); // starts the session on the first unavailable; advances it after
+      },
+      onConnectResolved(result) {
+        attemptInFlightRef.current = false;
+        if (!sessionActiveRef.current) return; // no active session → normal behaviour
+        if (result === "error") {
+          // Hard-down: the connect itself failed, so drive the next attempt now
+          // (no unavailable event will arrive — there's no live probe).
+          scheduleNext();
+          return;
+        }
+        // Connected: optimistically recovered, but a wedged cluster may re-flag
+        // ~30s later. Hold the session open through a dwell; if no unavailable
+        // arrives, declare recovery and reset.
+        if (dwellTimerRef.current != null) window.clearTimeout(dwellTimerRef.current);
+        dwellTimerRef.current = window.setTimeout(
+          () => endSession(true),
+          RECOVERY_DWELL_MS,
+        );
+      },
+      reset(resetCounter) {
+        endSession(resetCounter);
+      },
+    };
+  }
+
+  // Mount-only flag, so the [context.id] effect below can reset per-context
+  // state without falsely tripping the unmount guard on a context switch.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  // Per-context auto-reconnect lifecycle. Keyed on context.id ONLY (not the
+  // attempt counter) so our own setAttempt bumps don't wipe the session. On
+  // enter: clean slate. On leave (context switch or unmount): clear timers and
+  // the reconnecting flag for the OLD id (captured in the closure — cidRef has
+  // already advanced to the new id by the time cleanup runs).
+  useEffect(() => {
+    const cid = context.id;
+    attemptsUsedRef.current = 0;
+    sessionActiveRef.current = false;
+    attemptInFlightRef.current = false;
+    if (backoffTimerRef.current != null) {
+      window.clearTimeout(backoffTimerRef.current);
+      backoffTimerRef.current = null;
+    }
+    if (dwellTimerRef.current != null) {
+      window.clearTimeout(dwellTimerRef.current);
+      dwellTimerRef.current = null;
+    }
+    setAutoReconnect(null);
+    return () => {
+      if (backoffTimerRef.current != null) {
+        window.clearTimeout(backoffTimerRef.current);
+        backoffTimerRef.current = null;
+      }
+      if (dwellTimerRef.current != null) {
+        window.clearTimeout(dwellTimerRef.current);
+        dwellTimerRef.current = null;
+      }
+      sessionActiveRef.current = false;
+      attemptInFlightRef.current = false;
+      attemptsUsedRef.current = 0;
+      setClusterReconnecting(cid, false);
+    };
+  }, [context.id, setClusterReconnecting]);
 
   useEffect(() => {
     const id = ++reqId.current;
@@ -66,10 +257,11 @@ export function useClusterConnection(context: ContextInfo): {
     // initial connect window. The backend emits exactly one unavailable
     // event per cluster lifetime; it's the data plane's "this is dead"
     // signal that the resource table uses to dim its rows + show the
-    // banner.
+    // banner — and our trigger to start silently auto-reconnecting.
     onClusterHealth(context.id, (evt) => {
       if (cancelled) return;
       applyClusterHealth(context.id, evt.status, evt.reason);
+      if (evt.status === "unavailable") ctlRef.current?.onUnavailable();
     }).then((fn) => {
       if (cancelled) fn();
       else unlistenHealth = fn;
@@ -93,7 +285,10 @@ export function useClusterConnection(context: ContextInfo): {
     api
       .connectContext(context.id, connectId)
       .then((info) => {
-        if (reqId.current === id) setState({ status: "ok", info });
+        if (reqId.current === id) {
+          setState({ status: "ok", info });
+          ctlRef.current?.onConnectResolved("ok");
+        }
       })
       .catch((e: unknown) => {
         if (reqId.current !== id) return;
@@ -102,6 +297,7 @@ export function useClusterConnection(context: ContextInfo): {
           setState({ status: "cancelled" });
         } else {
           setState({ status: "error", message });
+          ctlRef.current?.onConnectResolved("error");
         }
       });
     // Effect cleanup runs on context change *and* unmount. Either way the
@@ -127,9 +323,11 @@ export function useClusterConnection(context: ContextInfo): {
   // `insert_connected` returns the existing entry if one was lazy-created
   // (App's eager namespaces subscribe runs before connect_context, and a
   // wedged client built then would otherwise get reused on every retry) —
-  // hence reconnect_cluster first, then a fresh attempt.
+  // hence reconnect_cluster first, then a fresh attempt. Cancels any active
+  // auto-reconnect session first so a manual press wins cleanly.
   const reconnect = () => {
     const id = context.id;
+    ctlRef.current?.reset(true);
     api
       .reconnectCluster(id)
       .catch(logErr("cluster-connect"))
@@ -139,5 +337,5 @@ export function useClusterConnection(context: ContextInfo): {
       });
   };
 
-  return { state, cancel, reconnect };
+  return { state, cancel, reconnect, autoReconnect };
 }

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -9,6 +9,7 @@ import {
   semverGt,
   selectUpdateAvailable,
   selectActiveClusterIds,
+  selectClusterDegraded,
   buildPrefsPayload,
   selectClustersToDisconnect,
   type DockTab,
@@ -1435,5 +1436,39 @@ describe("cluster tabs", () => {
     expect(selectClustersToDisconnect(s, aId)).toEqual([]);
     // Closing V: default::a kept by A, only default::c is freed.
     expect(selectClustersToDisconnect(s, vId)).toEqual(["default::c"]);
+  });
+});
+
+describe("cluster degraded state", () => {
+  it("selectClusterDegraded is true for unavailable OR reconnecting", () => {
+    const base = { clusterHealth: {}, clusterReconnecting: {} };
+    expect(selectClusterDegraded(base, "c1")).toBe(false);
+    expect(
+      selectClusterDegraded(
+        { clusterHealth: { c1: "unavailable" }, clusterReconnecting: {} },
+        "c1",
+      ),
+    ).toBe(true);
+    expect(
+      selectClusterDegraded(
+        { clusterHealth: { c1: "healthy" }, clusterReconnecting: { c1: true } },
+        "c1",
+      ),
+    ).toBe(true);
+    // A healthy, non-reconnecting cluster is not degraded.
+    expect(
+      selectClusterDegraded(
+        { clusterHealth: { c1: "healthy" }, clusterReconnecting: { c1: false } },
+        "c1",
+      ),
+    ).toBe(false);
+  });
+
+  it("setClusterReconnecting toggles the flag and prunes on false", () => {
+    const st = useAppStore.getState();
+    st.setClusterReconnecting("c1", true);
+    expect(useAppStore.getState().clusterReconnecting.c1).toBe(true);
+    st.setClusterReconnecting("c1", false);
+    expect("c1" in useAppStore.getState().clusterReconnecting).toBe(false);
   });
 });

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -360,6 +360,12 @@ type AppState = {
   // Reason string from the last unavailable event, keyed the same way.
   // Surfaced verbatim in the banner so the operator can debug.
   clusterHealthReason: Record<string, string | null>;
+  // True while `useClusterConnection` is mid auto-reconnect for a cluster.
+  // Distinct from `clusterHealth` because a wedged cluster's freshly-rebuilt
+  // client can read momentarily "healthy" between retries — this flag keeps
+  // the read-only gate + reconnecting banner steady across the whole session.
+  // Set/cleared only by the hook; never persisted.
+  clusterReconnecting: Record<string, boolean>;
 
   // Active port-forwards keyed by id. Initially hydrated by api.pfList() at
   // App boot; mutated on every `portforward://status` event. Detail-panel
@@ -513,6 +519,7 @@ type AppState = {
     reason: string | null,
   ) => void;
   clearClusterHealth: (clusterId: string) => void;
+  setClusterReconnecting: (clusterId: string, value: boolean) => void;
 
   hydrateForwards: (entries: ForwardEntry[]) => void;
   upsertForward: (entry: ForwardEntry) => void;
@@ -819,6 +826,7 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   clusterHealth: {},
   clusterHealthReason: {},
+  clusterReconnecting: {},
 
   forwards: {},
   forwardsOpen: false,
@@ -1275,6 +1283,17 @@ export const useAppStore = create<AppState>((set, get) => ({
       const { [clusterId]: _h, ...rest } = s.clusterHealth;
       const { [clusterId]: _r, ...restR } = s.clusterHealthReason;
       return { clusterHealth: rest, clusterHealthReason: restR };
+    }),
+  setClusterReconnecting: (clusterId, value) =>
+    set((s) => {
+      if ((s.clusterReconnecting[clusterId] ?? false) === value) return s;
+      if (value) {
+        return {
+          clusterReconnecting: { ...s.clusterReconnecting, [clusterId]: true },
+        };
+      }
+      const { [clusterId]: _x, ...rest } = s.clusterReconnecting;
+      return { clusterReconnecting: rest };
     }),
 
   hydrateForwards: (entries) =>
@@ -1802,6 +1821,26 @@ export function selectActiveClusterIds(s: {
     if (exists(id) && !base.includes(id)) base.push(id);
   }
   return base;
+}
+
+/// True when a cluster is not currently usable for writes: either the health
+/// probe declared it unavailable, or the connection hook is mid auto-reconnect
+/// (a freshly-rebuilt-but-unverified client). Read by every write affordance
+/// (row menu, bulk bar, detail buttons, inline edit, YAML/Helm save) to gate
+/// itself down to read-only. Pure — usable from reducers, imperative menu
+/// builders, and tests. The backend stays the final arbiter; this is courtesy
+/// disabling so the operator isn't firing doomed mutations at a dead apiserver.
+export function selectClusterDegraded(
+  s: {
+    clusterHealth: Record<string, ClusterHealthStatus>;
+    clusterReconnecting: Record<string, boolean>;
+  },
+  clusterId: string,
+): boolean {
+  return (
+    s.clusterHealth[clusterId] === "unavailable" ||
+    s.clusterReconnecting[clusterId] === true
+  );
 }
 
 /// Hook form of `selectActiveClusterIds` with a referentially-stable result:


### PR DESCRIPTION
## Problem

When a cluster's apiserver disappeared, the single-cluster table froze — `pointerEvents:"none"` on the dimmed overlay meant the operator could see rows + the error but **couldn't click into a detail panel**. And there was no recovery short of a manual click: the health probe declared the cluster unavailable exactly once, then the probe loop exited (`crates/core/src/health.rs` — "recovery requires manual reconnect").

## What changed

**1. Silent auto-reconnect (10×).** `useClusterConnection` now retries on a health `unavailable` event (or a mid-session connect error) up to 10 times with capped exponential backoff (2/4/8/16/30…s), then falls through to the existing manual banner. Each retry rebuilds a **fresh client** (`reconnect_cluster` + `connect_context`) — which respects the documented "wedged HTTP/2 pool → rebuild" contract in `health.rs`, so **no backend change**. Session state lives in refs; a `[context.id]`-only effect owns the timer/counter lifecycle so per-attempt `setAttempt` bumps can't reset it. Recovery via a 60s dwell; manual reconnect cancels the session. The shared hook means single **and** virtual-context clusters both inherit it.

**2. Interactive degraded table.** Dropped `pointerEvents:"none"` — rows stay clickable (detail opens on the cached row + a best-effort live fetch; cross-kind nav works). `ReconnectBanner` gained a busy/progress variant ("Reconnecting… (k/10)", "Reconnect now"). `VirtualClusterPanel` shows a per-member reconnecting strip; healthy members keep serving the merged table.

**3. Read-only gating** (read + navigate only while degraded) via a new pure store selector `selectClusterDegraded` (unavailable OR reconnecting): row context menu, bulk bar, detail title buttons, the inline-edit chokepoint (pencil no-op + `saveAll` hard-stop + `GlobalSaveBar`), YAML tab, Helm upgrade/install, namespace-forward. Reads/nav/copy/logs/metrics stay live; the apiserver remains the final arbiter.

## Tests
New `useClusterConnection.test.ts`, `ClusterPanel.test.tsx`, `editSession.readonly.test.tsx`; extended store / rowActions / BulkBar / YamlTab / VirtualClusterPanel. `tsc --noEmit` clean, full `vitest run` green (1094 tests).

## Reviewer pass
Found + fixed one race: `runAttempt`'s async `.finally` read `cidRef.current`, which could advance to a different cluster on a mid-flight context switch — now pins `contextId` at attempt entry (same guard `reconnect()` already uses).

## Not covered (follow-ups)
- Per-port forward chips, Dock create-from-YAML, and Dock terminal/exec openers are **not** read-only gated — they fail at the apiserver instead.
- Auto-reconnect is frontend-driven by design; no server-side retry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)