### PR TITLE
feat(table): custom columns from resource labels

### DIFF
--- a/crates/core/src/table_views.rs
+++ b/crates/core/src/table_views.rs
@@ -24,6 +24,12 @@ pub struct TableView {
     pub sorting: Vec<SortEntry>,
     #[serde(default)]
     pub column_sizing: HashMap<String, f64>,
+    /// Label keys (`metadata.labels` keys) the operator promoted to custom
+    /// columns for this `(cluster/scope, kind)`. Rendered as extra text
+    /// columns reading from the watcher-injected `__labels` map. Empty for
+    /// legacy files thanks to `serde(default)`.
+    #[serde(default)]
+    pub label_columns: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -61,4 +67,55 @@ pub async fn save(file: &TableViewsFile) -> std::io::Result<()> {
 #[must_use]
 pub fn key(cluster_id: &str, kind_id: &str) -> String {
     format!("{cluster_id}::{kind_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_view_without_label_columns_defaults_empty() {
+        // Files written before `label_columns` landed must still parse,
+        // yielding an empty custom-column list rather than failing.
+        let legacy = r#"{ "sorting": [], "column_sizing": {} }"#;
+        let view: TableView = serde_json::from_str(legacy).expect("legacy view parses");
+        assert!(view.label_columns.is_empty());
+    }
+
+    #[test]
+    fn label_columns_round_trip() {
+        let view = TableView {
+            sorting: vec![SortEntry {
+                id: "name".into(),
+                desc: false,
+            }],
+            column_sizing: HashMap::new(),
+            label_columns: vec![
+                "topology.kubernetes.io/zone".into(),
+                "node-role.kubernetes.io/control-plane".into(),
+            ],
+        };
+        let json = serde_json::to_string(&view).expect("serialize");
+        let back: TableView = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.label_columns, view.label_columns);
+    }
+
+    #[test]
+    fn views_file_round_trip_keyed() {
+        let mut file = TableViewsFile::default();
+        let k = key("default::minikube", "nodes");
+        file.views.insert(
+            k.clone(),
+            TableView {
+                label_columns: vec!["kubernetes.io/arch".into()],
+                ..TableView::default()
+            },
+        );
+        let json = serde_json::to_string(&file).expect("serialize file");
+        let back: TableViewsFile = serde_json::from_str(&json).expect("deserialize file");
+        assert_eq!(
+            back.views.get(&k).map(|v| v.label_columns.clone()),
+            Some(vec!["kubernetes.io/arch".to_string()])
+        );
+    }
 }

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -783,6 +783,22 @@ describe("metrics + prefs + table views", () => {
       view,
     });
   });
+
+  it("setTableView forwards label_columns intact", async () => {
+    const cap = captureNext({});
+    const view: Parameters<typeof api.setTableView>[2] = {
+      sorting: [],
+      column_sizing: {},
+      label_columns: ["topology.kubernetes.io/zone", "kubernetes.io/arch"],
+    };
+    await api.setTableView("ctx", "nodes", view);
+    expect(cap.calls[0]?.cmd).toBe("set_table_view");
+    expect(cap.calls[0]?.args).toEqual({
+      clusterId: "ctx",
+      kindId: "nodes",
+      view,
+    });
+  });
 });
 
 describe("Prometheus", () => {

--- a/ui/src/components/ColumnPicker.test.tsx
+++ b/ui/src/components/ColumnPicker.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+import { ColumnPicker } from "./ColumnPicker";
+
+afterEach(cleanup);
+
+function renderPicker(props: {
+  available?: string[];
+  enabled?: string[];
+  onToggle?: (key: string) => void;
+  onReset?: () => void;
+}) {
+  return render(
+    <ColumnPicker
+      available={props.available ?? []}
+      enabled={props.enabled ?? []}
+      onToggle={props.onToggle ?? (() => {})}
+      onReset={props.onReset ?? (() => {})}
+    />,
+  );
+}
+
+describe("ColumnPicker", () => {
+  it("is closed until the control is clicked", () => {
+    const { queryByRole, getByRole } = renderPicker({ available: ["zone"] });
+    expect(queryByRole("menu")).toBeNull();
+    fireEvent.click(getByRole("button", { name: "Customize columns" }));
+    expect(getByRole("menu")).toBeTruthy();
+  });
+
+  it("lists the available keys with checked state reflecting enabled", () => {
+    const { getByRole } = renderPicker({
+      available: ["topology.kubernetes.io/zone", "kubernetes.io/arch"],
+      enabled: ["kubernetes.io/arch"],
+    });
+    fireEvent.click(getByRole("button", { name: "Customize columns" }));
+    expect(
+      getByRole("menuitemcheckbox", {
+        name: "topology.kubernetes.io/zone",
+      }).getAttribute("aria-checked"),
+    ).toBe("false");
+    expect(
+      getByRole("menuitemcheckbox", {
+        name: "kubernetes.io/arch",
+      }).getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  it("toggles a key when its row is clicked", () => {
+    const onToggle = vi.fn();
+    const { getByRole } = renderPicker({ available: ["zone"], onToggle });
+    fireEvent.click(getByRole("button", { name: "Customize columns" }));
+    fireEvent.click(getByRole("menuitemcheckbox", { name: "zone" }));
+    expect(onToggle).toHaveBeenCalledWith("zone");
+  });
+
+  it("shows a persisted-but-absent key so it can be turned off", () => {
+    const { getByRole } = renderPicker({
+      available: [],
+      enabled: ["stale/key"],
+    });
+    fireEvent.click(getByRole("button", { name: "Customize columns" }));
+    expect(
+      getByRole("menuitemcheckbox", { name: "stale/key" }).getAttribute(
+        "aria-checked",
+      ),
+    ).toBe("true");
+  });
+
+  it("renders an empty state when there are no labels", () => {
+    const { getByRole, getByText } = renderPicker({});
+    fireEvent.click(getByRole("button", { name: "Customize columns" }));
+    expect(getByText("No labels on these resources.")).toBeTruthy();
+  });
+
+  it("shows Reset only when columns are enabled, and fires onReset", () => {
+    const onReset = vi.fn();
+    const { getByRole } = renderPicker({
+      available: ["zone"],
+      enabled: ["zone"],
+      onReset,
+    });
+    fireEvent.click(getByRole("button", { name: "Customize columns" }));
+    fireEvent.click(getByRole("button", { name: "Reset" }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides Reset when nothing is enabled", () => {
+    const { getByRole, queryByRole } = renderPicker({ available: ["zone"] });
+    fireEvent.click(getByRole("button", { name: "Customize columns" }));
+    expect(queryByRole("button", { name: "Reset" })).toBeNull();
+  });
+});

--- a/ui/src/components/ColumnPicker.tsx
+++ b/ui/src/components/ColumnPicker.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useResolvedTheme } from "../store";
+import { FF_MONO, FONT_SANS, FS_MD, FS_SM, FS_XS, R_LG, R_MD } from "../theme";
+import { Checkbox, Icons } from "./ui";
+import { labelColumnHeader } from "../lib/labelColumns";
+
+type Props = {
+  /// Distinct label keys present on the current rows (the universe to pick
+  /// from), sorted.
+  available: string[];
+  /// Label keys currently promoted to columns.
+  enabled: string[];
+  /// Toggle one key on/off. The parent owns the persisted list.
+  onToggle: (key: string) => void;
+  /// Clear all custom columns back to none.
+  onReset: () => void;
+};
+
+// ColumnPicker — the table header's right-edge "⋯" control. Opens a dropdown
+// listing every label key found on the current rows; checking one adds a
+// custom column reading that label, unchecking removes it. The chosen set is
+// owned + persisted per (scope, kind) by the parent ResourceTable.
+export function ColumnPicker({
+  available,
+  enabled,
+  onToggle,
+  onReset,
+}: Props) {
+  const resolved = useResolvedTheme();
+  const t = resolved.tokens;
+  const mode = resolved.mode;
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  // Close on outside click + Esc. Same pattern as SessionsPopover / Select.
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const enabledSet = useMemo(() => new Set(enabled), [enabled]);
+  // Union of available + enabled, so a key that was persisted but is no
+  // longer present on any current row can still be unchecked here. Sorted
+  // for stable scanning.
+  const keys = useMemo(() => {
+    const s = new Set(available);
+    for (const k of enabled) s.add(k);
+    return [...s].sort();
+  }, [available, enabled]);
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: "relative",
+        display: "flex",
+        // Last header cell: fixed width, never shrinks, stretches to the full
+        // header height (parent header is display:flex, align-items:stretch).
+        width: 30,
+        flexShrink: 0,
+        alignSelf: "stretch",
+      }}
+    >
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Customize columns"
+        title="Customize columns"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          width: 30,
+          height: "100%",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: open ? t.surfaceAlt : t.headerAlt,
+          border: "none",
+          borderLeft: `1px solid ${t.border}`,
+          color: open ? t.text : t.textMuted,
+          cursor: "pointer",
+          padding: 0,
+        }}
+      >
+        {Icons.more}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          style={{
+            position: "absolute",
+            top: "100%",
+            right: 0,
+            marginTop: 4,
+            zIndex: 50,
+            width: 280,
+            background: t.surface,
+            border: `1px solid ${t.border}`,
+            borderRadius: R_LG,
+            boxShadow:
+              mode === "dark"
+                ? "0 12px 32px rgba(0,0,0,0.45)"
+                : "0 12px 32px rgba(15,20,30,0.18)",
+            display: "flex",
+            flexDirection: "column",
+            overflow: "hidden",
+            fontFamily: FONT_SANS,
+          }}
+        >
+          <div
+            style={{
+              padding: "8px 10px",
+              borderBottom: `1px solid ${t.borderSoft}`,
+              background: t.surfaceAlt,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  color: t.textMuted,
+                  fontSize: FS_SM,
+                  fontFamily: FF_MONO,
+                  letterSpacing: 0.5,
+                  textTransform: "uppercase",
+                }}
+              >
+                Custom columns
+              </div>
+              <div style={{ color: t.textDim, fontSize: FS_XS, marginTop: 2 }}>
+                From resource labels
+              </div>
+            </div>
+            {enabled.length > 0 && (
+              <button
+                type="button"
+                onClick={onReset}
+                title="Remove all custom columns"
+                style={{
+                  flexShrink: 0,
+                  background: "transparent",
+                  border: `1px solid ${t.border}`,
+                  borderRadius: R_MD,
+                  color: t.textMuted,
+                  fontSize: FS_XS,
+                  fontFamily: FONT_SANS,
+                  padding: "3px 8px",
+                  cursor: "pointer",
+                }}
+              >
+                Reset
+              </button>
+            )}
+          </div>
+          <div style={{ overflow: "auto", maxHeight: 320 }}>
+            {keys.length === 0 ? (
+              <div
+                style={{
+                  padding: 14,
+                  color: t.textDim,
+                  fontSize: FS_MD,
+                  textAlign: "center",
+                }}
+              >
+                No labels on these resources.
+              </div>
+            ) : (
+              keys.map((key) => {
+                const checked = enabledSet.has(key);
+                return (
+                  <div
+                    key={key}
+                    role="menuitemcheckbox"
+                    aria-checked={checked}
+                    aria-label={key}
+                    onClick={() => onToggle(key)}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "7px 10px",
+                      borderBottom: `1px solid ${t.borderSoft}`,
+                      cursor: "pointer",
+                    }}
+                  >
+                    {/* Checkbox stops click propagation, so a direct hit
+                        toggles once; clicking the rest of the row toggles via
+                        the row handler. */}
+                    <Checkbox
+                      t={t}
+                      checked={checked}
+                      onChange={() => onToggle(key)}
+                    />
+                    <div
+                      style={{
+                        minWidth: 0,
+                        display: "flex",
+                        flexDirection: "column",
+                      }}
+                    >
+                      <span
+                        style={{
+                          color: t.text,
+                          fontSize: FS_MD,
+                          fontWeight: 600,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {labelColumnHeader(key)}
+                      </span>
+                      <span
+                        style={{
+                          color: t.textDim,
+                          fontSize: FS_XS,
+                          fontFamily: FF_MONO,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {key}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -2,6 +2,7 @@ import { logErr } from "../lib/log";
 import {
   createContext,
   memo,
+  useCallback,
   useContext,
   useEffect,
   useLayoutEffect,
@@ -51,6 +52,14 @@ import { makeTerminalTab } from "./Dock";
 import { confirm, toast } from "../lib/dialog";
 import { latinLetter } from "../lib/keyboard";
 import { parseTableFilter } from "../lib/tableFilter";
+import {
+  cellRaw,
+  headerWidthFloor,
+  labelColumnDef,
+  labelKeyUniverse,
+  placeLabelColumns,
+} from "../lib/labelColumns";
+import { ColumnPicker } from "./ColumnPicker";
 import { useMetricsSubscriptions } from "../lib/useMetricsSubscription";
 import {
   applyScopedDelta,
@@ -235,6 +244,10 @@ type Props = {
   viewScopeId: string;
   kind: ResourceKind;
 };
+
+// Width of the right gutter reserved for the column-picker control. Must
+// match the ColumnPicker button width so the control fills the gutter.
+const COLMENU_W = 30;
 
 // Resource table — the page is the data (P1). No skeleton on poll, no
 // spinner on re-fetch (R-01). Identifiers in mono (R-07), numbers tabular
@@ -667,25 +680,47 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
   // auto-fit owns the widths and recomputes on container resize.
   const userResizedRef = useRef(false);
 
+  // Label keys the operator promoted to custom columns for this (scope, kind),
+  // persisted alongside the sort. Seeded from disk; the column-picker menu
+  // mutates it.
+  const [labelColumns, setLabelColumns] = useState<string[]>(
+    () => persistedView?.label_columns ?? [],
+  );
+
+  // Distinct label keys across the (filtered) rows — the universe the picker
+  // offers. Sampled inside `labelKeyUniverse` to bound cost on huge tables.
+  const labelKeys = useMemo(() => labelKeyUniverse(filtered), [filtered]);
+
+  const toggleLabelColumn = useCallback((key: string) => {
+    setLabelColumns((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    );
+  }, []);
+
+  // Clear all custom columns back to the default (none).
+  const resetLabelColumns = useCallback(() => setLabelColumns([]), []);
+
   // When the kind / view scope changes, reset to whatever was persisted for
-  // the new (scope, kind). Without this the sort from kind A would leak onto
-  // kind B until the operator clicked something.
+  // the new (scope, kind). Without this the sort (and custom columns) from
+  // kind A would leak onto kind B until the operator clicked something.
   useEffect(() => {
     setSorting(sortingFromPersisted(persistedView?.sorting, kind));
     setColumnSizing({});
+    setLabelColumns(persistedView?.label_columns ?? []);
     userResizedRef.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewScopeId, kind.id]);
 
-  // Debounced persistence (sorting only — widths stay in memory).
+  // Debounced persistence (sorting + custom label columns — widths stay in
+  // memory). `label_columns` must ride along or this write would clobber it.
   useEffect(() => {
     const timeout = setTimeout(() => {
-      const view = { sorting, column_sizing: {} };
+      const view = { sorting, column_sizing: {}, label_columns: labelColumns };
       setTableView(viewScopeId, kind.id, view);
       api.setTableView(viewScopeId, kind.id, view).catch(logErr("table"));
     }, 200);
     return () => clearTimeout(timeout);
-  }, [sorting, viewScopeId, kind.id, setTableView]);
+  }, [sorting, labelColumns, viewScopeId, kind.id, setTableView]);
 
   // Refs so the cell renderer can read fresh values without triggering a
   // columns-memo recompute (which invalidates TanStack's entire row model
@@ -718,11 +753,19 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
     const base = kind.columns.filter(
       (c) => !(singleNs && c.id === "namespace"),
     );
-    if (!isMultiCluster) return base;
+    // Custom label columns slot in just before the trailing Age column (so Age
+    // stays rightmost), in the operator's chosen order.
+    const labelCols = labelColumns.map(labelColumnDef);
+    if (!isMultiCluster) return placeLabelColumns(base, labelCols);
     const nsIdx = base.findIndex((c) => c.id === "namespace");
     const insertAt = nsIdx >= 0 ? nsIdx + 1 : Math.min(1, base.length);
-    return [...base.slice(0, insertAt), CLUSTER_COL, ...base.slice(insertAt)];
-  }, [kind, singleNs, isMultiCluster]);
+    const withCluster = [
+      ...base.slice(0, insertAt),
+      CLUSTER_COL,
+      ...base.slice(insertAt),
+    ];
+    return placeLabelColumns(withCluster, labelCols);
+  }, [kind, singleNs, isMultiCluster, labelColumns]);
 
   const columns = useMemo<TanColumnDef<ScopedRow>[]>(() => {
     const cols: TanColumnDef<ScopedRow>[] = visibleColumns.map((c) => {
@@ -834,6 +877,7 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
     body.addEventListener("scroll", onScroll, { passive: true });
     return () => body.removeEventListener("scroll", onScroll);
   }, []);
+
   const virtualizer = useVirtualizer({
     count: sortedRows.length,
     getScrollElement: () => scrollRef.current,
@@ -1146,6 +1190,7 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
           overflow: "hidden",
           display: "flex",
           flexDirection: "column",
+          position: "relative",
         }}
       >
         {/* Header */}
@@ -1302,6 +1347,15 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
               </div>
             );
           })}
+          {/* Column picker — last header cell, in the gutter reserved by the
+              body's matching paddingRight. As a flex child it stretches to the
+              full header height (no measurement, no half-height bug). */}
+          <ColumnPicker
+            available={labelKeys}
+            enabled={labelColumns}
+            onToggle={toggleLabelColumn}
+            onReset={resetLabelColumns}
+          />
         </div>
 
         {/* Partial-data strip: some members of a merged view failed to
@@ -1352,7 +1406,10 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
 
         <div
           ref={scrollRef}
-          style={{ flex: 1, overflow: "auto", minHeight: 0 }}
+          // paddingRight mirrors the header so columns stay aligned and the
+          // auto-fit (which measures this element's content box) fills the
+          // reduced width. The reserved strip reads as table right-padding.
+          style={{ flex: 1, overflow: "auto", minHeight: 0, paddingRight: COLMENU_W }}
           onClick={(e) => {
             // Delegated row click. Per-row onClick props were the biggest
             // source of GC pressure on large tables — every render
@@ -2220,12 +2277,17 @@ function naturalContentWidth(c: ColumnDef, sample: ResourceRow[]): number {
   const font = isMonoCell(c) ? CELL_FONT_MONO : CELL_FONT_TEXT;
   let dataWidth = 0;
   for (const r of sample) {
-    const v = r[c.id];
+    const v = cellRaw(c, r);
     if (typeof v !== "string" && typeof v !== "number") continue;
     const w = measureText(String(v), font);
     if (w > dataWidth) dataWidth = w;
   }
-  return Math.ceil(Math.max(dataWidth, headerWidth)) + CHROME_PAD;
+  // Custom label columns size to their VALUES only — the label-derived header
+  // is often longer than the data (e.g. header "control-plane" over "true"
+  // cells) and would pad the column wide around mostly-short values. The
+  // header ellipsises instead. Built-in columns keep the header floor so the
+  // title stays fully readable.
+  return Math.ceil(Math.max(dataWidth, headerWidthFloor(c, headerWidth))) + CHROME_PAD;
 }
 
 // Natural width for the synthetic Cluster column — the longest *displayed*
@@ -2339,7 +2401,9 @@ function accessorFor(c: ColumnDef) {
     };
   }
   return (row: ResourceRow): string => {
-    const v = row[c.id];
+    // `cellRaw` so synthetic label columns (kind "text") sort by their
+    // `__labels` value rather than a missing top-level field.
+    const v = cellRaw(c, row);
     if (v == null) return "";
     return String(v);
   };
@@ -2442,7 +2506,9 @@ export function renderCell(
   ) => void,
   setSelectedNamespaces: (ns: Set<string>) => void,
 ) {
-  const value = row[c.id];
+  // Label columns read from `__labels`; everything else from the projected
+  // top-level field.
+  const value = cellRaw(c, row);
 
   // CPU / Mem on the Pods table are projected as null on the backend
   // (metrics-server fills them in via a side channel). Keep this branch

--- a/ui/src/lib/labelColumns.test.ts
+++ b/ui/src/lib/labelColumns.test.ts
@@ -1,0 +1,172 @@
+// Pure helpers behind custom label columns. The header-shortening,
+// key-universe aggregation, and `cellRaw` indirection are the bits that
+// silently break a column (wrong header, missing key, value read from the
+// wrong place), so they're worth pinning.
+
+import { describe, it, expect } from "vitest";
+import {
+  LABEL_COL_PREFIX,
+  labelColumnId,
+  isLabelColumnId,
+  labelColumnHeader,
+  labelColumnDef,
+  labelKeyUniverse,
+  placeLabelColumns,
+  headerWidthFloor,
+  cellRaw,
+} from "./labelColumns";
+import type { ColumnDef, ResourceRow } from "../types";
+
+const row = (
+  fields: Record<string, unknown>,
+  labels?: Record<string, string>,
+): ResourceRow => ({ uid: String(fields.uid ?? "u"), __labels: labels, ...fields });
+
+describe("labelColumnId / isLabelColumnId", () => {
+  it("prefixes the key and round-trips the predicate", () => {
+    const id = labelColumnId("topology.kubernetes.io/zone");
+    expect(id).toBe(`${LABEL_COL_PREFIX}topology.kubernetes.io/zone`);
+    expect(isLabelColumnId(id)).toBe(true);
+  });
+
+  it("does not flag backend column ids", () => {
+    expect(isLabelColumnId("name")).toBe(false);
+    expect(isLabelColumnId("namespace")).toBe(false);
+    expect(isLabelColumnId("cpu")).toBe(false);
+  });
+});
+
+describe("labelColumnHeader", () => {
+  it("shows the segment after the last slash", () => {
+    expect(labelColumnHeader("topology.kubernetes.io/zone")).toBe("zone");
+    expect(labelColumnHeader("node-role.kubernetes.io/control-plane")).toBe(
+      "control-plane",
+    );
+  });
+
+  it("falls back to the whole key when there is no prefix", () => {
+    expect(labelColumnHeader("app")).toBe("app");
+  });
+
+  it("falls back to the whole key when the tail is empty", () => {
+    expect(labelColumnHeader("foo/")).toBe("foo/");
+  });
+});
+
+describe("labelColumnDef", () => {
+  it("builds a text column carrying labelKey", () => {
+    const c = labelColumnDef("kubernetes.io/arch");
+    expect(c).toEqual({
+      id: "label:kubernetes.io/arch",
+      header: "arch",
+      kind: "text",
+      labelKey: "kubernetes.io/arch",
+    });
+  });
+});
+
+describe("labelKeyUniverse", () => {
+  it("collects distinct keys across rows, sorted", () => {
+    const rows = [
+      row({ uid: "a" }, { zone: "us-1", arch: "amd64" }),
+      row({ uid: "b" }, { arch: "arm64", os: "linux" }),
+      row({ uid: "c" }),
+    ];
+    expect(labelKeyUniverse(rows)).toEqual(["arch", "os", "zone"]);
+  });
+
+  it("returns empty when no row carries labels", () => {
+    expect(labelKeyUniverse([row({ uid: "a" }), row({ uid: "b" })])).toEqual([]);
+  });
+
+  it("respects the sample limit", () => {
+    const rows = [
+      row({ uid: "0" }, { only: "first" }),
+      row({ uid: "1" }, { hidden: "beyond-sample" }),
+    ];
+    // Sampling just the first row never sees the second row's keys.
+    expect(labelKeyUniverse(rows, 1)).toEqual(["only"]);
+  });
+});
+
+describe("placeLabelColumns", () => {
+  const col = (id: string, kind?: ColumnDef["kind"]): ColumnDef => ({
+    id,
+    header: id,
+    kind,
+  });
+  const labels = [labelColumnDef("zone"), labelColumnDef("arch")];
+
+  it("inserts label columns just before the trailing Age column", () => {
+    const cols = [col("name"), col("cpu"), col("creation_timestamp", "age")];
+    expect(placeLabelColumns(cols, labels).map((c) => c.id)).toEqual([
+      "name",
+      "cpu",
+      "label:zone",
+      "label:arch",
+      "creation_timestamp",
+    ]);
+  });
+
+  it("anchors on the LAST age column (keeps an earlier age-kind col put)", () => {
+    // Lease: "Renewed" (age) then "Age" (age). Labels go before the last one.
+    const cols = [
+      col("name"),
+      col("renew_time", "age"),
+      col("creation_timestamp", "age"),
+    ];
+    expect(placeLabelColumns(cols, labels).map((c) => c.id)).toEqual([
+      "name",
+      "renew_time",
+      "label:zone",
+      "label:arch",
+      "creation_timestamp",
+    ]);
+  });
+
+  it("appends when there is no age column", () => {
+    const cols = [col("name"), col("data", "number")];
+    expect(placeLabelColumns(cols, labels).map((c) => c.id)).toEqual([
+      "name",
+      "data",
+      "label:zone",
+      "label:arch",
+    ]);
+  });
+
+  it("is a no-op when there are no label columns", () => {
+    const cols = [col("name"), col("creation_timestamp", "age")];
+    expect(placeLabelColumns(cols, [])).toBe(cols);
+  });
+});
+
+describe("headerWidthFloor", () => {
+  it("is 0 for label columns (size to values, header ellipsises)", () => {
+    expect(headerWidthFloor(labelColumnDef("zone"), 120)).toBe(0);
+  });
+
+  it("is the measured header width for built-in columns", () => {
+    const c = { id: "restarts", header: "Restarts", kind: "number" as const };
+    expect(headerWidthFloor(c, 120)).toBe(120);
+  });
+});
+
+describe("cellRaw", () => {
+  it("reads label columns from __labels", () => {
+    const c = labelColumnDef("zone");
+    expect(cellRaw(c, row({ uid: "a" }, { zone: "us-east-1a" }))).toBe(
+      "us-east-1a",
+    );
+  });
+
+  it("yields undefined when the row lacks the label", () => {
+    const c = labelColumnDef("zone");
+    expect(cellRaw(c, row({ uid: "a" }, { other: "x" }))).toBeUndefined();
+    expect(cellRaw(c, row({ uid: "a" }))).toBeUndefined();
+  });
+
+  it("reads normal columns from the top-level field", () => {
+    const c = { id: "name", header: "Name", kind: "text" as const };
+    expect(cellRaw(c, row({ uid: "a", name: "nginx" }))).toBe("nginx");
+  });
+});

--- a/ui/src/lib/labelColumns.ts
+++ b/ui/src/lib/labelColumns.ts
@@ -1,0 +1,106 @@
+// Custom table columns derived from a resource's `metadata.labels`.
+//
+// Labels already ride on every row as `row.__labels` (watcher-injected). A
+// "label column" is a synthetic, frontend-only `ColumnDef` that reads its
+// value from that map instead of a top-level projected field. The chosen
+// keys persist per (scope, kind) inside `TableView.label_columns`.
+//
+// These helpers are pure so the table wiring and the column-picker menu can
+// share them and they can be unit-tested without rendering.
+
+import type { ColumnDef, ResourceRow } from "../types";
+
+// Prefix that namespaces a label column's stable `id` so it can never
+// collide with a backend-projected column id (which are plain field names
+// like `name` / `namespace` / `cpu`).
+export const LABEL_COL_PREFIX = "label:";
+
+/** Stable column id for a label key. */
+export function labelColumnId(key: string): string {
+  return `${LABEL_COL_PREFIX}${key}`;
+}
+
+/** Whether a column id refers to a synthetic label column. */
+export function isLabelColumnId(id: string): boolean {
+  return id.startsWith(LABEL_COL_PREFIX);
+}
+
+/**
+ * Header text for a label column. Kubernetes label keys are usually
+ * `prefix/name` (`topology.kubernetes.io/zone`); the segment after the last
+ * `/` is the human-meaningful part, so we show that and fall back to the
+ * whole key when there's no prefix or the tail is empty.
+ */
+export function labelColumnHeader(key: string): string {
+  const slash = key.lastIndexOf("/");
+  const tail = slash >= 0 ? key.slice(slash + 1) : key;
+  return tail || key;
+}
+
+/** Build the synthetic `ColumnDef` for a label key. */
+export function labelColumnDef(key: string): ColumnDef {
+  return {
+    id: labelColumnId(key),
+    header: labelColumnHeader(key),
+    kind: "text",
+    labelKey: key,
+  };
+}
+
+/**
+ * All distinct label keys present across `rows`, sorted ascending. Sampled
+ * to bound cost on large tables — within a single kind the set of label keys
+ * is near-uniform across objects, so a sample surfaces the real universe.
+ */
+export function labelKeyUniverse(rows: ResourceRow[], sampleLimit = 500): string[] {
+  const seen = new Set<string>();
+  const n = Math.min(rows.length, sampleLimit);
+  for (let i = 0; i < n; i++) {
+    const labels = rows[i]?.__labels;
+    if (labels) {
+      for (const k of Object.keys(labels)) seen.add(k);
+    }
+  }
+  return [...seen].sort();
+}
+
+/**
+ * Splice custom label columns in just before the trailing Age column so Age
+ * stays the rightmost column. Anchors on the *last* `age`-kind column (some
+ * kinds carry an earlier age-kind field, e.g. a Lease's "Renewed" — that one
+ * keeps its place; only the final "Age" gets the label columns ahead of it).
+ * Falls back to appending when the kind has no age column at all.
+ */
+export function placeLabelColumns(
+  cols: ColumnDef[],
+  labelCols: ColumnDef[],
+): ColumnDef[] {
+  if (labelCols.length === 0) return cols;
+  let ageIdx = -1;
+  for (let i = 0; i < cols.length; i++) {
+    if (cols[i]?.kind === "age") ageIdx = i;
+  }
+  if (ageIdx < 0) return [...cols, ...labelCols];
+  return [...cols.slice(0, ageIdx), ...labelCols, ...cols.slice(ageIdx)];
+}
+
+/**
+ * Header-width floor for auto-fit. Custom label columns return 0 so the
+ * column sizes to its values only (the often-longer label-derived header
+ * ellipsises); built-in columns return the measured header width so the title
+ * stays fully readable.
+ */
+export function headerWidthFloor(c: ColumnDef, headerWidth: number): number {
+  return c.labelKey != null ? 0 : headerWidth;
+}
+
+/**
+ * Raw cell value for a column: label columns read from `__labels`,
+ * everything else from the row's top-level projected field. Single source of
+ * truth so sort accessor, cell renderer, and natural-width measurement stay
+ * in agreement.
+ */
+export function cellRaw(c: ColumnDef, row: ResourceRow): unknown {
+  if (c.labelKey != null) return row.__labels?.[c.labelKey];
+  return row[c.id];
+}

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -686,6 +686,31 @@ describe("tableViews", () => {
     });
     expect(Object.keys(useAppStore.getState().tableViews)).toEqual(["ctx::pods"]);
   });
+
+  it("keeps a label-column-only view (no sort/sizing) instead of pruning it", () => {
+    useAppStore.getState().setTableView("ctx", "nodes", {
+      sorting: [],
+      column_sizing: {},
+      label_columns: ["topology.kubernetes.io/zone"],
+    } as never);
+    expect(useAppStore.getState().tableViews["ctx::nodes"]?.label_columns).toEqual([
+      "topology.kubernetes.io/zone",
+    ]);
+  });
+
+  it("prunes once label columns are also cleared", () => {
+    useAppStore.getState().setTableView("ctx", "nodes", {
+      sorting: [],
+      column_sizing: {},
+      label_columns: ["zone"],
+    } as never);
+    useAppStore.getState().setTableView("ctx", "nodes", {
+      sorting: [],
+      column_sizing: {},
+      label_columns: [],
+    } as never);
+    expect(useAppStore.getState().tableViews["ctx::nodes"]).toBeUndefined();
+  });
 });
 
 describe("UI scale", () => {

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1560,7 +1560,13 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => {
       const key = `${clusterId}::${kindId}`;
       const next = { ...s.tableViews };
-      if (view.sorting.length === 0 && Object.keys(view.column_sizing).length === 0) {
+      // Prune a view only when it carries nothing worth persisting. A view
+      // with custom label columns but no sort/sizing must survive.
+      if (
+        view.sorting.length === 0 &&
+        Object.keys(view.column_sizing).length === 0 &&
+        (view.label_columns?.length ?? 0) === 0
+      ) {
         delete next[key];
       } else {
         next[key] = view;

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -214,6 +214,10 @@ export type TableSortEntry = { id: string; desc: boolean };
 export type TableView = {
   sorting: TableSortEntry[];
   column_sizing: Record<string, number>;
+  // Label keys promoted to custom columns for this (scope, kind). Optional
+  // on the wire so older backends (no `label_columns`) round-trip; the
+  // current backend always sends an array (possibly empty).
+  label_columns?: string[];
 };
 export type TableViewsFile = {
   views: Record<string, TableView>;
@@ -397,6 +401,11 @@ export type ColumnDef = {
   id: string;
   header: string;
   kind?: ColumnKind;
+  // Set only on synthetic, frontend-built custom columns derived from a
+  // resource's `metadata.labels`. When present, the cell value is read from
+  // `row.__labels[labelKey]` instead of `row[id]`. The backend never sets
+  // this — it is not part of the wire `ResourceKind.columns` payload.
+  labelKey?: string;
 };
 
 export type ResourceKind = {


### PR DESCRIPTION
## What

Promote any `metadata.labels` key to a real table column, per **(cluster, kind)**.

A **⋮ control** in each table header opens a picker listing every label key found on the current rows. Check one → it becomes a sortable, auto-sized text column. **Reset** clears all custom columns. Works for Nodes, Pods, every typed kind, **and CRDs** (the dynamic watcher already injects labels).

## How

- **Labels already on rows.** The watcher injects `metadata.labels` as `__labels` on every row (typed + dynamic/CRD paths). Custom columns read from that map — near-zero backend.
- **Persistence reuses `TableView`.** New `label_columns: Vec<String>` field (`#[serde(default)]`, legacy files still parse), keyed `"<scope>::<kind_id>"` in `table_views.json`. No new Tauri command — `set_table_view` round-trips the whole view.
- **Ordering.** Custom columns slot in just before the trailing **Age** column so Age stays rightmost (anchors on the *last* age-kind column, so e.g. a Lease's "Renewed" keeps its place).
- **Auto-size to values.** Custom columns size to their cell values, not the often-longer label-derived header (which ellipsises). Built-in columns keep their header floor.
- **⋮ control** is the header's last flex child (`alignSelf: stretch`) → full header height by layout, no measurement.

## Bug fixed

The store pruned any `TableView` with empty sort + sizing — which would have **dropped a label-only view** on save. Prune now also checks `label_columns`.

## Tests

- Backend: `TableView` serde round-trip (legacy → empty vec; keyed file).
- `labelColumns` helpers: key universe, placement (before last Age), value-only width floor, `cellRaw`.
- `ColumnPicker`: render, toggle, reset (show/hide + fires), empty state, stale-key.
- Store prune carve-out; api `set_table_view` shape carries `label_columns`.

`cargo fmt`/`clippy`/`check --workspace` ✓ · `tsc -b` ✓ · vitest **1122/1122** ✓.

## Notes / not covered

- Not visually run (tests + typecheck only).
- H-scroll trade-off: on a too-narrow window where columns overflow, the ⋮ scrolls with the header rather than staying pinned.
- Helm release/chart rows are synthetic (no k8s labels) → empty picker there, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)