### PR TITLE
fix(rail): collapsible CRD groups + domain-hierarchy sort

### DIFF
--- a/ui/src/components/Rail.test.tsx
+++ b/ui/src/components/Rail.test.tsx
@@ -7,7 +7,7 @@
 // additional renders.
 
 import { describe, it, expect, afterEach } from "vitest";
-import { render, cleanup, act } from "@testing-library/react";
+import { render, cleanup, act, fireEvent } from "@testing-library/react";
 import { Profiler, type ProfilerOnRenderCallback } from "react";
 import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
 import { useAppStore } from "../store";
@@ -138,5 +138,133 @@ describe("Rail CRD discovery across active clusters", () => {
     });
     await act(async () => {});
     expect(useAppStore.getState().kindClusters).toEqual({});
+  });
+});
+
+describe("Rail CRD group expand/collapse + domain sort", () => {
+  const crd = (group: string, kind: string) => ({
+    id: `crd:${group}|v1|${kind.toLowerCase()}s|${kind}|ns`,
+    group,
+    version: "v1",
+    kind,
+    plural: `${kind.toLowerCase()}s`,
+    namespaced: true,
+    category: "CustomResources" as const,
+    columns: [],
+  });
+
+  // Three groups; auto.gke.io + gke.io share a family, cert-manager.io does
+  // not. A plain lexicographic sort would order these
+  // auto.gke.io / cert-manager.io / gke.io — splitting the gke family.
+  const AUTO = crd("auto.gke.io", "AutoPilot");
+  const CERT = crd("cert-manager.io", "Certificate");
+  const MANAGED = crd("gke.io", "Managed");
+  const GROUP_NAMES = ["auto.gke.io", "cert-manager.io", "gke.io"];
+
+  const mountRail = async () => {
+    setMockInvoke((cmd) => {
+      if (cmd === "list_resource_kinds") return [];
+      if (cmd === "list_custom_resource_kinds") return [AUTO, CERT, MANAGED];
+      return undefined;
+    });
+    act(() => {
+      useAppStore.setState({
+        contexts: [
+          {
+            id: "default::a",
+            name: "a",
+            cluster: "c",
+            user: null,
+            namespace: null,
+            is_current: false,
+            group: "Default",
+            source_id: "default",
+            source_path: null,
+          },
+        ],
+        virtualContexts: [{ id: "v1", name: "a", members: ["default::a"] }],
+        selectedVirtualContextId: "v1",
+        selectedContext: null,
+        scopeExtras: [],
+        selectedKindId: null,
+        railMode: "pinned",
+      });
+    });
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<Rail mode="dark" />));
+    });
+    await act(async () => {});
+    return container;
+  };
+
+  // Group headers are the <button>s whose text contains an API group name.
+  // Longest-match-first so "auto.gke.io" isn't mistaken for "gke.io".
+  const groupHeaders = (c: HTMLElement) =>
+    Array.from(c.querySelectorAll("button"))
+      .map((b) => {
+        const txt = b.textContent ?? "";
+        const name = [...GROUP_NAMES]
+          .sort((a, z) => z.length - a.length)
+          .find((g) => txt.includes(g));
+        return name ? { name, button: b } : null;
+      })
+      .filter((x): x is { name: string; button: HTMLButtonElement } => !!x);
+
+  const header = (c: HTMLElement, group: string) => {
+    const h = groupHeaders(c).find((x) => x.name === group);
+    if (!h) throw new Error(`no group header for ${group}`);
+    return h.button;
+  };
+
+  // A kind's row is the <button> whose trimmed text is exactly the kind name.
+  const kindVisible = (c: HTMLElement, kind: string) =>
+    Array.from(c.querySelectorAll("button")).some(
+      (b) => b.textContent?.trim() === kind,
+    );
+
+  it("orders group headers by domain hierarchy, keeping a family contiguous", async () => {
+    const c = await mountRail();
+    expect(groupHeaders(c).map((h) => h.name)).toEqual([
+      "cert-manager.io",
+      "gke.io",
+      "auto.gke.io",
+    ]);
+  });
+
+  it("expands a group on header click and collapses it again (round-trip)", async () => {
+    const c = await mountRail();
+    // Default: all groups collapsed.
+    expect(kindVisible(c, "Managed")).toBe(false);
+
+    await act(async () => {
+      fireEvent.click(header(c, "gke.io"));
+    });
+    expect(kindVisible(c, "Managed")).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(header(c, "gke.io"));
+    });
+    expect(kindVisible(c, "Managed")).toBe(false);
+  });
+
+  it("lets the operator collapse the group holding the current selection", async () => {
+    // Regression: previously `isOpen = expanded.has(g) || activeGroup === g`
+    // pinned the selected CRD's group permanently open, so the toggle
+    // silently no-op'd. The selected group now auto-expands but stays
+    // collapsible.
+    const c = await mountRail();
+    expect(kindVisible(c, "Managed")).toBe(false); // collapsed by default
+
+    // Real user path: select the CRD, which lives in the gke.io group.
+    await act(async () => {
+      useAppStore.getState().selectKind(MANAGED.id);
+    });
+    expect(kindVisible(c, "Managed")).toBe(true); // auto-expanded on selection
+
+    await act(async () => {
+      fireEvent.click(header(c, "gke.io"));
+    });
+    expect(kindVisible(c, "Managed")).toBe(false); // and can be hidden back
   });
 });

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -15,6 +15,7 @@ import {
   vibrantSurface,
 } from "../theme";
 import { IS_MAC } from "../lib/keyboard";
+import { compareApiGroups } from "../lib/crdGroups";
 import { ErrorBlock, Icons, Tooltip, resolveKindIcon } from "./ui";
 import { OpenClustersStrip } from "./OpenClustersStrip";
 
@@ -640,14 +641,34 @@ function CustomResourcesBody({
     arr.push(k);
     buckets.set(k.group, arr);
   }
-  const groupNames = Array.from(buckets.keys()).sort();
+  // Sort by domain hierarchy (root-first) so a vendor's groups stay
+  // contiguous — gke.io / auto.gke.io / node.gke.io group together instead
+  // of being split apart by an unrelated group that sorts between them
+  // lexicographically (e.g. cert-manager.io).
+  const groupNames = Array.from(buckets.keys()).sort(compareApiGroups);
 
   // Collapse state per group. Default: collapsed — busy clusters can have
   // 30+ CRDs across many vendors, so showing all of them by default makes
   // the rail unscannable. Auto-expand the group that contains the active
   // selection so the user always sees where they are.
   const activeGroup = dynamic.find((k) => k.id === selectedId)?.group ?? null;
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  // `expanded` is the single source of truth for which groups are open. Seed
+  // it with the active group so a restored/preselected CRD reveals its group
+  // on mount without a flash of collapsed state.
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    activeGroup ? new Set([activeGroup]) : new Set(),
+  );
+  // Auto-expand the group holding the selection, but only when the selection
+  // *moves* into a new group — never on every render. Folding this into
+  // `isOpen` (as `|| activeGroup === g`) pinned the selected group open and
+  // silently no-op'd the collapse toggle; seeding `expanded` instead lets the
+  // operator collapse it again afterward.
+  useEffect(() => {
+    if (!activeGroup) return;
+    setExpanded((prev) =>
+      prev.has(activeGroup) ? prev : new Set(prev).add(activeGroup),
+    );
+  }, [activeGroup]);
   const toggle = (g: string) =>
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -670,7 +691,7 @@ function CustomResourcesBody({
         />
       ))}
       {groupNames.map((g) => {
-        const isOpen = expanded.has(g) || activeGroup === g;
+        const isOpen = expanded.has(g);
         const groupItems = buckets.get(g) ?? [];
         return (
           <div key={g} style={{ marginTop: 4 }}>

--- a/ui/src/lib/crdGroups.test.ts
+++ b/ui/src/lib/crdGroups.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { compareApiGroups, sortApiGroups } from "./crdGroups";
+
+describe("compareApiGroups", () => {
+  it("keeps a shared domain family contiguous", () => {
+    // Plain .sort() would interleave cert-manager.io between the gke.io
+    // family; domain-hierarchy sort keeps gke.* together.
+    const groups = [
+      "cert-manager.io",
+      "node.gke.io",
+      "argoproj.io",
+      "gke.io",
+      "auto.gke.io",
+    ];
+    expect(sortApiGroups(groups)).toEqual([
+      "argoproj.io",
+      "cert-manager.io",
+      "gke.io",
+      "auto.gke.io",
+      "node.gke.io",
+    ]);
+  });
+
+  it("heads a family with its shortest (most general) parent group", () => {
+    expect(sortApiGroups(["auto.gke.io", "gke.io", "node.gke.io"])).toEqual([
+      "gke.io",
+      "auto.gke.io",
+      "node.gke.io",
+    ]);
+  });
+
+  it("orders by TLD first, then org", () => {
+    expect(sortApiGroups(["foo.example.com", "foo.example.io"])).toEqual([
+      "foo.example.com",
+      "foo.example.io",
+    ]);
+  });
+
+  it("is a total order — reflexive, and stable regardless of input order", () => {
+    expect(compareApiGroups("gke.io", "gke.io")).toBe(0);
+    const forward = sortApiGroups(["a.io", "b.io", "a.a.io"]);
+    const reversed = sortApiGroups(["a.a.io", "b.io", "a.io"]);
+    expect(forward).toEqual(reversed);
+  });
+
+  it("handles single-segment and empty groups without throwing", () => {
+    expect(sortApiGroups(["", "io", "gke.io"])).toEqual(["", "io", "gke.io"]);
+  });
+});

--- a/ui/src/lib/crdGroups.ts
+++ b/ui/src/lib/crdGroups.ts
@@ -1,0 +1,35 @@
+// Sorting Kubernetes API group names by domain hierarchy (root-first).
+//
+// CRD group names are reverse-DNS domains ("gke.io", "auto.gke.io",
+// "cert-manager.io"). A plain lexicographic sort interleaves unrelated
+// vendors between a shared family — e.g. "cert-manager.io" sorts between
+// "auto.gke.io" and "gke.io" — scattering related CRDs across the rail so
+// an operator can't scan a vendor's kinds in one place.
+//
+// Comparing by dot-segments in reverse (TLD first, then org, then
+// sub-group) keeps every group under a shared parent contiguous:
+//   gke.io, auto.gke.io, node.gke.io  →  grouped together under io › gke.
+// A shorter prefix sorts before its children ("gke.io" before
+// "auto.gke.io"), so the parent group heads its own family.
+
+/**
+ * Compare two API group names by domain hierarchy, root-first.
+ * Suitable as an `Array.prototype.sort` comparator.
+ */
+export function compareApiGroups(a: string, b: string): number {
+  if (a === b) return 0;
+  const ra = a.split(".").reverse();
+  const rb = b.split(".").reverse();
+  const n = Math.min(ra.length, rb.length);
+  for (let i = 0; i < n; i++) {
+    const c = ra[i]!.localeCompare(rb[i]!);
+    if (c !== 0) return c;
+  }
+  // Shared prefix: the shorter (more general) group heads its family.
+  return ra.length - rb.length;
+}
+
+/** Return a new array of API group names ordered by domain hierarchy. */
+export function sortApiGroups(groups: readonly string[]): string[] {
+  return [...groups].sort(compareApiGroups);
+}


### PR DESCRIPTION
## Problem

Two bugs in the **Custom Resources** rail:

1. **Can't collapse a CRD group back.** Once a CRD was selected, its group stayed pinned open — the caret rotated but the body wouldn't hide.
2. **CRD groups sorted lexicographically**, splitting a vendor's family. With many CRDs, `cert-manager.io` sorts *between* `auto.gke.io` and `gke.io`, scattering related kinds across the list.

## Fix

**Collapse** (`Rail.tsx`): `isOpen` used `expanded.has(g) || activeGroup === g` — the `||` overrode any collapse for the selected group. Now `expanded` is the single source of truth; a `useEffect` auto-expands the active group only when the selection *moves* into a new group, so it stays collapsible.

**Sort** (`ui/src/lib/crdGroups.ts`): new `compareApiGroups` reverses dot-segments (TLD → org → sub-group) so a domain family stays contiguous and the parent group heads it:

```
cert-manager.io
gke.io
  auto.gke.io
  node.gke.io
```

## Tests

- `crdGroups.test.ts` — family contiguity, parent-first, TLD-priority, total-order/stability, empty/single-segment.
- `Rail.test.tsx` — header domain order, expand↔collapse round-trip, and the regression: selected group auto-expands **and** stays collapsible.

Gate: `tsc --noEmit` clean, full frontend suite **1137/1137** pass. No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)