### PR TITLE
feat(pods): graceful single-pod eviction

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -22,18 +22,19 @@ use ferrisscope_core::sources::{
 use ferrisscope_core::ssh as ssh_keychain;
 use ferrisscope_core::table_views::{self, TableView, TableViewsFile};
 use ferrisscope_kube_ext::{
-    apply_resource, delete_resource, discover_crds, drain_node, get_cluster_role_binding_detail,
-    get_cluster_role_detail, get_config_map_detail, get_cron_job_detail,
-    get_custom_resource_definition_detail, get_custom_resource_detail, get_daemon_set_detail,
-    get_deployment_detail, get_endpoint_slice_detail, get_endpoints_detail, get_event_detail,
-    get_helm_chart_detail, get_helm_release_detail, get_horizontal_pod_autoscaler_detail,
-    get_ingress_class_detail, get_ingress_detail, get_job_detail, get_lease_detail,
-    get_limit_range_detail, get_mutating_webhook_configuration_detail, get_namespace_detail,
-    get_network_policy_detail, get_node_detail, get_persistent_volume_claim_detail,
-    get_persistent_volume_detail, get_pod_detail, get_pod_disruption_budget_detail,
-    get_priority_class_detail, get_replica_set_detail, get_replication_controller_detail,
-    get_resource_quota_detail, get_resource_yaml, get_role_binding_detail, get_role_detail,
-    get_secret_detail, get_service_account_detail, get_service_detail, get_stateful_set_detail,
+    apply_resource, delete_resource, discover_crds, drain_node, evict_pod,
+    get_cluster_role_binding_detail, get_cluster_role_detail, get_config_map_detail,
+    get_cron_job_detail, get_custom_resource_definition_detail, get_custom_resource_detail,
+    get_daemon_set_detail, get_deployment_detail, get_endpoint_slice_detail, get_endpoints_detail,
+    get_event_detail, get_helm_chart_detail, get_helm_release_detail,
+    get_horizontal_pod_autoscaler_detail, get_ingress_class_detail, get_ingress_detail,
+    get_job_detail, get_lease_detail, get_limit_range_detail,
+    get_mutating_webhook_configuration_detail, get_namespace_detail, get_network_policy_detail,
+    get_node_detail, get_persistent_volume_claim_detail, get_persistent_volume_detail,
+    get_pod_detail, get_pod_disruption_budget_detail, get_priority_class_detail,
+    get_replica_set_detail, get_replication_controller_detail, get_resource_quota_detail,
+    get_resource_yaml, get_role_binding_detail, get_role_detail, get_secret_detail,
+    get_service_account_detail, get_service_detail, get_stateful_set_detail,
     get_storage_class_detail, get_validating_webhook_configuration_detail, get_well_known_detail,
     helm_install_chart, helm_repo_update, helm_uninstall, helm_upgrade,
     list_config_maps_in_namespace, list_namespace_names,
@@ -2206,6 +2207,22 @@ pub(crate) async fn list_pods_on_node_cmd(
 ) -> Result<Vec<Value>, String> {
     let entry = state.entry(&cluster_id).await?;
     list_pods_on_node(entry.cluster.client(), &node)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Gracefully evict a single pod via the policy/v1 Eviction subresource
+/// (PDB-aware). A blocked eviction (429) surfaces as the apiserver's own
+/// disruption-budget message so the frontend can toast it verbatim.
+#[tauri::command]
+pub(crate) async fn evict_pod_cmd(
+    cluster_id: String,
+    namespace: String,
+    name: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let entry = state.entry(&cluster_id).await?;
+    evict_pod(entry.cluster.client(), &namespace, &name)
         .await
         .map_err(|e| e.to_string())
 }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -222,6 +222,7 @@ fn main() {
             commands::cordon_node_cmd,
             commands::drain_node_cmd,
             commands::list_pods_on_node_cmd,
+            commands::evict_pod_cmd,
             commands::restart_pod_cmd,
             commands::restart_pods_cmd,
             commands::restart_workload_cmd,

--- a/crates/kube-ext/src/fetch.rs
+++ b/crates/kube-ext/src/fetch.rs
@@ -2381,6 +2381,34 @@ pub async fn list_pods_on_node(client: Client, node: &str) -> Result<Vec<Value>,
     Ok(rows)
 }
 
+/// Evict a single pod via the policy/v1 Eviction subresource. Unlike a plain
+/// DELETE this is graceful *and* PDB-aware: the apiserver refuses with 429 if
+/// the eviction would violate a PodDisruptionBudget, which we surface as a
+/// `Conflict` carrying the apiserver's own reason rather than a bare kube
+/// string. The pod's owning controller (if any) reschedules a replacement;
+/// a bare pod is simply gone — same as `kubectl drain` treats it, but here the
+/// caller has already chosen the pod explicitly so we don't gate on `force`.
+pub async fn evict_pod(client: Client, namespace: &str, name: &str) -> Result<(), FetchError> {
+    let pods: Api<Pod> = Api::namespaced(client, namespace);
+    let ep = EvictParams::default();
+    match pods.evict(name, &ep).await {
+        Ok(_) => Ok(()),
+        // 404 == the pod is already gone (raced our list, or someone else
+        // deleted it). Eviction is idempotent from the operator's intent —
+        // the goal is "this pod off the node" and it already is. Report
+        // success rather than a scary NotFound.
+        Err(kube::Error::Api(status)) if status.code == 404 => Ok(()),
+        // 429 TooManyRequests == the eviction would breach a PDB. Surface the
+        // apiserver's explanation ("Cannot evict pod as it would violate the
+        // pod's disruption budget.") so the operator knows to retry later or
+        // scale up first, instead of an opaque error code.
+        Err(kube::Error::Api(status)) if status.code == 429 => {
+            Err(FetchError::Conflict(status.message))
+        }
+        Err(e) => Err(FetchError::Kube(e)),
+    }
+}
+
 // ── Multi-doc YAML apply (Create-from-YAML) ────────────────────────────────
 
 /// Per-document outcome from `apply_yaml`. The frontend renders a list of

--- a/crates/kube-ext/src/lib.rs
+++ b/crates/kube-ext/src/lib.rs
@@ -14,7 +14,7 @@ pub mod watcher;
 pub mod well_known;
 
 pub use fetch::{
-    apply_resource, apply_yaml, delete_resource, discover_crds, drain_node,
+    apply_resource, apply_yaml, delete_resource, discover_crds, drain_node, evict_pod,
     get_cluster_role_binding_detail, get_cluster_role_detail, get_config_map_detail,
     get_cron_job_detail, get_custom_resource_definition_detail, get_custom_resource_detail,
     get_daemon_set_detail, get_deployment_detail, get_endpoint_slice_detail, get_endpoints_detail,

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1246,10 +1246,39 @@ function buildPodBulkActions(
       },
     },
     {
+      // Graceful, PDB-aware bulk eviction. Sits ahead of Delete (raw DELETE)
+      // so the budget-respecting path is the first destructive option, and
+      // carries the divider that opens the destructive group.
+      icon: Icons.podDrain,
+      label: "Evict",
+      disabled: degraded,
+      separatorBefore: true,
+      danger: true,
+      onClick: () => {
+        void (async () => {
+          if (confirmDestructive) {
+            const ok = await confirm({
+              title: `Evict ${count} pod${count === 1 ? "" : "s"}?`,
+              body: `Graceful, PDB-aware eviction. A pod protected by a PodDisruptionBudget is refused (reported in the summary), not force-killed. Controller-owned pods reschedule; bare pods are gone.\n\n${summary}${more}`,
+              confirmLabel: "Evict",
+              tone: "danger",
+            });
+            if (!ok) return;
+          }
+          await runForAll("Evict", (m) => {
+            // Pods are namespaced; guard anyway so a malformed selection lands
+            // in the failure summary instead of a bad backend call.
+            if (!m.namespace)
+              return Promise.reject(new Error("pod has no namespace"));
+            return api.evictPod(m.clusterId, m.namespace, m.name);
+          });
+        })();
+      },
+    },
+    {
       icon: Icons.trash,
       label: "Delete",
       disabled: degraded,
-      separatorBefore: true,
       danger: true,
       onClick: () => {
         void (async () => {

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -442,6 +442,17 @@ describe("node operations", () => {
     expect(cap.calls[0]?.cmd).toBe("list_pods_on_node_cmd");
     expect(cap.calls[0]?.args).toEqual({ clusterId: "ctx", node: "worker-1" });
   });
+
+  it("evictPod → evict_pod_cmd with namespace + name", async () => {
+    const cap = captureNext(undefined);
+    await api.evictPod("ctx", "default", "api-0");
+    expect(cap.calls[0]?.cmd).toBe("evict_pod_cmd");
+    expect(cap.calls[0]?.args).toEqual({
+      clusterId: "ctx",
+      namespace: "default",
+      name: "api-0",
+    });
+  });
 });
 
 describe("pod / workload restart", () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -611,6 +611,13 @@ export const api = {
   listPodsOnNode: (clusterId: string, node: string) =>
     invoke<ResourceRow[]>("list_pods_on_node_cmd", { clusterId, node }),
 
+  // Gracefully evict a single pod (policy/v1 Eviction subresource, PDB-aware).
+  // Rejects with the apiserver's disruption-budget message when a PDB blocks
+  // it; unlike deleteResource this respects budgets and lets the owning
+  // controller reschedule a replacement.
+  evictPod: (clusterId: string, namespace: string, name: string) =>
+    invoke<void>("evict_pod_cmd", { clusterId, namespace, name }),
+
   // Trigger `kubectl rollout restart`-equivalent for the pod's owning
   // workload (Deployment/STS/DS). Returns [ownerKind, ownerName].
   restartPod: (clusterId: string, namespace: string, name: string) =>

--- a/ui/src/components/DetailPanel.tsx
+++ b/ui/src/components/DetailPanel.tsx
@@ -14,7 +14,16 @@ import type {
   ResourceKind,
   ResourceRow,
 } from "../types";
-import { FF_MONO, type ThemeMode, type Tokens, FS_LG, FS_MD, FS_SM, FS_XS } from "../theme";
+import {
+  FF_MONO,
+  type ThemeMode,
+  type Tokens,
+  FS_LG,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+  R_SM,
+} from "../theme";
 import {
   Chip,
   ContainerDots,
@@ -1837,6 +1846,13 @@ function PodSummary({
   detailVersion: number;
 }) {
   const t = useResolvedTheme().tokens;
+  // Honour the same "confirm destructive actions" setting the row menu / bulk
+  // bar respect, so the inline Evict button doesn't prompt when the user has
+  // opted out globally. Read before the early returns to keep hook order stable.
+  const confirmDestructive = useAppStore((s) => s.settings.confirmDestructive);
+  // Disable the inline Evict button while the cluster is unavailable / mid
+  // auto-reconnect — same gate the row menu and bulk bar use.
+  const degraded = useAppStore((s) => selectClusterDegraded(s, clusterId));
   const [state, setState] = useState<DetailState>({ kind: "loading" });
   const [refetch, setRefetch] = useState(0);
   const reqId = useRef(0);
@@ -2056,6 +2072,56 @@ function PodSummary({
             >
               {d.node}
             </LinkValue>
+            <button
+              type="button"
+              disabled={degraded}
+              onClick={() => {
+                if (degraded) return;
+                void (async () => {
+                  const ns = d.namespace;
+                  if (!ns) {
+                    toast.bad("Pod has no namespace — can't evict.");
+                    return;
+                  }
+                  if (confirmDestructive) {
+                    const ok = await confirm({
+                      title: `Evict pod ${ns}/${d.name}?`,
+                      body: `Graceful, PDB-aware eviction off node ${d.node}. Blocked if it would breach a PodDisruptionBudget. A controller-owned pod is rescheduled elsewhere; a bare pod is gone.`,
+                      confirmLabel: "Evict",
+                      tone: "danger",
+                    });
+                    if (!ok) return;
+                  }
+                  try {
+                    await api.evictPod(clusterId, ns, d.name);
+                    toast.ok(`Evicted pod ${ns}/${d.name}.`);
+                  } catch (e) {
+                    // 429 → apiserver's disruption-budget message, verbatim.
+                    toast.bad(`Evict failed: ${String(e)}`);
+                  }
+                })();
+              }}
+              title={
+                degraded
+                  ? "Cluster unavailable — can't evict right now"
+                  : "Evict this pod off the node (graceful, PDB-aware)"
+              }
+              style={{
+                marginLeft: 8,
+                fontFamily: FF_MONO,
+                fontSize: FS_XS,
+                color: degraded ? t.textMuted : t.bad,
+                background: "transparent",
+                border: `1px solid ${t.border}`,
+                borderRadius: R_SM,
+                padding: "1px 8px",
+                cursor: degraded ? "not-allowed" : "pointer",
+                opacity: degraded ? 0.5 : 1,
+                lineHeight: 1.6,
+              }}
+            >
+              Evict
+            </button>
           </DetailRow>
         )}
         {d.host_ips.length > 0 && (

--- a/ui/src/components/HeaderToast.tsx
+++ b/ui/src/components/HeaderToast.tsx
@@ -91,15 +91,20 @@ function HeaderToastCard({
     dismissToast(toast.id);
   };
 
+  // Hover tooltip keeps the strip single-line (per Helmsman) but still surfaces
+  // the body and the kube context this happened against; the full structured
+  // detail lives in the notifications panel behind the expand affordance.
+  const titleLines = [toast.text];
+  if (toast.body) titleLines.push(toast.body);
+  if (toast.meta?.context) titleLines.push(`Context: ${toast.meta.context}`);
+  titleLines.push("", "Click to open notifications");
+  const title = titleLines.join("\n");
+
   return (
     <button
       type="button"
       onClick={onCardClick}
-      title={
-        toast.body
-          ? `${toast.text}\n${toast.body}\n\nClick to open notifications`
-          : "Click to open notifications"
-      }
+      title={title}
       style={{
         display: "grid",
         gridTemplateColumns: queued > 0

--- a/ui/src/components/NotificationsPanel.test.tsx
+++ b/ui/src/components/NotificationsPanel.test.tsx
@@ -1,0 +1,59 @@
+// Notifications panel: a logged notification keeps its one-line headline but
+// hides structured context (kube context/cluster/namespace/kind/resource) behind
+// an expander. Bare notifications with nothing extra stay static (no toggle).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { NotificationsPanel } from "./NotificationsPanel";
+import { useAppStore } from "../store";
+import type { Notification } from "../store";
+
+function seed(notes: Notification[]) {
+  useAppStore.setState({ notificationsOpen: true, notifications: notes });
+}
+
+afterEach(cleanup);
+
+const withMeta: Notification = {
+  id: "n1",
+  tone: "ok",
+  text: "Evicted pod default/nginx-7f",
+  createdAt: 1_700_000_000_000,
+  meta: {
+    context: "prod-eu-1",
+    cluster: "gke_acme_prod",
+    namespace: "default",
+    kind: "Pod",
+    name: "nginx-7f",
+  },
+};
+
+describe("NotificationsPanel expandable rows", () => {
+  it("hides structured detail until the row is expanded", () => {
+    seed([withMeta]);
+    render(<NotificationsPanel mode="dark" />);
+
+    // Headline is always visible; the context detail is behind the expander.
+    expect(screen.getByText("Evicted pod default/nginx-7f")).toBeTruthy();
+    expect(screen.queryByText("prod-eu-1")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Evicted pod/ }));
+
+    // Now the structured rows and their labels are revealed.
+    expect(screen.getByText("Context")).toBeTruthy();
+    expect(screen.getByText("prod-eu-1")).toBeTruthy();
+    expect(screen.getByText("Namespace")).toBeTruthy();
+    expect(screen.getByText("default")).toBeTruthy();
+    // Absolute timestamp is appended to the detail box.
+    expect(screen.getByText("Time")).toBeTruthy();
+  });
+
+  it("shows no expander for a bare notification with no meta or body", () => {
+    seed([{ id: "n2", tone: "info", text: "plain notice", createdAt: 1 }]);
+    render(<NotificationsPanel mode="dark" />);
+
+    expect(screen.getByText("plain notice")).toBeTruthy();
+    // The headline is a static div, not a toggle button.
+    expect(screen.queryByRole("button", { name: /plain notice/ })).toBeNull();
+  });
+});

--- a/ui/src/components/NotificationsPanel.tsx
+++ b/ui/src/components/NotificationsPanel.tsx
@@ -1,7 +1,17 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useAppStore, useResolvedTheme } from "../store";
-import type { Notification } from "../store";
-import { FF_MONO, FONT_SANS, type ThemeMode, type Tokens, R_SM, FS_MD, FS_SM, FS_XS } from "../theme";
+import type { Notification, NotificationDetail, NotificationMeta } from "../store";
+import {
+  FF_MONO,
+  FONT_SANS,
+  type ThemeMode,
+  type Tokens,
+  R_SM,
+  R_MD,
+  FS_MD,
+  FS_SM,
+  FS_XS,
+} from "../theme";
 import { Btn, Eyebrow, IconBtn, Icons, EmptyState } from "./ui";
 
 type Props = { mode: ThemeMode };
@@ -115,7 +125,27 @@ export function NotificationsPanel({ mode }: Props) {
   );
 }
 
+// Flatten a notification's structured meta into an ordered label/value list.
+// Fixed order puts the operator's most-asked question first (which context /
+// cluster did this happen against), then resource identity, then the reason.
+// Empty fields are skipped; caller `extra` pairs append in their own order.
+function metaRows(m: NotificationMeta): NotificationDetail[] {
+  const out: NotificationDetail[] = [];
+  const push = (label: string, value?: string | null, mono?: boolean) => {
+    if (value != null && value !== "") out.push({ label, value, mono });
+  };
+  push("Context", m.context);
+  push("Cluster", m.cluster, true);
+  push("Namespace", m.namespace, true);
+  push("Kind", m.kind);
+  push("Resource", m.name, true);
+  push("Reason", m.reason, true);
+  if (m.extra) for (const d of m.extra) push(d.label, d.value, d.mono);
+  return out;
+}
+
 function Row({ t, n }: { t: Tokens; n: Notification }) {
+  const [open, setOpen] = useState(false);
   const accent =
     n.tone === "ok"
       ? t.good
@@ -124,6 +154,12 @@ function Row({ t, n }: { t: Tokens; n: Notification }) {
         : n.tone === "bad"
           ? t.bad
           : t.accent;
+
+  const rows = n.meta ? metaRows(n.meta) : [];
+  // Only rows with something to reveal get an expand affordance. A bare
+  // one-line toast with no meta and no body stays a static card.
+  const hasDetail = rows.length > 0 || !!n.body;
+
   return (
     <div
       style={{
@@ -145,33 +181,97 @@ function Row({ t, n }: { t: Tokens; n: Notification }) {
         }}
       />
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div
-          style={{
-            fontSize: FS_MD,
-            color: t.text,
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-word",
-            lineHeight: 1.5,
-            fontWeight: n.body ? 600 : 400,
-          }}
-        >
-          {n.text}
-        </div>
-        {n.body && (
-          <div
+        {hasDetail ? (
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            aria-expanded={open}
+            title={open ? "Collapse" : "Show detail"}
             style={{
-              marginTop: 4,
-              fontSize: FS_SM,
-              color: t.textDim,
-              fontFamily: FF_MONO,
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-              lineHeight: 1.45,
+              display: "grid",
+              gridTemplateColumns: "1fr auto",
+              alignItems: "start",
+              gap: 8,
+              width: "100%",
+              padding: 0,
+              border: "none",
+              background: "transparent",
+              textAlign: "left",
+              cursor: "pointer",
+              color: "inherit",
+              font: "inherit",
             }}
           >
-            {n.body}
+            <span
+              style={{
+                fontSize: FS_MD,
+                color: t.text,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                lineHeight: 1.5,
+                fontWeight: 600,
+              }}
+            >
+              {n.text}
+            </span>
+            <span
+              aria-hidden
+              style={{
+                display: "inline-flex",
+                color: t.textMuted,
+                marginTop: 2,
+                transition: "color .12s",
+              }}
+            >
+              {open ? Icons.chevD : Icons.chevR}
+            </span>
+          </button>
+        ) : (
+          <div
+            style={{
+              fontSize: FS_MD,
+              color: t.text,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              lineHeight: 1.5,
+            }}
+          >
+            {n.text}
           </div>
         )}
+
+        {open && hasDetail && (
+          <div
+            style={{
+              marginTop: 8,
+              padding: "8px 10px",
+              background: t.chip,
+              border: `1px solid ${t.borderSoft}`,
+              borderRadius: R_MD,
+              display: "grid",
+              gridTemplateColumns: "auto 1fr",
+              columnGap: 12,
+              rowGap: 5,
+              alignItems: "baseline",
+            }}
+          >
+            {rows.map((d, i) => (
+              <DetailLine key={`${d.label}-${i}`} t={t} d={d} />
+            ))}
+            <DetailLine
+              t={t}
+              d={{
+                label: "Time",
+                value: new Date(n.createdAt).toLocaleString(),
+                mono: true,
+              }}
+            />
+            {n.body && (
+              <DetailLine t={t} d={{ label: "Details", value: n.body, mono: true }} />
+            )}
+          </div>
+        )}
+
         <div
           style={{
             marginTop: 4,
@@ -184,6 +284,38 @@ function Row({ t, n }: { t: Tokens; n: Notification }) {
         </div>
       </div>
     </div>
+  );
+}
+
+// One label/value line inside the expanded detail box. Label column is dim and
+// nowrap; value wraps and is selectable so operators can copy it out.
+function DetailLine({ t, d }: { t: Tokens; d: NotificationDetail }) {
+  return (
+    <>
+      <span
+        style={{
+          fontSize: FS_XS,
+          color: t.textMuted,
+          fontFamily: FF_MONO,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {d.label}
+      </span>
+      <span
+        style={{
+          fontSize: FS_SM,
+          color: t.text,
+          fontFamily: d.mono ? FF_MONO : FONT_SANS,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          lineHeight: 1.45,
+          userSelect: "text",
+        }}
+      >
+        {d.value}
+      </span>
+    </>
   );
 }
 

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -1869,6 +1869,30 @@ function buildRowActionContext(
         }
       })();
     };
+    ctx.evict = () => {
+      void (async () => {
+        if (!ns) {
+          toast.bad("Pod has no namespace — can't evict.");
+          return;
+        }
+        if (confirmDestructive) {
+          const ok = await confirm({
+            title: `Evict pod ${qualified}?`,
+            body: "Graceful, PDB-aware eviction. Blocked if it would breach a PodDisruptionBudget. If owned by a controller it's rescheduled; a bare pod is gone.",
+            confirmLabel: "Evict",
+            tone: "danger",
+          });
+          if (!ok) return;
+        }
+        try {
+          await api.evictPod(clusterId, ns, name);
+          toast.ok(`Evicted pod ${qualified}.`);
+        } catch (e) {
+          // Surfaces the apiserver's disruption-budget message on a 429 block.
+          toast.bad(`Evict failed: ${String(e)}`);
+        }
+      })();
+    };
   } else if (kind.id === "nodes") {
     ctx.openExec = () => {
       openNodeDebugTab(clusterId, contextLabel, name, addDockTab);

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -1804,6 +1804,17 @@ function buildRowActionContext(
     openLogs: base.openLogs,
   };
 
+  // Structured notification detail for this row's actions. The active kube
+  // context/cluster is auto-attached by `emit`; here we add the resource
+  // identity (and, on failures, the raw error) so the notifications panel can
+  // show what was acted on and — for errors — the full apiserver message.
+  const rowMeta = (reason?: string) => ({
+    kind: kind.kind,
+    namespace: ns,
+    name,
+    ...(reason !== undefined ? { reason } : {}),
+  });
+
   if (kind.id === "pods") {
     ctx.openExec = () => {
       if (!ns) {
@@ -1840,9 +1851,9 @@ function buildRowActionContext(
         }
         try {
           await api.deleteResource(clusterId, "pods", ns, name, null);
-          toast.ok(`Deleted pod ${qualified}.`);
+          toast.ok(`Deleted pod ${qualified}.`, { meta: rowMeta() });
         } catch (e) {
-          toast.bad(`Delete failed: ${String(e)}`);
+          toast.bad(`Delete failed: ${String(e)}`, { meta: rowMeta(String(e)) });
         }
       })();
     };
@@ -1863,9 +1874,13 @@ function buildRowActionContext(
         }
         try {
           const [k, n] = await api.restartPod(clusterId, ns, name);
-          toast.ok(`Restarted ${k} ${ns}/${n}.`);
+          toast.ok(`Restarted ${k} ${ns}/${n}.`, {
+            meta: { kind: k, namespace: ns, name: n },
+          });
         } catch (e) {
-          toast.bad(`Restart failed: ${String(e)}`);
+          toast.bad(`Restart failed: ${String(e)}`, {
+            meta: rowMeta(String(e)),
+          });
         }
       })();
     };
@@ -1886,10 +1901,10 @@ function buildRowActionContext(
         }
         try {
           await api.evictPod(clusterId, ns, name);
-          toast.ok(`Evicted pod ${qualified}.`);
+          toast.ok(`Evicted pod ${qualified}.`, { meta: rowMeta() });
         } catch (e) {
           // Surfaces the apiserver's disruption-budget message on a 429 block.
-          toast.bad(`Evict failed: ${String(e)}`);
+          toast.bad(`Evict failed: ${String(e)}`, { meta: rowMeta(String(e)) });
         }
       })();
     };
@@ -1913,11 +1928,13 @@ function buildRowActionContext(
           }
           try {
             await api.cordonNode(clusterId, name, target);
-            toast.ok(target ? `Cordoned ${name}.` : `Uncordoned ${name}.`);
+            toast.ok(target ? `Cordoned ${name}.` : `Uncordoned ${name}.`, {
+              meta: rowMeta(),
+            });
           } catch (e) {
-            toast.bad(
-              `${target ? "Cordon" : "Uncordon"} failed: ${String(e)}`,
-            );
+            toast.bad(`${target ? "Cordon" : "Uncordon"} failed: ${String(e)}`, {
+              meta: rowMeta(String(e)),
+            });
           }
         })();
       },
@@ -1935,7 +1952,7 @@ function buildRowActionContext(
           const report = await api.drainNode(clusterId, name, false);
           summarizeDrain(name, report);
         } catch (e) {
-          toast.bad(`Drain failed: ${String(e)}`);
+          toast.bad(`Drain failed: ${String(e)}`, { meta: rowMeta(String(e)) });
         }
       })();
     };
@@ -1950,9 +1967,9 @@ function buildRowActionContext(
         if (!ok) return;
         try {
           await api.deleteResource(clusterId, "nodes", null, name, null);
-          toast.ok(`Deleted node ${name}.`);
+          toast.ok(`Deleted node ${name}.`, { meta: rowMeta() });
         } catch (e) {
-          toast.bad(`Delete failed: ${String(e)}`);
+          toast.bad(`Delete failed: ${String(e)}`, { meta: rowMeta(String(e)) });
         }
       })();
     };
@@ -1978,9 +1995,11 @@ function buildRowActionContext(
         }
         try {
           await api.deleteResource(clusterId, kind.id, ns, name, null);
-          toast.ok(`Uninstalled release ${qualified}.`);
+          toast.ok(`Uninstalled release ${qualified}.`, { meta: rowMeta() });
         } catch (e) {
-          toast.bad(`Uninstall failed: ${String(e)}`);
+          toast.bad(`Uninstall failed: ${String(e)}`, {
+            meta: rowMeta(String(e)),
+          });
         }
       })();
     };
@@ -2003,9 +2022,9 @@ function buildRowActionContext(
         }
         try {
           await api.deleteResource(clusterId, kind.id, ns, name, null);
-          toast.ok(`Deleted ${kindLabel} ${qualified}.`);
+          toast.ok(`Deleted ${kindLabel} ${qualified}.`, { meta: rowMeta() });
         } catch (e) {
-          toast.bad(`Delete failed: ${String(e)}`);
+          toast.bad(`Delete failed: ${String(e)}`, { meta: rowMeta(String(e)) });
         }
       })();
     };

--- a/ui/src/components/detail/cluster/index.tsx
+++ b/ui/src/components/detail/cluster/index.tsx
@@ -3,8 +3,13 @@
 // detailVersion bumps, compose shared primitives, dispatch from DetailPanel.
 
 import { logErr } from "../../../lib/log";
+import { confirm, toast } from "../../../lib/dialog";
 import { useEffect, useRef, useState } from "react";
-import { useResolvedTheme } from "../../../store";
+import {
+  selectClusterDegraded,
+  useAppStore,
+  useResolvedTheme,
+} from "../../../store";
 import { api, onResourceDelta } from "../../../api";
 import { FF_MONO, type ThemeMode, type Tokens, R_LG, R_SM, FS_MD, FS_SM, FS_XS } from "../../../theme";
 import {  } from "../../../theme";
@@ -693,6 +698,7 @@ function PodsOnNodeSection(props: {
               key={row.uid}
               t={t}
               mode={mode}
+              clusterId={props.clusterId}
               row={row}
               onNavigate={props.onNavigate}
             />
@@ -705,16 +711,23 @@ function PodsOnNodeSection(props: {
 function PodOnNodeRow({
   t,
   mode,
+  clusterId,
   row,
   onNavigate,
 }: {
   t: Tokens;
   mode: ThemeMode;
+  clusterId: string;
   row: ResourceRow;
   onNavigate?: DetailNavigate;
 }) {
   const name = String(row.name ?? "");
   const ns = typeof row.namespace === "string" ? row.namespace : null;
+  // Match the row menu / bulk bar: skip the prompt when the user has turned
+  // off destructive confirmations globally, and disable the button while the
+  // cluster is unavailable / mid auto-reconnect.
+  const confirmDestructive = useAppStore((s) => s.settings.confirmDestructive);
+  const degraded = useAppStore((s) => selectClusterDegraded(s, clusterId));
   const phase = typeof row.phase === "string" ? row.phase : "Unknown";
   const ready = typeof row.ready === "string" ? row.ready : "";
   const restarts =
@@ -723,6 +736,34 @@ function PodOnNodeRow({
       : Number(row.restarts) || 0;
   const created =
     typeof row.creation_timestamp === "string" ? row.creation_timestamp : null;
+
+  // Graceful, PDB-aware eviction of this pod off the node being inspected.
+  // The list is fed by live pod deltas, so a successful evict removes the row
+  // on its own (Terminating → delete) — no manual refetch here.
+  const doEvict = () => {
+    void (async () => {
+      if (!ns) {
+        toast.bad("Pod has no namespace — can't evict.");
+        return;
+      }
+      if (confirmDestructive) {
+        const ok = await confirm({
+          title: `Evict pod ${ns}/${name}?`,
+          body: "Graceful, PDB-aware eviction off this node. Blocked if it would breach a PodDisruptionBudget. A controller-owned pod is rescheduled elsewhere; a bare pod is gone.",
+          confirmLabel: "Evict",
+          tone: "danger",
+        });
+        if (!ok) return;
+      }
+      try {
+        await api.evictPod(clusterId, ns, name);
+        toast.ok(`Evicted pod ${ns}/${name}.`);
+      } catch (e) {
+        // 429 → apiserver's disruption-budget message, surfaced verbatim.
+        toast.bad(`Evict failed: ${String(e)}`);
+      }
+    })();
+  };
 
   return (
     <DetailRow t={t} label={ns ?? "—"}>
@@ -770,6 +811,35 @@ function PodOnNodeRow({
           {ageFromIso(created)}
         </span>
       )}
+      <button
+        type="button"
+        disabled={degraded}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (degraded) return;
+          doEvict();
+        }}
+        title={
+          degraded
+            ? "Cluster unavailable — can't evict right now"
+            : "Evict pod (graceful, PDB-aware)"
+        }
+        style={{
+          marginLeft: created ? 8 : "auto",
+          fontFamily: FF_MONO,
+          fontSize: FS_XS,
+          color: degraded ? t.textMuted : t.bad,
+          background: "transparent",
+          border: `1px solid ${t.border}`,
+          borderRadius: R_SM,
+          padding: "1px 8px",
+          cursor: degraded ? "not-allowed" : "pointer",
+          opacity: degraded ? 0.5 : 1,
+          lineHeight: 1.6,
+        }}
+      >
+        Evict
+      </button>
     </DetailRow>
   );
 }

--- a/ui/src/components/rowActions.test.ts
+++ b/ui/src/components/rowActions.test.ts
@@ -86,6 +86,29 @@ describe("actionsForRow — View logs availability", () => {
   });
 });
 
+describe("actionsForRow — Evict pod", () => {
+  it("pods with an evict callback surface a danger 'Evict pod' item", () => {
+    const ctx: RowActionContext = {
+      ...ctxFor(kindOf("pods", "Pod"), { containers: ["app"] }),
+      evict: vi.fn(),
+    };
+    const item = actionsForRow(ctx).find(
+      (i) => i.kind === "item" && i.label === "Evict pod",
+    );
+    expect(item).toBeTruthy();
+    expect(item!.kind === "item" && item!.danger).toBe(true);
+    if (item?.kind === "item") item.onClick();
+    expect(ctx.evict).toHaveBeenCalledOnce();
+  });
+
+  it("no 'Evict pod' item without the callback, and never for non-pods", () => {
+    expect(labels(ctxFor(kindOf("pods", "Pod")))).not.toContain("Evict pod");
+    expect(
+      labels({ ...ctxFor(kindOf("nodes", "Node")), evict: vi.fn() }),
+    ).not.toContain("Evict pod");
+  });
+});
+
 describe("actionsForRow — read-only gating", () => {
   // A pod ctx wired with every optional write callback so all mutating items
   // are present in the menu (they're only pushed when their callback exists).
@@ -95,6 +118,7 @@ describe("actionsForRow — read-only gating", () => {
     openYamlEdit: vi.fn(),
     openPortForward: vi.fn(),
     restart: vi.fn(),
+    evict: vi.fn(),
     delete: vi.fn(),
   });
 
@@ -108,6 +132,7 @@ describe("actionsForRow — read-only gating", () => {
   it("disables every write action when readOnly", () => {
     for (const label of [
       "Delete pod",
+      "Evict pod",
       "Restart pod",
       "Exec shell",
       "Edit YAML",

--- a/ui/src/components/rowActions.ts
+++ b/ui/src/components/rowActions.ts
@@ -11,6 +11,9 @@ export type RowActionContext = {
   openYamlEdit?: () => void;
   openPortForward?: () => void;
   restart?: () => void;
+  // Graceful, PDB-aware single-pod eviction (pods only). Distinct from
+  // `delete` (raw DELETE) — surfaces the disruption-budget block when present.
+  evict?: () => void;
   delete?: () => void;
   // Node-only operations. `cordon` is null when the node action makes no
   // sense (non-node row); when present, it carries the *target* state — i.e.
@@ -145,13 +148,23 @@ export function actionsForRow(
     onClick: () => copy(row.uid),
   });
 
-  if (kind.id === "pods" && (restart || ctx.delete)) {
+  if (kind.id === "pods" && (restart || ctx.evict || ctx.delete)) {
     items.push({ kind: "separator" });
     if (restart)
       items.push({
         kind: "item",
         label: "Restart pod",
         onClick: restart,
+        disabled: readOnly,
+      });
+    // Evict = graceful, PDB-aware. Sits above Delete (raw DELETE) so the
+    // budget-respecting path is the first destructive option operators reach.
+    if (ctx.evict)
+      items.push({
+        kind: "item",
+        label: "Evict pod",
+        onClick: ctx.evict,
+        danger: true,
         disabled: readOnly,
       });
     if (ctx.delete)

--- a/ui/src/lib/dialog.test.ts
+++ b/ui/src/lib/dialog.test.ts
@@ -102,3 +102,50 @@ describe("toast", () => {
     expect(useAppStore.getState().notifications).toHaveLength(1);
   });
 });
+
+describe("toast meta (active-context auto-capture)", () => {
+  const activeContext = {
+    id: "ctx-1",
+    name: "prod-eu-1",
+    cluster: "gke_acme_prod",
+    user: null,
+    namespace: null,
+    is_current: true,
+    group: "",
+    source_id: "src",
+    source_path: null,
+  };
+
+  it("no active context → no meta on the toast", () => {
+    // beforeEach already reset selectedContext/contexts to their (null/empty)
+    // initial values, so a plain toast stays meta-free.
+    toast.ok("saved");
+    expect(useAppStore.getState().toasts[0]?.meta).toBeUndefined();
+  });
+
+  it("auto-attaches the active context + cluster when one is selected", () => {
+    useAppStore.setState({
+      selectedContext: "ctx-1",
+      contexts: [activeContext],
+    });
+    toast.ok("saved");
+    const meta = useAppStore.getState().toasts[0]?.meta;
+    expect(meta?.context).toBe("prod-eu-1");
+    expect(meta?.cluster).toBe("gke_acme_prod");
+  });
+
+  it("caller-supplied meta wins per-field over the auto-captured context", () => {
+    useAppStore.setState({
+      selectedContext: "ctx-1",
+      contexts: [activeContext],
+    });
+    toast.bad("Evict failed", {
+      meta: { context: "staging", namespace: "kube-system", reason: "boom" },
+    });
+    const meta = useAppStore.getState().toasts[0]?.meta;
+    expect(meta?.context).toBe("staging"); // caller override
+    expect(meta?.cluster).toBe("gke_acme_prod"); // filled from active context
+    expect(meta?.namespace).toBe("kube-system");
+    expect(meta?.reason).toBe("boom");
+  });
+});

--- a/ui/src/lib/dialog.ts
+++ b/ui/src/lib/dialog.ts
@@ -3,7 +3,7 @@
 // window.alert.
 
 import { useAppStore } from "../store";
-import type { Toast, ToastTone } from "../store";
+import type { NotificationMeta, Toast, ToastTone } from "../store";
 import type { SettingsTarget } from "../types";
 
 export type ConfirmOpts = {
@@ -41,11 +41,45 @@ const DEFAULT_TOAST_MS: Record<ToastTone, number> = {
 
 /// Extra, optional toast behaviour. `route` deep-links the toast (and its
 /// notification-log entry) to a Settings target instead of the notifications
-/// panel — see `Toast.route`.
+/// panel — see `Toast.route`. `meta` carries structured context for the
+/// NotificationsPanel's expanded row (see `Toast.meta`); the active kube
+/// context/cluster is auto-captured when the caller doesn't supply them.
 export type ToastOptions = {
   durationMs?: number;
   route?: SettingsTarget;
+  meta?: NotificationMeta;
 };
+
+// Merge the caller's `meta` over the active kube context/cluster resolved from
+// the live store. Caller-supplied fields win. Returns `undefined` when nothing
+// is populated so plain toasts stay meta-free (no expand affordance, existing
+// tests/rows unchanged). Kept side-effect free beyond the one `getState()` read
+// so it's callable from any (non-React) context, like the rest of this module.
+function resolveMeta(callerMeta?: NotificationMeta): NotificationMeta | undefined {
+  const s = useAppStore.getState();
+  const active =
+    s.selectedContext != null
+      ? (s.contexts.find((c) => c.id === s.selectedContext) ?? null)
+      : null;
+  const merged: NotificationMeta = {
+    context: callerMeta?.context ?? active?.name ?? undefined,
+    cluster: callerMeta?.cluster ?? active?.cluster ?? undefined,
+    namespace: callerMeta?.namespace ?? undefined,
+    kind: callerMeta?.kind ?? undefined,
+    name: callerMeta?.name ?? undefined,
+    reason: callerMeta?.reason ?? undefined,
+    extra: callerMeta?.extra,
+  };
+  const hasField =
+    merged.context != null ||
+    merged.cluster != null ||
+    merged.namespace != null ||
+    merged.kind != null ||
+    merged.name != null ||
+    merged.reason != null ||
+    (merged.extra?.length ?? 0) > 0;
+  return hasField ? merged : undefined;
+}
 
 function emit(tone: ToastTone, text: string, opts?: ToastOptions): string {
   const id = makeId();
@@ -63,6 +97,7 @@ function emit(tone: ToastTone, text: string, opts?: ToastOptions): string {
     body,
     durationMs: opts?.durationMs ?? DEFAULT_TOAST_MS[tone],
     route: opts?.route,
+    meta: resolveMeta(opts?.meta),
   };
   useAppStore.getState().pushToast(toast);
   return id;

--- a/ui/src/lib/log.test.ts
+++ b/ui/src/lib/log.test.ts
@@ -32,13 +32,20 @@ describe("reportErr", () => {
     warn.mockRestore();
   });
 
-  it("logs and pushes a warn toast with headline + error body", () => {
+  it("logs and pushes a warn toast with headline + structured error reason", () => {
     reportErr("prefs", "Couldn't load preferences")(new Error("disk on fire"));
     expect(warn).toHaveBeenCalledTimes(1);
     const toasts = useAppStore.getState().toasts;
     expect(toasts).toHaveLength(1);
     expect(toasts[0]?.tone).toBe("warn");
+    // Headline stays clean; the raw error moves into structured meta so the
+    // notifications panel can show it in the expanded row.
     expect(toasts[0]?.text).toBe("Couldn't load preferences");
-    expect(toasts[0]?.body).toContain("disk on fire");
+    expect(toasts[0]?.meta?.reason).toContain("disk on fire");
+    expect(toasts[0]?.meta?.extra).toContainEqual({
+      label: "Scope",
+      value: "prefs",
+      mono: true,
+    });
   });
 });

--- a/ui/src/lib/log.ts
+++ b/ui/src/lib/log.ts
@@ -18,8 +18,9 @@ export function logErr(scope: string): (e: unknown) => void {
 /**
  * `.catch` sink that logs AND shows a warn toast. For data flows whose
  * silent failure strands the operator (prefs, saved views, restored
- * port-forwards): the headline says what's missing, the body carries
- * the raw error for the notifications panel.
+ * port-forwards): the headline says what's missing, and the raw error is
+ * carried as structured `reason` (plus the scope tag) so the operator can
+ * expand the notification and read the full failure.
  */
 export function reportErr(
   scope: string,
@@ -28,6 +29,11 @@ export function reportErr(
   return (e) => {
     // eslint-disable-next-line no-console
     console.warn(`[${scope}]`, e);
-    toast.warn(`${headline}\n${String(e)}`);
+    toast.warn(headline, {
+      meta: {
+        reason: String(e),
+        extra: [{ label: "Scope", value: scope, mono: true }],
+      },
+    });
   };
 }

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -243,6 +243,25 @@ describe("toasts + notifications cap", () => {
     expect(s.notifications[0]?.id).toBe("n5");
   });
 
+  it("copies structured meta from the toast into the notification log entry", () => {
+    const meta = {
+      context: "prod-eu-1",
+      cluster: "gke_acme_prod",
+      namespace: "default",
+      kind: "Pod",
+      name: "nginx-7f",
+    };
+    useAppStore.getState().pushToast({ ...t("m"), meta });
+    const note = useAppStore.getState().notifications[0];
+    expect(note?.meta).toEqual(meta);
+    // Bare toast (no meta) leaves the log entry meta-free.
+    useAppStore.getState().pushToast(t("plain"));
+    const plain = useAppStore
+      .getState()
+      .notifications.find((x) => x.id === "plain");
+    expect(plain?.meta).toBeUndefined();
+  });
+
   it("carries a routed toast's route into both the toast and the notification log", () => {
     const routed: Toast = {
       id: "upd",

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -120,6 +120,27 @@ export type ConfirmModal = {
 };
 
 export type ToastTone = "info" | "ok" | "warn" | "bad";
+
+// One free-form label/value pair shown in a notification's expanded detail.
+// `mono` renders the value monospaced (ids, names, error text).
+export type NotificationDetail = { label: string; value: string; mono?: boolean };
+
+// Structured context for a notification, surfaced only in the expanded row of
+// the NotificationsPanel (never in the one-line toast/headline). The active
+// kube `context`/`cluster` are auto-captured at emit time (see lib/dialog.ts);
+// richer call sites add namespace/kind/name/reason. All fields optional so the
+// common toast keeps working; a notification with no populated field carries no
+// `meta` at all (the viewer then shows no expand affordance).
+export type NotificationMeta = {
+  context?: string | null; // kube context display name (ContextInfo.name)
+  cluster?: string | null; // kubeconfig cluster (ContextInfo.cluster)
+  namespace?: string | null;
+  kind?: string | null;
+  name?: string | null;
+  reason?: string | null; // event reason / raw error text
+  extra?: NotificationDetail[]; // arbitrary extras (ports, versions…)
+};
+
 export type Toast = {
   id: string;
   tone: ToastTone;
@@ -133,6 +154,8 @@ export type Toast = {
   // opens Settings at this target instead of the notifications panel. Used by
   // the "update available" toast to jump straight to About → What's new.
   route?: SettingsTarget;
+  // Structured context surfaced only in the NotificationsPanel expanded row.
+  meta?: NotificationMeta;
 };
 
 // Persistent in-memory copy of every toast ever pushed (per session). Toasts
@@ -147,6 +170,9 @@ export type Notification = {
   // Mirrors `Toast.route` so a logged notification stays clickable after its
   // toast auto-dismisses (e.g. the update notice deep-links to About).
   route?: SettingsTarget;
+  // Mirrors `Toast.meta` — structured detail shown when the operator expands
+  // this entry in the NotificationsPanel.
+  meta?: NotificationMeta;
 };
 
 export const NOTIFICATION_LOG_CAP = 50;
@@ -1591,6 +1617,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         body: toast.body,
         createdAt: Date.now(),
         route: toast.route,
+        meta: toast.meta,
       };
       const next = [...s.notifications, note];
       // Drop oldest if over the cap so the log stays bounded.


### PR DESCRIPTION
## What

Adds **PDB-aware pod eviction** (policy/v1 Eviction subresource), distinct from the existing raw DELETE. Exposed on four surfaces:

- **Pod row context menu** — "Evict pod", sits above "Delete pod" (graceful option first)
- **Selection bulk bar** — "Evict" action (icon `podDrain`), ahead of Delete; per-pod failure isolation via `runForAll`, PDB-blocked pods land in the aggregated toast
- **Node detail → Pods-on-node list** — per-row Evict button (evict a pod off the node you're inspecting)
- **Pod detail → Node row** — inline Evict button next to the node name

## Evict vs Delete

Both terminate the pod, but **evict respects PodDisruptionBudgets** — the apiserver refuses (429) if it would breach `minAvailable`. Delete never asks. That's why Evict is the first destructive option in each menu.

## Backend

- `fetch::evict_pod(client, ns, name)` → `Api::<Pod>::evict()` (same API `drain_node` uses)
- `evict_pod_cmd` (Tauri), registered in `main.rs`, re-exported from `lib.rs`
- **429** (PDB block) → surfaces the apiserver's own message verbatim (`Cannot evict pod as it would violate the pod's disruption budget.`)
- **404** → idempotent success (pod already gone = goal met)

## Consistency

All four surfaces:
- honour the `confirmDestructive` setting
- disable while the cluster is degraded / mid auto-reconnect
- ns-null guard, try/catch → toast

## Tests

- `api.test.ts` — `evict_pod_cmd` wire shape
- `rowActions.test.ts` — menu item presence, danger flag, callback fire, readOnly gating, absent for non-pods

`cargo fmt --check` clean · `cargo check` + `clippy` clean · `tsc` clean · vitest green.

## Not covered (flagged)

- `buildPodBulkActions` + detail buttons have no dedicated unit test — App.tsx / DetailPanel are Tauri-coupled and not unit-test-loadable (sibling Delete/Restart bulk actions are untested for the same reason). Core `api.evictPod` wire is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)