### PR TITLE
feat(ai): catalogue-driven model listing (models.dev)

### DIFF
--- a/crates/agent/src/provider/anthropic.rs
+++ b/crates/agent/src/provider/anthropic.rs
@@ -226,6 +226,13 @@ impl ChatProvider for AnthropicProvider {
                 return Err(ProviderError::Auth(body));
             }
         }
+        // Live `/models` unreachable. Prefer the models.dev catalogue
+        // (stays fresh across releases), then the curated static list as
+        // the offline / cold-start fallback so the picker is never empty.
+        let cat = crate::provider::catalogue::list_models(crate::config::ProviderKind::Anthropic);
+        if !cat.is_empty() {
+            return Ok(cat);
+        }
         Ok(meta::static_models(crate::config::ProviderKind::Anthropic)
             .iter()
             .map(|(id, name)| ModelInfo {

--- a/crates/agent/src/provider/catalogue.rs
+++ b/crates/agent/src/provider/catalogue.rs
@@ -23,6 +23,7 @@
 
 use crate::config::ProviderKind;
 use crate::provider::meta;
+use crate::provider::ModelInfo;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -86,6 +87,13 @@ struct Catalogue {
     cost_by_id: HashMap<(String, String), f64>,
     /// (provider_models_dev_id, model_id) → capability flags.
     caps_by_id: HashMap<(String, String), ModelCapabilities>,
+    /// provider_models_dev_id → the provider's full model list, as the
+    /// picker's source of truth. Populated from the same parse as the
+    /// lookup maps above. `list_models` reads this; the per-provider
+    /// `ChatProvider::list_models` impls fall back to it when their live
+    /// `/models` call fails (and use it as the *primary* source for
+    /// providers with no live endpoint — Codex OAuth, Z.AI, MiniMax).
+    models_by_provider: HashMap<String, Vec<ModelInfo>>,
     fetched_unix_ms: i64,
 }
 
@@ -105,6 +113,10 @@ struct ProviderEntry {
 
 #[derive(Debug, Deserialize)]
 struct ModelEntry {
+    /// Human-readable display name (models.dev `name`). Surfaced in the
+    /// picker as `id — name`. Absent → picker shows the bare id.
+    #[serde(default)]
+    name: Option<String>,
     #[serde(default)]
     limit: Option<ModelLimitJson>,
     #[serde(default)]
@@ -244,11 +256,12 @@ pub async fn load_from_disk(cache_root: PathBuf) {
     let Ok(resp) = serde_json::from_slice::<ApiResponse>(&bytes) else {
         return;
     };
-    let (next, next_cost, next_caps) = parse_catalogue(resp);
+    let (next, next_cost, next_caps, next_models) = parse_catalogue(resp);
     let mut g = slot().write().await;
     g.by_id = next;
     g.cost_by_id = next_cost;
     g.caps_by_id = next_caps;
+    g.models_by_provider = next_models;
     g.fetched_unix_ms = chrono::Utc::now().timestamp_millis();
     tracing::debug!(count = g.by_id.len(), "models.dev: loaded from disk cache");
 }
@@ -294,12 +307,13 @@ pub async fn refresh(cache_root: PathBuf) {
         }
     };
 
-    let (next, next_cost, next_caps) = parse_catalogue(parsed);
+    let (next, next_cost, next_caps, next_models) = parse_catalogue(parsed);
     {
         let mut g = slot().write().await;
         g.by_id = next;
         g.cost_by_id = next_cost;
         g.caps_by_id = next_caps;
+        g.models_by_provider = next_models;
         g.fetched_unix_ms = chrono::Utc::now().timestamp_millis();
         tracing::info!(count = g.by_id.len(), "models.dev: refreshed");
     }
@@ -317,18 +331,29 @@ type CatalogueMaps = (
     HashMap<(String, String), ModelLimits>,
     HashMap<(String, String), f64>,
     HashMap<(String, String), ModelCapabilities>,
+    HashMap<String, Vec<ModelInfo>>,
 );
 
 fn parse_catalogue(resp: ApiResponse) -> CatalogueMaps {
     let mut by_id = HashMap::new();
     let mut cost_by_id = HashMap::new();
     let mut caps_by_id = HashMap::new();
+    let mut models_by_provider: HashMap<String, Vec<ModelInfo>> = HashMap::new();
     for (provider_id, entry) in resp.0 {
         for (model_id, m) in entry.models {
             let key = (provider_id.clone(), model_id.clone());
+            let context_length = parse_limits(m.limit.as_ref()).map(|l| l.context);
             if let Some(limits) = parse_limits(m.limit.as_ref()) {
                 by_id.insert(key.clone(), limits);
             }
+            models_by_provider
+                .entry(provider_id.clone())
+                .or_default()
+                .push(ModelInfo {
+                    id: model_id.clone(),
+                    name: m.name.clone(),
+                    context_length,
+                });
             if let Some(c) = m.cost.as_ref().and_then(|c| c.input) {
                 cost_by_id.insert(key.clone(), c.max(0.0));
             }
@@ -363,7 +388,15 @@ fn parse_catalogue(resp: ApiResponse) -> CatalogueMaps {
     by_id.shrink_to_fit();
     cost_by_id.shrink_to_fit();
     caps_by_id.shrink_to_fit();
-    (by_id, cost_by_id, caps_by_id)
+    // Sort each provider's list once here (read-mostly afterwards) so
+    // `list_models` is a cheap clone. Same default ordering the call
+    // sites already apply to ids downstream.
+    for models in models_by_provider.values_mut() {
+        sort_model_infos(models);
+        models.shrink_to_fit();
+    }
+    models_by_provider.shrink_to_fit();
+    (by_id, cost_by_id, caps_by_id, models_by_provider)
 }
 
 /// Per-model capability lookup. Returns `None` when models.dev hasn't
@@ -411,23 +444,48 @@ const DEFAULT_PRIORITY: &[&str] = &["gpt-5", "claude-sonnet-4", "big-pickle", "g
 /// in the id, then alphabetical descending so newer-versioned ids
 /// (`*-2026-…`) come ahead of older ones at the tail.
 pub fn sort_for_default<T: AsRef<str>>(models: &mut [T]) {
-    models.sort_by(|a, b| {
-        let ai = priority_index(a.as_ref());
-        let bi = priority_index(b.as_ref());
-        // Higher index wins (opencode's `desc`). Models that don't match
-        // any priority entry get -1 and lose to anything that does.
-        bi.cmp(&ai)
-            .then_with(|| {
-                // "latest" first (asc on the boolean — false sorts before
-                // true, so we negate by mapping latest→0 and other→1).
-                latest_rank(a.as_ref()).cmp(&latest_rank(b.as_ref()))
-            })
-            .then_with(|| {
-                // Alphabetical descending among ties so newer date-tagged
-                // ids show up first.
-                b.as_ref().cmp(a.as_ref())
-            })
-    });
+    models.sort_by(|a, b| default_order(a.as_ref(), b.as_ref()));
+}
+
+/// The default-model comparator, keyed on a model id. Shared by
+/// `sort_for_default` (id lists at the call sites) and `sort_model_infos`
+/// (the `ModelInfo` lists stored in the catalogue) so both orderings stay
+/// identical.
+fn default_order(a: &str, b: &str) -> std::cmp::Ordering {
+    let ai = priority_index(a);
+    let bi = priority_index(b);
+    // Higher index wins (opencode's `desc`). Models that don't match
+    // any priority entry get -1 and lose to anything that does.
+    bi.cmp(&ai)
+        .then_with(|| latest_rank(a).cmp(&latest_rank(b)))
+        .then_with(|| b.cmp(a))
+}
+
+/// Sort a `ModelInfo` list by the default ordering (keyed on id). Applied
+/// once per catalogue refresh so `list_models` stays a cheap clone.
+fn sort_model_infos(models: &mut [ModelInfo]) {
+    models.sort_by(|a, b| default_order(&a.id, &b.id));
+}
+
+/// A provider's full model list from models.dev, pre-sorted by the
+/// default ordering. Empty when the catalogue hasn't loaded yet, the
+/// lock is contended, or `kind` has no models.dev id (e.g. Ollama —
+/// local models aren't in the catalogue). Callers treat empty as "fall
+/// back to my own source" (live `/models` or the static list).
+pub fn list_models(kind: ProviderKind) -> Vec<ModelInfo> {
+    let Some(mdid) = meta::models_dev_id(kind) else {
+        return Vec::new();
+    };
+    let Ok(g) = slot().try_read() else {
+        return Vec::new();
+    };
+    models_for(&g.models_by_provider, mdid)
+}
+
+/// Pure lookup + clone, split from `list_models` so it's unit-testable
+/// without seeding the global slot. Stored vecs are already sorted.
+fn models_for(map: &HashMap<String, Vec<ModelInfo>>, mdid: &str) -> Vec<ModelInfo> {
+    map.get(mdid).cloned().unwrap_or_default()
 }
 
 fn priority_index(id: &str) -> i32 {
@@ -521,7 +579,7 @@ mod tests {
             }
         });
         let resp: ApiResponse = serde_json::from_value(raw).unwrap();
-        let (_limits, _cost, caps) = parse_catalogue(resp);
+        let (_limits, _cost, caps, _models) = parse_catalogue(resp);
         let reasoner = caps
             .get(&("deepseek".to_string(), "deepseek-reasoner".to_string()))
             .expect("deepseek-reasoner caps");
@@ -557,7 +615,7 @@ mod tests {
             }
         });
         let resp: ApiResponse = serde_json::from_value(raw).unwrap();
-        let (_limits, _cost, caps) = parse_catalogue(resp);
+        let (_limits, _cost, caps, _models) = parse_catalogue(resp);
         assert!(
             caps.get(&("anthropic".to_string(), "claude-opus".to_string()))
                 .unwrap()
@@ -592,12 +650,50 @@ mod tests {
             }
         });
         let resp: ApiResponse = serde_json::from_value(raw).unwrap();
-        let (_limits, _cost, caps) = parse_catalogue(resp);
+        let (_limits, _cost, caps, _models) = parse_catalogue(resp);
         let m = caps
             .get(&("openai".to_string(), "legacy".to_string()))
             .expect("legacy caps");
         // Bare `interleaved: true` is parsed but ignored — we only act
         // when the field name is supplied.
         assert!(m.interleaved_field.is_none());
+    }
+
+    #[test]
+    fn parse_catalogue_builds_model_list_with_names_and_context() {
+        let raw = serde_json::json!({
+            "zai": {
+                "models": {
+                    "glm-4.5": { "name": "GLM-4.5", "limit": { "context": 128000 } },
+                    "glm-4.6": { "name": "GLM-4.6", "limit": { "context": 200000 } },
+                }
+            }
+        });
+        let resp: ApiResponse = serde_json::from_value(raw).unwrap();
+        let (_l, _c, _caps, models) = parse_catalogue(resp);
+        let list = models_for(&models, "zai");
+        assert_eq!(list.len(), 2);
+        // Display name + context window carried from the catalogue.
+        let glm46 = list.iter().find(|m| m.id == "glm-4.6").expect("glm-4.6");
+        assert_eq!(glm46.name.as_deref(), Some("GLM-4.6"));
+        assert_eq!(glm46.context_length, Some(200_000));
+        // Pre-sorted by the default ordering: neither id matches the
+        // priority list nor "latest", so alphabetical-descending wins and
+        // the newer 4.6 sorts ahead of 4.5.
+        assert_eq!(list[0].id, "glm-4.6");
+        assert_eq!(list[1].id, "glm-4.5");
+    }
+
+    #[test]
+    fn models_for_unknown_provider_is_empty() {
+        let map: HashMap<String, Vec<ModelInfo>> = HashMap::new();
+        assert!(models_for(&map, "nope").is_empty());
+    }
+
+    #[test]
+    fn list_models_empty_for_provider_without_models_dev_id() {
+        // Ollama serves local models absent from models.dev — no id, so
+        // the catalogue never supplies a list (caller stays on live).
+        assert!(list_models(ProviderKind::Ollama).is_empty());
     }
 }

--- a/crates/agent/src/provider/meta.rs
+++ b/crates/agent/src/provider/meta.rs
@@ -243,9 +243,15 @@ pub fn models_dev_id(kind: ProviderKind) -> Option<&'static str> {
         ProviderKind::Deepseek => "deepseek",
         ProviderKind::Mistral => "mistral",
         ProviderKind::Together => "togetherai",
-        // Z.AI / MiniMax / Ollama aren't reliably on models.dev — fall
-        // through to per-provider defaults.
-        ProviderKind::Zai | ProviderKind::Minimax | ProviderKind::Ollama => return None,
+        // Z.AI / MiniMax are on models.dev under their bare ids — this
+        // both drives the catalogue-backed model list (their live
+        // endpoints aren't enumerable) and enables context-window /
+        // capability enrichment for them.
+        ProviderKind::Zai => "zai",
+        ProviderKind::Minimax => "minimax",
+        // Ollama serves local models that aren't in models.dev — keep it
+        // on the live `/models` path.
+        ProviderKind::Ollama => return None,
     })
 }
 
@@ -284,5 +290,25 @@ pub fn static_models(kind: ProviderKind) -> &'static [(&'static str, &'static st
             ("gpt-5.2", "GPT-5.2"),
         ],
         _ => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn models_dev_id_maps_zai_and_minimax() {
+        // These drive catalogue-backed model lists (no enumerable live
+        // endpoint) plus context/capability enrichment.
+        assert_eq!(models_dev_id(ProviderKind::Zai), Some("zai"));
+        assert_eq!(models_dev_id(ProviderKind::Minimax), Some("minimax"));
+    }
+
+    #[test]
+    fn models_dev_id_none_for_ollama() {
+        // Ollama serves local models absent from models.dev — must stay on
+        // the live `/models` path.
+        assert_eq!(models_dev_id(ProviderKind::Ollama), None);
     }
 }

--- a/crates/agent/src/provider/openai_codex.rs
+++ b/crates/agent/src/provider/openai_codex.rs
@@ -298,9 +298,18 @@ impl ChatProvider for OpenAICodexProvider {
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
-        // Codex doesn't expose a public catalogue endpoint at the
-        // chatgpt.com host. Surface the curated allow-list. The same
-        // list opencode hard-codes in `plugin/codex.ts`.
+        // Codex doesn't expose a public `/models` endpoint at the
+        // chatgpt.com host, so we source the list from the models.dev
+        // `openai` catalogue (the same list opencode serves for the OAuth
+        // path — it does not restrict by auth mode). A few catalogue
+        // models may not be accepted by the Codex responses endpoint and
+        // will 400 on use; that's the accepted trade for staying fresh.
+        // The curated static list is the offline / not-yet-loaded
+        // fallback so the picker is never empty on a cold start.
+        let cat = crate::provider::catalogue::list_models(crate::config::ProviderKind::OpenAI);
+        if !cat.is_empty() {
+            return Ok(cat);
+        }
         Ok(meta::static_models(crate::config::ProviderKind::OpenAI)
             .iter()
             .map(|(id, name)| ModelInfo {

--- a/crates/agent/src/provider/openai_compat.rs
+++ b/crates/agent/src/provider/openai_compat.rs
@@ -126,6 +126,52 @@ impl OpenAICompatibleProvider {
         }
         h
     }
+
+    /// Fetch the provider's live model list from its OpenAI-compatible
+    /// `GET /models` endpoint. The freshest source when available;
+    /// `list_models` falls back to the models.dev catalogue / static list
+    /// when this errors or returns nothing.
+    async fn fetch_live_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        let resp = self
+            .client
+            .get(self.url("/models"))
+            .headers(self.headers())
+            .send()
+            .await
+            .map_err(|e| ProviderError::transport(e.to_string()))?;
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ProviderError::from_http_status(status, body));
+        }
+        let parsed: OaModelsResponse = resp
+            .json()
+            .await
+            .map_err(|e| ProviderError::Decode(e.to_string()))?;
+        Ok(parsed
+            .data
+            .into_iter()
+            .map(|m| ModelInfo {
+                id: m.id,
+                name: m.name,
+                context_length: m.context_length,
+            })
+            .collect())
+    }
+
+    /// The curated per-provider static model list — the offline / cold-start
+    /// fallback used when neither the live endpoint nor models.dev yield
+    /// anything.
+    fn static_models(&self) -> Vec<ModelInfo> {
+        meta::static_models(self.kind)
+            .iter()
+            .map(|(id, name)| ModelInfo {
+                id: (*id).to_string(),
+                name: Some((*name).to_string()),
+                context_length: None,
+            })
+            .collect()
+    }
 }
 
 // ─── OpenAI-compatible request/response shapes (subset we need) ─────────────
@@ -297,44 +343,47 @@ impl ChatProvider for OpenAICompatibleProvider {
     async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
         match self.models_endpoint {
             ModelsEndpoint::OpenAiCompatible => {
-                let resp = self
-                    .client
-                    .get(self.url("/models"))
-                    .headers(self.headers())
-                    .send()
-                    .await
-                    .map_err(|e| ProviderError::transport(e.to_string()))?;
-                if !resp.status().is_success() {
-                    let status = resp.status().as_u16();
-                    let body = resp.text().await.unwrap_or_default();
-                    return Err(ProviderError::from_http_status(status, body));
+                // Live `/models` is the freshest source (OpenRouter alone
+                // ships hundreds, updated constantly). On failure or an
+                // empty list, fall back to the models.dev catalogue, then
+                // the static list. Only surface the live error when we
+                // have nothing at all to show.
+                let live = self.fetch_live_models().await;
+                if let Ok(list) = &live {
+                    if !list.is_empty() {
+                        return Ok(live.unwrap_or_default());
+                    }
                 }
-                let parsed: OaModelsResponse = resp
-                    .json()
-                    .await
-                    .map_err(|e| ProviderError::Decode(e.to_string()))?;
-                Ok(parsed
-                    .data
-                    .into_iter()
-                    .map(|m| ModelInfo {
-                        id: m.id,
-                        name: m.name,
-                        context_length: m.context_length,
-                    })
-                    .collect())
+                let cat = catalogue::list_models(self.kind);
+                if !cat.is_empty() {
+                    return Ok(cat);
+                }
+                match live {
+                    // Live succeeded but was empty — surface the empty list
+                    // rather than an error (the provider genuinely has none
+                    // reachable, or the catalogue simply isn't loaded).
+                    Ok(list) => Ok(list),
+                    Err(e) => {
+                        let fallback = self.static_models();
+                        if fallback.is_empty() {
+                            Err(e)
+                        } else {
+                            Ok(fallback)
+                        }
+                    }
+                }
             }
             ModelsEndpoint::Static | ModelsEndpoint::AnthropicCatalogue => {
-                // AnthropicCatalogue lands here only if the OpenAI-compat
-                // provider has been mis-wired; fall back to the static
-                // list rather than fail.
-                Ok(meta::static_models(self.kind)
-                    .iter()
-                    .map(|(id, name)| ModelInfo {
-                        id: (*id).to_string(),
-                        name: Some((*name).to_string()),
-                        context_length: None,
-                    })
-                    .collect())
+                // No enumerable live endpoint (Z.AI, MiniMax; AnthropicCatalogue
+                // only lands here on a mis-wire). models.dev is the source of
+                // truth; the static list is the offline / not-yet-loaded
+                // fallback so the picker is never empty on a cold start.
+                let cat = catalogue::list_models(self.kind);
+                if cat.is_empty() {
+                    Ok(self.static_models())
+                } else {
+                    Ok(cat)
+                }
             }
         }
     }
@@ -699,5 +748,31 @@ mod tests {
         let content = v["content"].as_str().unwrap();
         assert!(content.starts_with("describe"));
         assert!(content.contains("does not support image input"));
+    }
+
+    #[tokio::test]
+    async fn static_kind_falls_back_to_static_models_when_catalogue_empty() {
+        // Z.AI has no enumerable live endpoint. With the models.dev
+        // catalogue unloaded (the default in a unit test — nothing seeds
+        // the global slot), list_models must return the curated static
+        // list rather than an empty picker. No network is touched: the
+        // Static branch never calls the live `/models` endpoint.
+        use crate::config::{Credential, ProviderKind};
+        // Building a reqwest client needs a process-global rustls crypto
+        // provider; main.rs installs it in the app, tests install it here.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let p = OpenAICompatibleProvider::for_kind(
+            ProviderKind::Zai,
+            &Credential::ApiKey { key: "x".into() },
+            None,
+            None,
+        );
+        let models = p.list_models().await.expect("static fallback");
+        assert!(!models.is_empty());
+        let static_ids: std::collections::HashSet<&str> = meta::static_models(ProviderKind::Zai)
+            .iter()
+            .map(|(id, _)| *id)
+            .collect();
+        assert!(models.iter().all(|m| static_ids.contains(m.id.as_str())));
     }
 }

--- a/ui/src/components/chat/ProviderPickerPopover.tsx
+++ b/ui/src/components/chat/ProviderPickerPopover.tsx
@@ -3,6 +3,7 @@ import { useResolvedTheme } from "../../store";
 import { FF_MONO, FONT_SANS, type ThemeMode, R_LG, FS_MD, FS_XS } from "../../theme";
 import { Btn, Icons } from "../ui";
 import type { AiSettingsWire, ProviderKind } from "../../types";
+import { PROVIDER_ORDER } from "../../lib/providers";
 
 type Props = {
   mode: ThemeMode;
@@ -52,25 +53,12 @@ export function ProviderPickerPopover({
     };
   }, [onClose]);
 
-  // Render in the same order Settings → AI uses (mirrors Rust's
-  // `ProviderKind::all()`), so muscle memory carries between the two
-  // surfaces.
-  const order: ProviderKind[] = [
-    "opencode_zen",
-    "openai",
-    "anthropic",
-    "open_router",
-    "zai",
-    "minimax",
-    "groq",
-    "deepseek",
-    "mistral",
-    "together",
-    "ollama",
-  ];
-  const rows = order
-    .map((kind) => settings.providers[kind])
-    .filter((p): p is NonNullable<typeof p> => Boolean(p));
+  // Render in the shared PROVIDER_ORDER — the same list Settings → AI uses
+  // (mirrors Rust's `ProviderKind::all()`) — so muscle memory carries
+  // between the two surfaces.
+  const rows = PROVIDER_ORDER.map((kind) => settings.providers[kind]).filter(
+    (p): p is NonNullable<typeof p> => Boolean(p),
+  );
 
   return (
     <div

--- a/ui/src/components/settings/AiSection.tsx
+++ b/ui/src/components/settings/AiSection.tsx
@@ -32,6 +32,7 @@ import {
   hexWithAlpha,
 } from "../../theme";
 import { Btn, ErrorBlock, Field, SectionHeader, Select, Toggle } from "../ui";
+import { PROVIDER_ORDER } from "../../lib/providers";
 import {
   KvEditor,
   kvBufferFromPairs,
@@ -182,26 +183,12 @@ export function AiSection({}: { mode: ThemeMode }) {
     }
   };
 
-  // Render rows in the order Rust's ProviderKind::all() returns. We mirror
-  // that order on the wire so the UI doesn't have to know it. OpenCode
-  // Zen leads — it's the default for fresh installs and works without
-  // a key (free tier) so a brand-new user can chat immediately.
-  const providerOrder: ProviderKind[] = [
-    "opencode_zen",
-    "openai",
-    "anthropic",
-    "open_router",
-    "zai",
-    "minimax",
-    "groq",
-    "deepseek",
-    "mistral",
-    "together",
-    "ollama",
-  ];
-  const visibleProviders = providerOrder
-    .map((kind) => settings.providers[kind])
-    .filter((p): p is ProviderStatusWire => Boolean(p));
+  // Render rows in the shared PROVIDER_ORDER (mirrors Rust's
+  // ProviderKind::all()); the chat-header switcher uses the same list so
+  // muscle memory carries between the two surfaces.
+  const visibleProviders = PROVIDER_ORDER.map(
+    (kind) => settings.providers[kind],
+  ).filter((p): p is ProviderStatusWire => Boolean(p));
 
   return (
     <div>

--- a/ui/src/lib/providers.test.ts
+++ b/ui/src/lib/providers.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { PROVIDER_ORDER } from "./providers";
+import type { ProviderKind } from "../types";
+
+describe("PROVIDER_ORDER", () => {
+  it("has no duplicate provider kinds", () => {
+    expect(new Set(PROVIDER_ORDER).size).toBe(PROVIDER_ORDER.length);
+  });
+
+  it("leads with the free-tier default so fresh installs can chat", () => {
+    // OpenCode Zen works without a key — it must be first so a brand-new
+    // user sees a usable provider at the top of both surfaces.
+    expect(PROVIDER_ORDER[0]).toBe("opencode_zen");
+  });
+
+  it("covers every ProviderKind exactly once", () => {
+    // Mirror of the union in types.ts. `satisfies Record<ProviderKind, ...>`
+    // in providers.ts guarantees this at compile time; this asserts the same
+    // set at runtime so a drift in either list fails loudly.
+    const expected: ProviderKind[] = [
+      "opencode_zen",
+      "openai",
+      "anthropic",
+      "open_router",
+      "zai",
+      "minimax",
+      "groq",
+      "deepseek",
+      "mistral",
+      "together",
+      "ollama",
+    ];
+    expect([...PROVIDER_ORDER].sort()).toEqual([...expected].sort());
+  });
+});

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -1,0 +1,29 @@
+import type { ProviderKind } from "../types";
+
+// Display order for the AI provider list, shared by Settings → AI
+// (`AiSection`) and the chat-header provider switcher
+// (`ProviderPickerPopover`) so the two surfaces render identically and
+// muscle memory carries between them. Mirrors Rust's `ProviderKind::all()`.
+// OpenCode Zen leads — it's the default for fresh installs and works
+// without a key (free tier), so a brand-new user can chat immediately.
+//
+// `satisfies Record<ProviderKind, number>` makes this exhaustive at compile
+// time: adding a `ProviderKind` without listing it here is a type error, and
+// listing an unknown key is too. Add new providers to this one map.
+const ORDER_INDEX = {
+  opencode_zen: 0,
+  openai: 1,
+  anthropic: 2,
+  open_router: 3,
+  zai: 4,
+  minimax: 5,
+  groq: 6,
+  deepseek: 7,
+  mistral: 8,
+  together: 9,
+  ollama: 10,
+} satisfies Record<ProviderKind, number>;
+
+export const PROVIDER_ORDER: readonly ProviderKind[] = (
+  Object.keys(ORDER_INDEX) as ProviderKind[]
+).sort((a, b) => ORDER_INDEX[a] - ORDER_INDEX[b]);


### PR DESCRIPTION
## Why

The model picker showed **stale OpenAI models** — OpenAI connected via *Sign in with ChatGPT* (Codex) sourced its list from a hard-coded `static_models()` table, so new releases never appeared until someone hand-edited `meta.rs`. **zai** and **minimax** had the same latent rot (also `ModelsEndpoint::Static`).

Investigated how [opencode](https://github.com/sst/opencode) avoids this: it's **catalogue-driven** — `models.dev/api.json` is the master list for ~every provider, and OAuth does **not** restrict it. We already fetch, disk-cache, and parse that full per-provider list in `catalogue.rs` — then **threw the id list away**, using models.dev for enrichment only (context window, capabilities, vision, free-tier, sort). This PR retains it and makes it the pick-list source.

## What (hybrid)

`ChatProvider::list_models()` is the single chokepoint; all three call sites (settings picker, default-select, provider test) route through it, so there are **no command or frontend changes** and `ModelInfo` is unchanged.

| Provider | List source (after) |
|---|---|
| **openai (ChatGPT-OAuth/Codex)** | models.dev catalogue → static fallback — **the fix** |
| **zai, minimax** | models.dev catalogue → static fallback |
| openrouter, groq, deepseek, mistral, together, openai-apikey, opencode_zen | live `/models` → catalogue → static |
| anthropic | live `/v1/models` → catalogue → static |
| ollama | live only (local models aren't on models.dev) |

- `catalogue.rs`: parse `name` per model, keep `models_by_provider`, add `list_models(kind)`; shared `default_order` comparator between `sort_for_default` and the new `sort_model_infos`.
- `meta.rs`: map `Zai`/`Minimax` to their models.dev ids (also enables context-window + capability enrichment for them). Ollama stays `None`.
- `static_models()` retained as the offline / cold-start fallback so the picker is never empty on first run.

## Also included

`refactor(ai)`: the identical provider-order array duplicated in `AiSection` and `ProviderPickerPopover` is extracted to one `PROVIDER_ORDER` (`ui/src/lib/providers.ts`), made exhaustive at compile time via `satisfies Record<ProviderKind, number>`.

## Tests

- catalogue parse/list + sort ordering; unknown provider empty; `list_models(Ollama)` empty
- `models_dev_id` mapping (zai/minimax mapped, ollama `None`)
- provider static-fallback when the catalogue is unloaded
- frontend `PROVIDER_ORDER` (no dupes, covers every `ProviderKind`)

`cargo fmt --all --check` clean · 44 agent tests pass · clippy `-D warnings` clean on agent+app.

## Deliberately out of scope

- **Build-time embedded models.dev snapshot** (opencode's `generate.ts`) for instant cold-start — separable follow-up. On a true first run with no cache and no network, the static fallback covers it.
- **Dropping live `/models`** for openrouter/groq/etc — rejected: live is strictly fresher there.

## Caveat

The Codex/OAuth picker now lists all ~55 `openai` catalogue models; a few may `400` if the Codex responses endpoint rejects them (matches opencode's OAuth behavior). Not yet smoke-tested against a live ChatGPT-OAuth session in the GUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)