### PR TITLE
fix(events): filter object events at apiserver

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -37,7 +37,7 @@ use ferrisscope_kube_ext::{
     get_service_account_detail, get_service_detail, get_stateful_set_detail,
     get_storage_class_detail, get_validating_webhook_configuration_detail, get_well_known_detail,
     helm_install_chart, helm_repo_update, helm_uninstall, helm_upgrade,
-    list_config_maps_in_namespace, list_namespace_names,
+    list_config_maps_in_namespace, list_namespace_names, list_object_events,
     list_persistent_volume_claims_in_namespace, list_pods_on_node, list_secrets_in_namespace,
     list_services_in_namespace, lookup, merge_patch_resource, registry, restart_pod_owner,
     restart_pods_owners, restart_workload, set_node_cordon, start_forward, ApplyResult,
@@ -1784,6 +1784,23 @@ detail_cmd! { get_cron_job_detail_cmd => get_cron_job_detail, namespaced }
 detail_cmd! { get_node_detail_cmd => get_node_detail, cluster }
 detail_cmd! { get_namespace_detail_cmd => get_namespace_detail, cluster }
 detail_cmd! { get_event_detail_cmd => get_event_detail, namespaced }
+
+/// Events attached to one object, filtered by UID at the apiserver. A
+/// namespaced target uses a namespaced Event API so pod detail does not require
+/// cluster-wide Event permissions or wait for every namespace to load.
+#[tauri::command]
+pub(crate) async fn list_object_events_cmd(
+    cluster_id: String,
+    namespace: Option<String>,
+    uid: String,
+    state: State<'_, AppState>,
+) -> Result<Vec<Value>, String> {
+    let entry = state.entry(&cluster_id).await?;
+    list_object_events(entry.cluster.client(), namespace.as_deref(), &uid)
+        .await
+        .map_err(|e| e.to_string())
+}
+
 detail_cmd! { get_service_detail_cmd => get_service_detail, namespaced }
 detail_cmd! { get_endpoints_detail_cmd => get_endpoints_detail, namespaced }
 detail_cmd! { get_endpoint_slice_detail_cmd => get_endpoint_slice_detail, namespaced }

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -178,6 +178,7 @@ fn main() {
             commands::get_node_detail_cmd,
             commands::get_namespace_detail_cmd,
             commands::get_event_detail_cmd,
+            commands::list_object_events_cmd,
             commands::get_service_detail_cmd,
             commands::get_endpoints_detail_cmd,
             commands::get_endpoint_slice_detail_cmd,

--- a/crates/kube-ext/src/fetch.rs
+++ b/crates/kube-ext/src/fetch.rs
@@ -184,6 +184,30 @@ pub async fn get_event_detail(
     Ok(events::project_detail(&api.get(name).await?))
 }
 
+const OBJECT_EVENTS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Fetch only Events attached to one concrete Kubernetes object. The UID field
+/// selector is evaluated by the apiserver, avoiding the detail panel's former
+/// cluster-wide Event reflector and client-side filtering.
+pub async fn list_object_events(
+    client: Client,
+    namespace: Option<&str>,
+    uid: &str,
+) -> Result<Vec<Value>, FetchError> {
+    let api: Api<Event> = match namespace.filter(|ns| !ns.is_empty()) {
+        Some(ns) => Api::namespaced(client, ns),
+        None => Api::all(client),
+    };
+    let params = ListParams::default().fields(&format!("involvedObject.uid={uid}"));
+    let list = tokio::time::timeout(OBJECT_EVENTS_TIMEOUT, api.list(&params))
+        .await
+        .map_err(|_| {
+            FetchError::Timeout("listing object events timed out after 15s".to_owned())
+        })??;
+
+    Ok(list.items.iter().filter_map(events::project_row).collect())
+}
+
 pub async fn get_service_detail(
     client: Client,
     namespace: &str,

--- a/crates/kube-ext/src/kinds/events.rs
+++ b/crates/kube-ext/src/kinds/events.rs
@@ -6,6 +6,30 @@ use crate::registry::{Category, ColumnDef, ColumnKind, KindSpec, ResourceKind};
 
 pub struct EventSpec;
 
+fn event_count(ev: &Event) -> i32 {
+    ev.series
+        .as_ref()
+        .and_then(|series| series.count)
+        .or(ev.count)
+        .unwrap_or(1)
+}
+
+fn event_last_seen(ev: &Event) -> Option<String> {
+    ev.series
+        .as_ref()
+        .and_then(|series| series.last_observed_time.as_ref())
+        .map(|time| time.0.to_string())
+        .or_else(|| ev.last_timestamp.as_ref().map(|time| time.0.to_string()))
+        .or_else(|| ev.event_time.as_ref().map(|time| time.0.to_string()))
+        .or_else(|| ev.first_timestamp.as_ref().map(|time| time.0.to_string()))
+        .or_else(|| {
+            ev.metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|time| time.0.to_string())
+        })
+}
+
 impl KindSpec for EventSpec {
     type K = Event;
 
@@ -66,13 +90,9 @@ impl KindSpec for EventSpec {
             (None, Some(n)) => n.clone(),
             _ => String::new(),
         };
-        // Prefer event_time (microtime) → last_timestamp → first_timestamp.
-        let last_seen = ev
-            .event_time
-            .as_ref()
-            .map(|t| t.0.to_string())
-            .or_else(|| ev.last_timestamp.as_ref().map(|t| t.0.to_string()))
-            .or_else(|| ev.first_timestamp.as_ref().map(|t| t.0.to_string()));
+        // Modern repeated Events advance series.lastObservedTime while their
+        // eventTime remains the first observation.
+        let last_seen = event_last_seen(ev);
         let source = ev.source.as_ref().and_then(|s| s.component.clone());
 
         json!({
@@ -82,7 +102,7 @@ impl KindSpec for EventSpec {
             "reason": ev.reason.clone().unwrap_or_default(),
             "object": object_label,
             "message": ev.message.clone().unwrap_or_default(),
-            "count": ev.count.unwrap_or(0),
+            "count": event_count(ev),
             "last_seen": last_seen,
             "source": source,
             // For per-object filtering on the detail panel.
@@ -92,6 +112,17 @@ impl KindSpec for EventSpec {
             "involved_name": involved.name.clone(),
         })
     }
+}
+
+/// Project a fetched Event into the same row shape used by the reflector.
+/// Real API objects always carry a UID; malformed rows without one are skipped
+/// so the frontend never receives an unstable table key.
+pub fn project_row(ev: &Event) -> Option<Value> {
+    let uid = ev.metadata.uid.clone()?;
+    let mut row = EventSpec::project(ev);
+    row.as_object_mut()?
+        .insert("uid".to_owned(), Value::String(uid));
+    Some(row)
 }
 
 // Rich projection used by the event detail panel. The interesting structure
@@ -138,7 +169,7 @@ pub fn project_detail(ev: &Event) -> Value {
         "type": ev.type_.clone().unwrap_or_else(|| "Normal".to_owned()),
         "reason": ev.reason.clone(),
         "message": ev.message.clone(),
-        "count": ev.count.unwrap_or(0),
+        "count": event_count(ev),
         "action": ev.action.clone(),
         "reporting_controller": ev.reporting_component.clone(),
         "reporting_instance": ev.reporting_instance.clone(),
@@ -150,4 +181,71 @@ pub fn project_detail(ev: &Event) -> Value {
         "related": related,
         "series": series,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn modern_series_drives_row_recency_and_count() {
+        let event: Event = serde_json::from_value(json!({
+            "metadata": {
+                "name": "pod-started.abc",
+                "namespace": "default",
+                "uid": "event-uid",
+                "creationTimestamp": "2026-07-15T08:00:00Z"
+            },
+            "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "api-0",
+                "uid": "pod-uid"
+            },
+            "type": "Normal",
+            "reason": "Started",
+            "eventTime": "2026-07-15T08:01:00.000000Z",
+            "lastTimestamp": "2026-07-15T08:02:00Z",
+            "count": 2,
+            "series": {
+                "count": 7,
+                "lastObservedTime": "2026-07-15T08:07:00.000000Z"
+            }
+        }))
+        .expect("valid Event fixture");
+
+        let row = project_row(&event).expect("API Event has a UID");
+        assert_eq!(row["uid"], "event-uid");
+        assert_eq!(row["involved_uid"], "pod-uid");
+        assert_eq!(row["count"], 7);
+        assert_eq!(row["last_seen"], "2026-07-15T08:07:00Z");
+
+        let detail = project_detail(&event);
+        assert_eq!(detail["count"], 7);
+    }
+
+    #[test]
+    fn singleton_event_defaults_to_count_one_and_creation_time() {
+        let event: Event = serde_json::from_value(json!({
+            "metadata": {
+                "name": "scheduled.abc",
+                "namespace": "default",
+                "uid": "event-uid",
+                "creationTimestamp": "2026-07-15T08:00:00Z"
+            },
+            "involvedObject": {
+                "kind": "Pod",
+                "namespace": "default",
+                "name": "api-0",
+                "uid": "pod-uid"
+            },
+            "reason": "Scheduled"
+        }))
+        .expect("valid Event fixture");
+
+        let row = EventSpec::project(&event);
+        assert_eq!(row["count"], 1);
+        assert_eq!(row["last_seen"], "2026-07-15T08:00:00Z");
+    }
 }

--- a/crates/kube-ext/src/lib.rs
+++ b/crates/kube-ext/src/lib.rs
@@ -29,7 +29,7 @@ pub use fetch::{
     get_service_account_detail, get_service_detail, get_stateful_set_detail,
     get_storage_class_detail, get_validating_webhook_configuration_detail, get_well_known_detail,
     helm_available, helm_install_chart, helm_repo_update, helm_uninstall, helm_upgrade,
-    list_config_maps_in_namespace, list_namespace_names,
+    list_config_maps_in_namespace, list_namespace_names, list_object_events,
     list_persistent_volume_claims_in_namespace, list_pods_on_node, list_secrets_in_namespace,
     list_services_in_namespace, merge_patch_resource, restart_pod_owner, restart_pods_owners,
     restart_workload, set_node_cordon, ApplyConflict, ApplyOk, ApplyResult, DocApplyResult,

--- a/crates/kube-ext/tests/integration_events.rs
+++ b/crates/kube-ext/tests/integration_events.rs
@@ -1,0 +1,99 @@
+//! Object Event query integration test against a real kind cluster.
+
+#![cfg(feature = "integration")]
+
+use ferrisscope_kube_ext::list_object_events;
+use ferrisscope_test_support::kind::{ensure_two_clusters, KindCluster};
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::Api;
+use kube::config::{KubeConfigOptions, Kubeconfig};
+use kube::{Client, Config, ResourceExt};
+
+async fn build_client(cluster: &KindCluster) -> Client {
+    let kubeconfig = Kubeconfig::from_yaml(&cluster.kubeconfig_text).expect("parse kubeconfig");
+    let options = KubeConfigOptions {
+        context: Some(cluster.context_name.clone()),
+        ..Default::default()
+    };
+    let config = Config::from_custom_kubeconfig(kubeconfig, &options)
+        .await
+        .expect("build config");
+    Client::try_from(config).expect("build client")
+}
+
+fn namespace_yaml(name: &str) -> String {
+    format!("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: {name}\n")
+}
+
+fn pod_yaml(namespace: &str, name: &str) -> String {
+    format!(
+        "apiVersion: v1\nkind: Pod\nmetadata:\n  name: {name}\n  namespace: {namespace}\nspec:\n  containers:\n  - name: pause\n    image: registry.k8s.io/pause:3.10\n"
+    )
+}
+
+fn event_yaml(namespace: &str, name: &str, pod_name: &str, pod_uid: &str) -> String {
+    format!(
+        "apiVersion: v1\nkind: Event\nmetadata:\n  name: {name}\n  namespace: {namespace}\ninvolvedObject:\n  apiVersion: v1\n  kind: Pod\n  namespace: {namespace}\n  name: {pod_name}\n  uid: {pod_uid}\nreason: TestEvent\nmessage: integration event\ntype: Normal\nsource:\n  component: ferrisscope-test\n"
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn object_event_query_returns_only_the_selected_uid() {
+    let (cluster, _other) = ensure_two_clusters().await.expect("boot kind");
+    let namespace = "fs-it-object-events";
+    cluster
+        .kubectl_apply(&namespace_yaml(namespace))
+        .expect("apply namespace");
+    cluster
+        .kubectl_apply(&pod_yaml(namespace, "selected"))
+        .expect("apply selected pod");
+    cluster
+        .kubectl_apply(&pod_yaml(namespace, "other"))
+        .expect("apply other pod");
+
+    let client = build_client(&cluster).await;
+    let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let selected_uid = pods
+        .get("selected")
+        .await
+        .expect("get selected pod")
+        .uid()
+        .expect("selected pod UID");
+    let other_uid = pods
+        .get("other")
+        .await
+        .expect("get other pod")
+        .uid()
+        .expect("other pod UID");
+
+    cluster
+        .kubectl_apply(&event_yaml(
+            namespace,
+            "selected-event",
+            "selected",
+            &selected_uid,
+        ))
+        .expect("apply selected Event");
+    cluster
+        .kubectl_apply(&event_yaml(namespace, "other-event", "other", &other_uid))
+        .expect("apply other Event");
+
+    let rows = list_object_events(client, Some(namespace), &selected_uid)
+        .await
+        .expect("list selected object Events");
+    assert!(!rows.is_empty(), "selected pod should have Events");
+    assert!(
+        rows.iter().all(|row| row["involved_uid"] == selected_uid),
+        "field selector returned an Event for another object: {rows:?}"
+    );
+    assert!(
+        rows.iter().all(|row| row["involved_uid"] != other_uid),
+        "field selector must exclude the other pod"
+    );
+    assert!(
+        rows.iter().any(|row| row["reason"] == "TestEvent"),
+        "seeded Event was not returned: {rows:?}"
+    );
+
+    let _ = cluster.kubectl(&["delete", "namespace", namespace, "--wait=false"]);
+}

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -234,6 +234,19 @@ describe("detail getters", () => {
     expect(cap.calls[0]?.cmd).toBe("get_node_detail_cmd");
     expect(cap.calls[0]?.args).toEqual({ clusterId: "ctx", name: "worker-1" });
   });
+
+  it("listObjectEvents sends namespace + UID to the filtered command", async () => {
+    const cap = captureNext([]);
+    await api.listObjectEvents("ctx", "default", "pod-uid");
+    expect(cap.calls[0]).toEqual({
+      cmd: "list_object_events_cmd",
+      args: {
+        clusterId: "ctx",
+        namespace: "default",
+        uid: "pod-uid",
+      },
+    });
+  });
 });
 
 describe("getResourceYaml", () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -237,6 +237,16 @@ export const api = {
     invoke<NamespaceDetail>("get_namespace_detail_cmd", { clusterId, name }),
   getEventDetail: (clusterId: string, namespace: string, name: string) =>
     invoke<EventDetail>("get_event_detail_cmd", { clusterId, namespace, name }),
+  listObjectEvents: (
+    clusterId: string,
+    namespace: string | null,
+    uid: string,
+  ) =>
+    invoke<ResourceRow[]>("list_object_events_cmd", {
+      clusterId,
+      namespace,
+      uid,
+    }),
   getServiceDetail: (clusterId: string, namespace: string, name: string) =>
     invoke<ServiceDetail>("get_service_detail_cmd", {
       clusterId,

--- a/ui/src/components/DetailPanel.events.test.tsx
+++ b/ui/src/components/DetailPanel.events.test.tsx
@@ -1,0 +1,56 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetMockInvoke, setMockInvoke } from "../test/tauri-mock";
+import { ObjectEvents } from "./DetailPanel";
+
+afterEach(() => {
+  cleanup();
+  resetMockInvoke();
+});
+
+describe("ObjectEvents", () => {
+  it("uses the server-filtered object Events command instead of a global subscription", async () => {
+    const calls: Array<{ cmd: string; args?: Record<string, unknown> }> = [];
+    setMockInvoke((cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd !== "list_object_events_cmd") {
+        throw new Error(`unexpected command: ${cmd}`);
+      }
+      return [
+        {
+          uid: "event-uid",
+          involved_uid: "pod-uid",
+          type: "Normal",
+          reason: "Started",
+          message: "Started container api",
+          count: 3,
+          last_seen: "2026-07-15T08:07:00Z",
+        },
+      ];
+    });
+
+    await act(async () => {
+      render(
+        <ObjectEvents
+          mode="dark"
+          clusterId="ctx"
+          targetNamespace="production"
+          targetUid="pod-uid"
+        />,
+      );
+    });
+
+    expect(await screen.findByText("Started container api")).toBeInTheDocument();
+    expect(screen.getByText("Normal")).toBeInTheDocument();
+    expect(calls).toEqual([
+      {
+        cmd: "list_object_events_cmd",
+        args: {
+          clusterId: "ctx",
+          namespace: "production",
+          uid: "pod-uid",
+        },
+      },
+    ]);
+  });
+});

--- a/ui/src/components/DetailPanel.tsx
+++ b/ui/src/components/DetailPanel.tsx
@@ -1,4 +1,3 @@
-import { logErr } from "../lib/log";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api, onResourceDelta } from "../api";
 import { parseYaml, stripYaml, type Json } from "../lib/yamlEdit";
@@ -1263,6 +1262,7 @@ export function DetailPanel({
             <ObjectEvents
               mode={mode}
               clusterId={clusterId}
+              targetNamespace={target.namespace}
               targetUid={target.uid}
             />
           ) : null}
@@ -1580,91 +1580,62 @@ type EventState =
   | { kind: "ready"; rows: ResourceRow[] }
   | { kind: "error"; message: string };
 
-function ObjectEvents({
+export function ObjectEvents({
   mode,
   clusterId,
+  targetNamespace,
   targetUid,
 }: {
   mode: ThemeMode;
   clusterId: string;
+  targetNamespace: string | null;
   targetUid: string;
 }) {
   const t = useResolvedTheme().tokens;
   const [state, setState] = useState<EventState>({ kind: "loading" });
-  const rowsRef = useRef<Map<string, ResourceRow>>(new Map());
-  const initialDoneRef = useRef(false);
-  const watcherInitDoneRef = useRef(false);
   const [now, setNow] = useState<number>(() => Date.now());
 
   useEffect(() => {
     let cancelled = false;
-    let unlisten: (() => void) | null = null;
-    rowsRef.current = new Map();
-    initialDoneRef.current = false;
-    watcherInitDoneRef.current = false;
+    let inFlight = false;
     setState({ kind: "loading" });
 
-    (async () => {
+    const load = async () => {
+      if (inFlight) return;
+      inFlight = true;
       try {
-        unlisten = await onResourceDelta(clusterId, "events", null, (delta) => {
-          if (cancelled) return;
-
-          if (delta.kind === "init_done") {
-            watcherInitDoneRef.current = true;
-            if (initialDoneRef.current) {
-              setState({ kind: "ready", rows: Array.from(rowsRef.current.values()) });
-            }
-            return;
-          }
-
-          const next = new Map(rowsRef.current);
-          if (delta.kind === "upsert") {
-            if (delta.row.involved_uid === targetUid) {
-              next.set(delta.row.uid, delta.row);
-            }
-          } else {
-            next.delete(delta.uid);
-          }
-          rowsRef.current = next;
-
-          if (initialDoneRef.current) {
-            // Only transition to ready if the watcher is fully synced, OR we have at least one event.
-            if (watcherInitDoneRef.current || next.size > 0) {
-              setState({ kind: "ready", rows: Array.from(next.values()) });
-            }
-          }
-        });
-
-        const result = await api.subscribeResource(clusterId, "events", null);
-        if (cancelled) return;
-
-        if (result.init_done) {
-          watcherInitDoneRef.current = true;
-        }
-
-        const merged = new Map<string, ResourceRow>(rowsRef.current);
-        for (const row of result.rows) {
-          if (row.involved_uid === targetUid) merged.set(row.uid, row);
-        }
-        rowsRef.current = merged;
-        initialDoneRef.current = true;
-
-        if (watcherInitDoneRef.current || merged.size > 0) {
-          setState({ kind: "ready", rows: Array.from(merged.values()) });
+        const rows = await api.listObjectEvents(
+          clusterId,
+          targetNamespace,
+          targetUid,
+        );
+        if (!cancelled) {
+          setState({
+            kind: "ready",
+            // Keep UID validation client-side as a defensive check against an
+            // apiserver or proxy that ignores unsupported field selectors.
+            rows: rows.filter((row) => row.involved_uid === targetUid),
+          });
         }
       } catch (e) {
         if (!cancelled) setState({ kind: "error", message: String(e) });
+      } finally {
+        inFlight = false;
       }
-    })();
+    };
+
+    void load();
 
     const tick = setInterval(() => setNow(Date.now()), 1000);
+    const poll = setInterval(() => {
+      if (typeof document === "undefined" || !document.hidden) void load();
+    }, DETAIL_POLL_MS);
     return () => {
       cancelled = true;
       clearInterval(tick);
-      if (unlisten) unlisten();
-      api.unsubscribeResource(clusterId, "events").catch(logErr("detail-panel"));
+      clearInterval(poll);
     };
-  }, [clusterId, targetUid]);
+  }, [clusterId, targetNamespace, targetUid]);
 
   const sorted = useMemo(() => {
     if (state.kind !== "ready") return [];
@@ -1764,9 +1735,7 @@ function ObjectEvents({
             >
               <td style={{ padding: "8px 14px" }}>
                 <StatusPill
-                  status={
-                    String(r.type ?? "") === "Warning" ? "Warning" : "Running"
-                  }
+                  status={String(r.type ?? "Normal")}
                   t={t}
                   mode={mode}
                   dense

--- a/ui/src/theme.test.ts
+++ b/ui/src/theme.test.ts
@@ -66,6 +66,7 @@ describe("statusBucket — known buckets", () => {
   // (e.g. a phase becomes warn instead of bad) this test will catch it.
   it.each([
     ["Running", "good"],
+    ["Normal", "good"],
     ["Ready", "good"],
     ["Active", "good"],
     ["Bound", "good"],

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -930,6 +930,7 @@ export type StatusBucket = "good" | "warn" | "bad" | "info" | "unknown";
 
 const GOOD = new Set([
   "Running",
+  "Normal",
   "Ready",
   "Active",
   "Available",


### PR DESCRIPTION
## Summary
- query per-object Events with an apiserver-side `involvedObject.uid` selector, namespace scoping, and a bounded timeout
- replace the detail tab's cluster-wide Event reflector with lightweight polling and visible request errors
- use modern EventSeries count/recency fields and render Normal Events with the correct status
- add frontend, projection, API-shape, and real kind-cluster regression coverage

## Testing
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy -p ferrisscope-kube-ext -p ferrisscope-app --all-targets -- -D warnings`
- `cargo test -p ferrisscope-kube-ext`
- `cargo test -p ferrisscope-kube-ext --features integration --test integration_events -- --nocapture`
- `npm test` (1180 tests)
- `npm run build`