### PR TITLE
fix: reconnect re-runs CRD discovery, HelmChart detail no longer white-screens, reconnecting UI clears on recovery

### DIFF
--- a/ui/src/components/DetailPanel.tsx
+++ b/ui/src/components/DetailPanel.tsx
@@ -27,6 +27,7 @@ import {
   Chip,
   ContainerDots,
   ErrorBlock,
+  ErrorBoundary,
   Eyebrow,
   IconBtn,
   Icons,
@@ -38,6 +39,7 @@ import {
 import type { ContainerLite } from "./ui";
 import { ContextMenu, type MenuItem, type MenuPosition } from "./ContextMenu";
 import { confirm, toast } from "../lib/dialog";
+import { logErr } from "../lib/log";
 import {
   Mono,
   ChipStrip,
@@ -1194,7 +1196,22 @@ export function DetailPanel({
             background: t.surfaceAlt,
           }}
         >
-          {tab === "summary" && hasSummary ? (
+          <ErrorBoundary
+            // A crash in any tab's body (summary / related / events / metrics)
+            // is contained here instead of unwinding to the React root and
+            // whiting out the whole window. Keyed on the object + tab so a
+            // fault resets automatically when the operator navigates elsewhere.
+            key={`${kind.id} ${target.namespace ?? ""} ${target.name} ${tab}`}
+            onError={logErr("detail-panel")}
+            fallback={(err) => (
+              <ErrorBlock
+                t={t}
+                message={err.message || String(err)}
+                kindLabel="this resource"
+              />
+            )}
+          >
+            {tab === "summary" && hasSummary ? (
             isPod ? (
               <PodSummary
                 mode={mode}
@@ -1319,6 +1336,7 @@ export function DetailPanel({
               controllerKind={workloadControllerKind}
             />
           ) : null}
+          </ErrorBoundary>
         </div>
       </div>
     </>

--- a/ui/src/components/Rail.tsx
+++ b/ui/src/components/Rail.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
-import { useActiveClusterIds, useAppStore, useResolvedTheme } from "../store";
+import {
+  useActiveClusterEpoch,
+  useActiveClusterIds,
+  useAppStore,
+  useResolvedTheme,
+} from "../store";
 import type { Category, PrefsRailMode, ResourceKind } from "../types";
 import {
   tokens,
@@ -61,6 +66,11 @@ export function Rail({}: Props) {
   // or the single selection). NUL-joined key — ids contain "::"/spaces.
   const activeClusterIds = useActiveClusterIds();
   const activeClusterKey = activeClusterIds.join(String.fromCharCode(0));
+  // Bumps on every reconnect of an active cluster (see `useActiveClusterEpoch`).
+  // Kept in the discovery effect's deps so a same-cluster reconnect — which
+  // leaves `activeClusterKey` unchanged — still re-runs discovery and clears a
+  // stale "CRD discovery: …" auth error once the reconnect fixes the client.
+  const reconnectEpoch = useActiveClusterEpoch();
   const setKinds = useAppStore((s) => s.setKinds);
   const setKindClusters = useAppStore((s) => s.setKindClusters);
   const setKindsLoading = useAppStore((s) => s.setKindsLoading);
@@ -201,7 +211,7 @@ export function Rail({}: Props) {
     return () => {
       cancelled = true;
     };
-  }, [activeClusterKey, setKinds, setKindClusters]);
+  }, [activeClusterKey, reconnectEpoch, setKinds, setKindClusters]);
 
   const grouped = useMemo(() => {
     const map = new Map<Category, ResourceKind[]>();

--- a/ui/src/components/detail/helm/chart.test.tsx
+++ b/ui/src/components/detail/helm/chart.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import type { HelmChartDetail } from "../../../types";
+
+// Monaco pulls in a web worker + canvas that jsdom can't run; the values editor
+// is irrelevant to what we're testing (hook order across load states), so stub
+// it to a plain node.
+vi.mock("@monaco-editor/react", () => ({
+  default: () => <div data-testid="monaco-stub" />,
+}));
+
+// Control the detail fetch by hand so we can hold the component in `loading`
+// and then flip it to `ready` — the exact transition that used to crash.
+const getHelmChartDetail = vi.fn<() => Promise<HelmChartDetail>>();
+vi.mock("../../../api", () => ({
+  api: {
+    getHelmChartDetail: (...args: unknown[]) =>
+      getHelmChartDetail(...(args as [])),
+  },
+}));
+
+import { HelmChartSummary } from "./chart";
+
+const DETAIL: HelmChartDetail = {
+  source: "cluster",
+  chart_name: "podinfo",
+  chart_version: "6.5.0",
+  app_version: "6.5.0",
+  description: "demo chart",
+  home: null,
+  icon: null,
+  sources: [],
+  keywords: [],
+  default_values_yaml: "replicaCount: 1\n",
+  used_by: [],
+  helm_available: true,
+};
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe("HelmChartSummary", () => {
+  beforeEach(() => {
+    getHelmChartDetail.mockReset();
+  });
+
+  // Regression: `useAppStore(selectClusterDegraded)` used to sit BELOW the
+  // loading/error early returns, so the ready render called one more hook than
+  // the loading render. React threw "Rendered more hooks than during the
+  // previous render" the instant the chart loaded and — with no error boundary
+  // — whited out the whole window. All hooks must run unconditionally, so the
+  // loading -> ready transition must render cleanly.
+  it("survives the loading -> ready transition without a hook-order crash", async () => {
+    const d = deferred<HelmChartDetail>();
+    getHelmChartDetail.mockReturnValue(d.promise);
+
+    render(
+      <HelmChartSummary
+        mode="dark"
+        clusterId="ctx"
+        uid="helm:chart:cluster:podinfo:6.5.0"
+        name="podinfo"
+        detailVersion={0}
+      />,
+    );
+
+    // Loading render: fewer hooks in the buggy version.
+    expect(screen.getByText("Loading chart…")).toBeTruthy();
+
+    // Ready render: the extra hook fired here and crashed. Now it must render.
+    await act(async () => {
+      d.resolve(DETAIL);
+      await d.promise;
+    });
+
+    // Reaching the ready render at all is the assertion — a hook-order crash
+    // would have thrown before any of this mounted. (The chart name shows in
+    // both the title and the release-name suggestion, hence getAllByText.)
+    expect(screen.getAllByText("podinfo").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Loading chart…")).toBeNull();
+    expect(getHelmChartDetail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/detail/helm/chart.tsx
+++ b/ui/src/components/detail/helm/chart.tsx
@@ -160,6 +160,16 @@ export function HelmChartSummary(props: {
     kind: "idle",
   });
 
+  // Cluster degraded (unavailable / mid auto-reconnect): block install (a
+  // doomed helm write) while leaving the chart browseable. MUST stay above the
+  // early returns below — calling it after the loading/error guards changed the
+  // hook count between the loading and ready renders, which threw "Rendered
+  // more hooks than during the previous render" and (no error boundary exists)
+  // whited out the whole window the instant the chart finished loading.
+  const degraded = useAppStore((s) =>
+    selectClusterDegraded(s, props.clusterId),
+  );
+
   // Seed defaults from the loaded chart on first ready (or when the
   // chart changes). Re-seed values only when the operator hasn't typed
   // anything custom — match by string equality with the prior seed.
@@ -189,11 +199,6 @@ export function HelmChartSummary(props: {
     return <ErrorBlock t={t} message={state.message} kindLabel="helm chart" />;
 
   const d = state.detail;
-  // Cluster degraded (unavailable / mid auto-reconnect): block install (a
-  // doomed helm write) while leaving the chart browseable.
-  const degraded = useAppStore((s) =>
-    selectClusterDegraded(s, props.clusterId),
-  );
   const canInstall =
     d.helm_available &&
     !degraded &&

--- a/ui/src/components/ui/ErrorBoundary.test.tsx
+++ b/ui/src/components/ui/ErrorBoundary.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function Boom({ explode }: { explode: boolean }): ReactElement {
+  if (explode) throw new Error("kaboom");
+  return <div>alive</div>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when nothing throws", () => {
+    render(
+      <ErrorBoundary fallback={() => <div>fallback</div>}>
+        <div>content</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("content")).toBeTruthy();
+    expect(screen.queryByText("fallback")).toBeNull();
+  });
+
+  it("shows the fallback (not a blank tree) and reports the error on a child throw", () => {
+    // React logs the caught error to console.error; silence it so the test
+    // output stays clean, and assert we forward it to onError instead.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary
+        onError={onError}
+        fallback={(err) => <div>caught: {err.message}</div>}
+      >
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("caught: kaboom")).toBeTruthy();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    spy.mockRestore();
+  });
+
+  it("a throwing onError never re-crashes the boundary", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <ErrorBoundary
+        onError={() => {
+          throw new Error("logger blew up");
+        }}
+        fallback={() => <div>still contained</div>}
+      >
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("still contained")).toBeTruthy();
+    spy.mockRestore();
+  });
+
+  it("recovers when a fresh key remounts the boundary (the navigation reset path)", () => {
+    // DetailPanel keys the boundary on object+tab, so navigating away remounts
+    // it with a clean slate. Model that: a crashed boundary under one key gives
+    // way to healthy children under a new key.
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { rerender } = render(
+      <ErrorBoundary key="a" fallback={() => <div>fallback</div>}>
+        <Boom explode />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("fallback")).toBeTruthy();
+
+    rerender(
+      <ErrorBoundary key="b" fallback={() => <div>fallback</div>}>
+        <Boom explode={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("alive")).toBeTruthy();
+    expect(screen.queryByText("fallback")).toBeNull();
+    spy.mockRestore();
+  });
+});

--- a/ui/src/components/ui/ErrorBoundary.tsx
+++ b/ui/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import { Component, type ReactNode, type ErrorInfo } from "react";
+
+interface Props {
+  /// Rendered in place of `children` after a render/lifecycle throw. Receives
+  /// the caught error and a `reset` that clears the boundary so `children`
+  /// re-mount (useful once the underlying cause is gone — e.g. after the
+  /// operator navigates elsewhere). Remounting the boundary with a fresh `key`
+  /// also resets it, which is how callers recover on navigation.
+  fallback: (error: Error, reset: () => void) => ReactNode;
+  /// Side-channel for logging/telemetry. MUST NOT throw.
+  onError?: (error: Error, info: ErrorInfo) => void;
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/// Generic React error boundary. Catches a throw from anywhere in its subtree's
+/// render / lifecycle and shows `fallback` instead of letting the exception
+/// unwind to the React root — which unmounts the whole tree and leaves a blank
+/// white window. There was previously no boundary anywhere in the app, so a
+/// single bad detail summary (e.g. a hooks-order violation) whited out the
+/// entire UI. Wrap crash-prone, self-contained surfaces (detail panel body,
+/// tab content) so a fault is contained to that surface.
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Never let logging throw and re-crash the boundary.
+    try {
+      this.props.onError?.(error, info);
+    } catch {
+      /* swallow */
+    }
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error !== null) {
+      return this.props.fallback(this.state.error, this.reset);
+    }
+    return this.props.children;
+  }
+}

--- a/ui/src/components/ui/index.ts
+++ b/ui/src/components/ui/index.ts
@@ -1,5 +1,6 @@
 export { Btn, IconBtn } from "./Btn";
 export type { BtnVariant, BtnSize } from "./Btn";
+export { ErrorBoundary } from "./ErrorBoundary";
 export { Tooltip } from "./Tooltip";
 export { StatusPill } from "./StatusPill";
 export {

--- a/ui/src/lib/useClusterConnection.test.ts
+++ b/ui/src/lib/useClusterConnection.test.ts
@@ -173,23 +173,48 @@ describe("useClusterConnection auto-reconnect", () => {
     expect(reconnectCluster).toHaveBeenCalledTimes(1);
   });
 
-  it("recovery dwell: a sustained reconnect ends the session and re-arms fresh", async () => {
+  it("successful reconnect clears the banner + grayed state immediately, not after the dwell", async () => {
+    // Regression: the recovery dwell used to hold `clusterReconnecting` true (so
+    // the pod table stayed grayed and the banner stayed up) for the full 60s
+    // after data was already flowing, reading as "stuck reconnecting". A connect
+    // success must drop the user-visible state at once.
     const { result } = renderHook(() => useClusterConnection(CTX));
     await flush();
 
     fireHealth(UNAVAIL);
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBe(true);
+
     await flush(2000); // attempt 1 fires, connect resolves ok
     expect(reconnectCluster).toHaveBeenCalledTimes(1);
-    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
-
-    // 60s with no further unavailable -> declared recovered.
-    await flush(60_000);
+    // Banner gone + table un-grayed the moment the connection is confirmed —
+    // no waiting on the dwell.
     expect(result.current.autoReconnect).toBeNull();
     expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBeUndefined();
 
-    // A fresh outage starts a brand-new session at attempt 1 (counter reset).
+    // The session is still open internally through the dwell; once it elapses
+    // quietly the counter resets, so a fresh outage starts at attempt 1.
+    await flush(60_000);
     fireHealth(UNAVAIL);
     expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+  });
+
+  it("re-flag inside the dwell resumes the retry counter instead of restarting at 1", async () => {
+    // The dwell keeps the session (counter) alive even though the banner is
+    // hidden: a wedged cluster that re-flags within 60s must continue the retry
+    // sequence, not reset to attempt 1 and risk an unbounded flap loop.
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    fireHealth(UNAVAIL);
+    await flush(2000); // attempt 1 fires, connect ok -> banner cleared, session open
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+    expect(result.current.autoReconnect).toBeNull();
+
+    // Re-flag before the 60s dwell elapses: the session is still alive, so this
+    // arms attempt 2 (not a fresh attempt 1) and re-shows the banner.
+    fireHealth(UNAVAIL);
+    expect(result.current.autoReconnect).toEqual({ attempt: 2, max: MAX });
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBe(true);
   });
 
   it("unmount mid-backoff fires no further reconnects", async () => {

--- a/ui/src/lib/useClusterConnection.ts
+++ b/ui/src/lib/useClusterConnection.ts
@@ -185,9 +185,21 @@ export function useClusterConnection(context: ContextInfo): {
           scheduleNext();
           return;
         }
-        // Connected: optimistically recovered, but a wedged cluster may re-flag
-        // ~30s later. Hold the session open through a dwell; if no unavailable
-        // arrives, declare recovery and reset.
+        // Connected. Drop the *user-visible* reconnecting state right now so the
+        // data plane un-grays and the banner disappears the instant the cluster
+        // is actually back — data is already flowing through the rebuilt client.
+        // Holding the grayed table + banner through the full re-flag dwell read
+        // as "stuck reconnecting" even though the connection had recovered (only
+        // a manual reconnect, which resets immediately, cleared it).
+        setClusterReconnecting(cidRef.current, false);
+        if (mountedRef.current) setAutoReconnect(null);
+        // The *session* stays open through a quiet dwell, though: a wedged
+        // cluster may re-flag ~30s later (the backend probe emits one
+        // `unavailable` then exits, so recovery is only provable by a connect
+        // succeeding). Keeping the counter alive means a re-flag inside the
+        // dwell resumes the retry sequence instead of restarting at attempt 1
+        // and risking an unbounded loop on a flapping cluster. If no unavailable
+        // arrives, `endSession(true)` declares recovery and resets the counter.
         if (dwellTimerRef.current != null) window.clearTimeout(dwellTimerRef.current);
         dwellTimerRef.current = window.setTimeout(
           () => endSession(true),

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -683,6 +683,20 @@ describe("cluster health", () => {
     expect(useAppStore.getState().clusterHealth["ctx"]).toBeUndefined();
     expect(useAppStore.getState().clusterHealthReason["ctx"]).toBeUndefined();
   });
+
+  it("clearClusterHealth bumps the per-cluster reconnect epoch monotonically", () => {
+    // Discovery effects key on this epoch so a same-cluster reconnect re-runs
+    // CRD discovery and clears any stale error. Each reconnect must advance it.
+    expect(useAppStore.getState().clusterEpoch["ctx"] ?? 0).toBe(0);
+    useAppStore.getState().clearClusterHealth("ctx");
+    expect(useAppStore.getState().clusterEpoch["ctx"]).toBe(1);
+    useAppStore.getState().clearClusterHealth("ctx");
+    expect(useAppStore.getState().clusterEpoch["ctx"]).toBe(2);
+    // A different cluster keeps its own independent counter.
+    useAppStore.getState().clearClusterHealth("other");
+    expect(useAppStore.getState().clusterEpoch["other"]).toBe(1);
+    expect(useAppStore.getState().clusterEpoch["ctx"]).toBe(2);
+  });
 });
 
 describe("tableViews", () => {

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -392,6 +392,12 @@ type AppState = {
   // the read-only gate + reconnecting banner steady across the whole session.
   // Set/cleared only by the hook; never persisted.
   clusterReconnecting: Record<string, boolean>;
+  // Monotonic reconnect counter per cluster, bumped by `clearClusterHealth`
+  // (i.e. on every manual or auto reconnect). Lets connection-independent
+  // effects that would otherwise stay keyed on a same-cluster reconnect —
+  // notably the Rail's CRD discovery — re-run and clear stale errors after a
+  // reconnect fixes the underlying auth/reachability problem. Never persisted.
+  clusterEpoch: Record<string, number>;
 
   // Active port-forwards keyed by id. Initially hydrated by api.pfList() at
   // App boot; mutated on every `portforward://status` event. Detail-panel
@@ -853,6 +859,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   clusterHealth: {},
   clusterHealthReason: {},
   clusterReconnecting: {},
+  clusterEpoch: {},
 
   forwards: {},
   forwardsOpen: false,
@@ -1308,7 +1315,16 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => {
       const { [clusterId]: _h, ...rest } = s.clusterHealth;
       const { [clusterId]: _r, ...restR } = s.clusterHealthReason;
-      return { clusterHealth: rest, clusterHealthReason: restR };
+      // Bump the reconnect epoch so effects keyed on it (Rail CRD discovery)
+      // re-run against the freshly-rebuilt client and drop any stale error.
+      return {
+        clusterHealth: rest,
+        clusterHealthReason: restR,
+        clusterEpoch: {
+          ...s.clusterEpoch,
+          [clusterId]: (s.clusterEpoch[clusterId] ?? 0) + 1,
+        },
+      };
     }),
   setClusterReconnecting: (clusterId, value) =>
     set((s) => {
@@ -1885,6 +1901,19 @@ export function useActiveClusterIds(): string[] {
     () => (joined === "" ? [] : joined.split("\u0000")),
     [joined],
   );
+}
+
+/// Combined reconnect-epoch of every active cluster. Bumps whenever any active
+/// cluster is reconnected (`clearClusterHealth`). A plain number so effects can
+/// add it to their dependency array to re-run on reconnect even when the active
+/// id set itself is unchanged (same-cluster reconnect). Epochs only ever
+/// increase, so summing is a sound change-detector.
+export function useActiveClusterEpoch(): number {
+  return useAppStore((s) => {
+    let sum = 0;
+    for (const id of selectActiveClusterIds(s)) sum += s.clusterEpoch[id] ?? 0;
+    return sum;
+  });
 }
 
 /// Resolve the active theme into a ready-to-use bag of tokens, typography,


### PR DESCRIPTION
Three connected reconnect/robustness bugs, all frontend (backend CRD discovery is stateless — no backend change).

## 1. Stale CRD discovery error pinned after reconnect
The Custom Resources rail cached its discovery error in Rail-local state and keyed discovery solely on the active cluster id set. A **same-cluster** reconnect never changed that key, so a stale `CRD discovery: exec credential plugin …` error stayed up even after the connection recovered.

Fix: per-cluster reconnect epoch bumped in `clearClusterHealth` (called by both manual + auto reconnect), folded into the discovery effect deps via `useActiveClusterEpoch()`. Reconnect now re-runs discovery and clears the error.

## 2. HelmChart detail whited out the whole window
Rules-of-Hooks violation: `useAppStore(selectClusterDegraded)` sat below the loading/error early returns in `HelmChartSummary`, so the ready render called one more hook than the loading render → React threw "Rendered more hooks than during the previous render" the instant the chart loaded. With **no error boundary anywhere**, the throw unwound to the React root and blanked the app.

Fix: move the hook above the guards; add a reusable `ErrorBoundary` wrapping the DetailPanel tab body (keyed on object + tab) so any future summary crash degrades to a contained `ErrorBlock` instead of a white screen.

## 3. Reconnecting banner stuck ON after recovery
The health probe emits one `unavailable` then exits, so recovery is only provable by a reconnect succeeding. On success the controller scheduled a 60s dwell but kept `clusterReconnecting` true the whole time — grayed table + banner for a full minute after data was flowing. Manual Reconnect (immediate reset) was the only thing that cleared it.

Fix: clear the user-visible reconnecting state immediately on connect-ok; keep the session + attempt counter alive through the dwell so a genuine re-flag within 60s resumes the retry sequence instead of restarting at attempt 1.

## Tests
- store: `clusterEpoch` bumps monotonically per cluster
- connection hook: banner clears immediately on connect-ok; re-flag inside dwell resumes counter (attempt 2, not 1)
- HelmChartSummary: loading→ready no-crash regression
- ErrorBoundary: containment / onError / key-reset

Full suite: 1187 passing, tsc clean.