### PR TITLE
feat(agent): Moonshot + Kimi For Coding providers, custom endpoints/models, usage-limit detection

### DIFF
--- a/crates/agent/src/config.rs
+++ b/crates/agent/src/config.rs
@@ -33,7 +33,31 @@ pub enum ProviderKind {
     Deepseek,
     Mistral,
     Together,
+    /// Moonshot AI (Kimi). OpenAI-compatible wire at
+    /// `https://api.moonshot.ai/v1`; `GET /models` is enumerable with a
+    /// key so the picker is fed live, with the models.dev catalogue
+    /// (`moonshotai`) as fallback.
+    Moonshot,
+    /// Kimi For Coding — the kimi.com coding subscription. Separate
+    /// product from the Moonshot platform: distinct base URL
+    /// (`https://api.kimi.com/coding/v1`), Anthropic-Messages wire
+    /// (models.dev `npm: @ai-sdk/anthropic`), its own model set
+    /// (`kimi-for-coding`, `k3`, …), and its own API keys.
+    #[serde(rename = "kimi_coding")]
+    KimiCoding,
     Ollama,
+    /// Operator-defined OpenAI-compatible endpoint (proxy / gateway /
+    /// self-hosted). No canonical base URL — the operator supplies one;
+    /// we probe `GET /models` and fall back to the operator's custom
+    /// model list when the endpoint isn't enumerable.
+    #[serde(rename = "custom_openai")]
+    CustomOpenAi,
+    /// Operator-defined Anthropic-Messages-compatible endpoint (e.g. a
+    /// gateway fronting Claude, or Kimi's `/anthropic` transport).
+    /// Same probing strategy as `CustomOpenAi` against Anthropic's
+    /// `GET /v1/models` shape.
+    #[serde(rename = "custom_anthropic")]
+    CustomAnthropic,
 }
 
 impl ProviderKind {
@@ -49,9 +73,13 @@ impl ProviderKind {
             Self::Minimax,
             Self::Groq,
             Self::Deepseek,
+            Self::Moonshot,
+            Self::KimiCoding,
             Self::Mistral,
             Self::Together,
             Self::Ollama,
+            Self::CustomOpenAi,
+            Self::CustomAnthropic,
         ]
     }
 
@@ -120,6 +148,14 @@ pub struct ProviderConfig {
     /// `None` = use the canonical default. Empty string = treat as `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+    /// Operator-supplied extra model ids, merged into whatever the
+    /// provider enumerates (live `/models`, models.dev catalogue, or the
+    /// static list). This is the only source for endpoints that can't
+    /// enumerate models at all, and the escape hatch for brand-new
+    /// models the catalogue hasn't picked up yet. Duplicates of an
+    /// enumerated id are dropped at merge time.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_models: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -302,7 +338,7 @@ pub struct AgentSettings {
 
 #[cfg(test)]
 mod mcp_config_tests {
-    use super::{McpServerConfig, McpTransport};
+    use super::{McpServerConfig, McpTransport, ProviderConfig, ProviderKind};
 
     #[test]
     fn legacy_config_deserializes_with_transport_and_trust_defaults() {
@@ -362,5 +398,40 @@ mod mcp_config_tests {
         assert!(!McpTransport::Stdio.is_remote());
         assert!(McpTransport::Sse.is_remote());
         assert!(McpTransport::Http.is_remote());
+    }
+
+    #[test]
+    fn provider_kind_custom_variants_use_stable_serde_ids() {
+        // Consecutive capitals would snake_case-mangle without the
+        // explicit renames (`CustomOpenAi` → `custom_open_ai`). The
+        // frontend union + keychain accounts depend on the stable ids.
+        assert_eq!(
+            serde_json::to_string(&ProviderKind::CustomOpenAi).unwrap(),
+            "\"custom_openai\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ProviderKind::CustomAnthropic).unwrap(),
+            "\"custom_anthropic\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ProviderKind::Moonshot).unwrap(),
+            "\"moonshot\""
+        );
+        let back: ProviderKind = serde_json::from_str("\"custom_openai\"").unwrap();
+        assert_eq!(back, ProviderKind::CustomOpenAi);
+    }
+
+    #[test]
+    fn provider_config_custom_models_round_trip_and_default_empty() {
+        // Legacy configs (no `custom_models` key) must parse with an
+        // empty list rather than erroring.
+        let cfg: ProviderConfig = serde_json::from_str(r#"{ "base_url": null }"#).unwrap();
+        assert!(cfg.custom_models.is_empty());
+        let cfg: ProviderConfig =
+            serde_json::from_str(r#"{ "custom_models": ["kimi-k2.5", "my-fine-tune"] }"#).unwrap();
+        assert_eq!(cfg.custom_models, vec!["kimi-k2.5", "my-fine-tune"]);
+        // Empty lists don't serialize (keeps prefs.json sparse).
+        let s = serde_json::to_string(&ProviderConfig::default()).unwrap();
+        assert!(!s.contains("custom_models"), "{s}");
     }
 }

--- a/crates/agent/src/provider/anthropic.rs
+++ b/crates/agent/src/provider/anthropic.rs
@@ -18,7 +18,7 @@ use super::{
     dropped_images_note, merge_top_level, ChatProvider, CompletionEvent, CompletionFinal,
     CompletionRequest, EventSink, FinishReason, ModelInfo, ProviderError, Usage,
 };
-use crate::config::Credential;
+use crate::config::{Credential, ProviderKind};
 use crate::provider::meta::{self, ProviderMeta};
 use crate::types::{ChatMessage, MessageRole, ToolCall};
 use async_trait::async_trait;
@@ -33,11 +33,16 @@ pub struct AnthropicProvider {
     client: reqwest::Client,
     base_url: String,
     api_key: String,
+    /// Drives catalogue / capability lookups and the default base URL.
+    /// `ProviderKind::Anthropic` for the first-party provider;
+    /// `ProviderKind::CustomAnthropic` for operator-defined
+    /// Anthropic-Messages-compatible gateways.
+    kind: ProviderKind,
 }
 
 impl AnthropicProvider {
-    pub fn new(cred: &Credential, base_url_override: Option<String>) -> Self {
-        let m: &ProviderMeta = meta::for_kind(crate::config::ProviderKind::Anthropic);
+    pub fn new(cred: &Credential, base_url_override: Option<String>, kind: ProviderKind) -> Self {
+        let m: &ProviderMeta = meta::for_kind(kind);
         let key = match cred {
             Credential::ApiKey { key } => key.trim().to_string(),
             // OAuth path is out of scope; if it gets here, send the
@@ -55,6 +60,7 @@ impl AnthropicProvider {
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| m.default_base_url.to_string()),
             api_key: key,
+            kind,
         }
     }
 
@@ -194,7 +200,7 @@ struct AnthropicModelEntry {
 #[async_trait]
 impl ChatProvider for AnthropicProvider {
     fn name(&self) -> &'static str {
-        "anthropic"
+        meta::for_kind(self.kind).id
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
@@ -229,11 +235,14 @@ impl ChatProvider for AnthropicProvider {
         // Live `/models` unreachable. Prefer the models.dev catalogue
         // (stays fresh across releases), then the curated static list as
         // the offline / cold-start fallback so the picker is never empty.
-        let cat = crate::provider::catalogue::list_models(crate::config::ProviderKind::Anthropic);
+        // Custom gateways have no catalogue entry — `list_models` returns
+        // empty for them and the static list is empty too, surfacing the
+        // live error to the operator instead of a phantom model list.
+        let cat = crate::provider::catalogue::list_models(self.kind);
         if !cat.is_empty() {
             return Ok(cat);
         }
-        Ok(meta::static_models(crate::config::ProviderKind::Anthropic)
+        Ok(meta::static_models(self.kind)
             .iter()
             .map(|(id, name)| ModelInfo {
                 id: (*id).to_string(),
@@ -251,10 +260,7 @@ impl ChatProvider for AnthropicProvider {
         // Drop image blocks only when models.dev positively says the
         // model is text-only; unknown models default to "try it" and let
         // the apiserver be the arbiter.
-        let supports_vision = crate::provider::catalogue::supports_vision(
-            crate::config::ProviderKind::Anthropic,
-            &req.model,
-        );
+        let supports_vision = crate::provider::catalogue::supports_vision(self.kind, &req.model);
         let (system, messages) = build_messages(&req.messages, supports_vision);
 
         let mut body = json!({
@@ -331,6 +337,30 @@ impl ChatProvider for AnthropicProvider {
                 "message_delta" => state.on_message_delta(&value),
                 "message_start" => state.on_message_start(&value),
                 "message_stop" => break,
+                // Mid-stream failure (`event: error` with
+                // `{type:"error", error:{type:"rate_limit_error"|
+                // "overloaded_error"|…, message}}` on an HTTP 200).
+                // Failing the round keeps it out of the empty-turn
+                // retry path and lets the classifier decide: transient
+                // (rate limit / overload) or terminal (quota).
+                "error" => {
+                    let err_type = value
+                        .pointer("/error/type")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("");
+                    let err_msg = value
+                        .pointer("/error/message")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("");
+                    return Err(ProviderError::Http {
+                        status: None,
+                        body: if err_type.is_empty() && err_msg.is_empty() {
+                            ev.data.clone()
+                        } else {
+                            format!("{err_type}: {err_msg}")
+                        },
+                    });
+                }
                 _ => {}
             }
         }

--- a/crates/agent/src/provider/meta.rs
+++ b/crates/agent/src/provider/meta.rs
@@ -211,6 +211,71 @@ const META_OLLAMA: ProviderMeta = ProviderMeta {
     default_context_window: 32_768,
 };
 
+const META_MOONSHOT: ProviderMeta = ProviderMeta {
+    id: "moonshot",
+    display_name: "Moonshot (Kimi)",
+    // International endpoint. Operators in mainland China can override
+    // the base URL to `https://api.moonshot.cn/v1` via the row's
+    // base-URL field — the wire shape is identical.
+    default_base_url: "https://api.moonshot.ai/v1",
+    auth_modes: &[AuthMode::ApiKey],
+    // `GET /v1/models` is enumerable with a key (verified: 401 without
+    // one), so the picker is fed live; models.dev (`moonshotai`) is the
+    // fallback when the endpoint is unreachable.
+    models_endpoint: ModelsEndpoint::OpenAiCompatible,
+    flavor: ProviderFlavor::OpenAiCompat,
+    // Kimi K2 generation is 256k; older moonshot-v1 models are 128k.
+    default_context_window: 131_072,
+};
+
+const META_CUSTOM_OPENAI: ProviderMeta = ProviderMeta {
+    id: "custom_openai",
+    display_name: "Custom (OpenAI-compatible)",
+    // No canonical endpoint — the operator must supply one via the
+    // base-URL field. The placeholder matches Ollama-style local
+    // gateways; it's only a hint, never a sensible default.
+    default_base_url: "http://localhost:8080/v1",
+    auth_modes: &[AuthMode::ApiKey],
+    // Probe `GET /models`; when the endpoint can't enumerate, the
+    // operator's custom model list carries the picker.
+    models_endpoint: ModelsEndpoint::OpenAiCompatible,
+    flavor: ProviderFlavor::OpenAiCompat,
+    // Unknown upstream — conservative middle; custom models get the
+    // same fallback unless the operator's gateway reports limits.
+    default_context_window: 131_072,
+};
+
+const META_CUSTOM_ANTHROPIC: ProviderMeta = ProviderMeta {
+    id: "custom_anthropic",
+    display_name: "Custom (Anthropic-compatible)",
+    default_base_url: "http://localhost:8080/v1",
+    auth_modes: &[AuthMode::ApiKey],
+    // Anthropic's `GET /v1/models` shape (`{data:[{id, display_name}]}`).
+    models_endpoint: ModelsEndpoint::AnthropicCatalogue,
+    flavor: ProviderFlavor::AnthropicMessages,
+    default_context_window: 200_000,
+};
+
+const META_KIMI_CODING: ProviderMeta = ProviderMeta {
+    id: "kimi_coding",
+    display_name: "Kimi For Coding",
+    // The kimi.com coding subscription — a separate product from the
+    // Moonshot platform (different keys, different model set). Verified
+    // against the live API: Anthropic-Messages wire (`x-api-key` +
+    // `anthropic-version`, `event:`-line SSE), enumerable
+    // `GET /v1/models`, thinking blocks always on
+    // (`supports_thinking_type: "only"` — streamed as `thinking_delta`,
+    // which our SSE machine skips), tolerant of assistant history
+    // without thinking blocks, and `budget_tokens` accepted.
+    default_base_url: "https://api.kimi.com/coding/v1",
+    auth_modes: &[AuthMode::ApiKey],
+    models_endpoint: ModelsEndpoint::AnthropicCatalogue,
+    flavor: ProviderFlavor::AnthropicMessages,
+    // kimi-for-coding / k3-256k are 256k; k3 is 1M. Conservative
+    // fallback; models.dev (`kimi-for-coding`) enriches per model.
+    default_context_window: 262_144,
+};
+
 pub fn for_kind(kind: ProviderKind) -> &'static ProviderMeta {
     match kind {
         ProviderKind::OpencodeZen => &META_OPENCODE_ZEN,
@@ -224,6 +289,10 @@ pub fn for_kind(kind: ProviderKind) -> &'static ProviderMeta {
         ProviderKind::Mistral => &META_MISTRAL,
         ProviderKind::Together => &META_TOGETHER,
         ProviderKind::Ollama => &META_OLLAMA,
+        ProviderKind::Moonshot => &META_MOONSHOT,
+        ProviderKind::KimiCoding => &META_KIMI_CODING,
+        ProviderKind::CustomOpenAi => &META_CUSTOM_OPENAI,
+        ProviderKind::CustomAnthropic => &META_CUSTOM_ANTHROPIC,
     }
 }
 
@@ -249,9 +318,19 @@ pub fn models_dev_id(kind: ProviderKind) -> Option<&'static str> {
         // capability enrichment for them.
         ProviderKind::Zai => "zai",
         ProviderKind::Minimax => "minimax",
+        // Moonshot's international catalogue on models.dev. (There's a
+        // separate `moonshotai-cn` entry for the China endpoint; we key
+        // enrichment off the international one — model ids overlap.)
+        ProviderKind::Moonshot => "moonshotai",
+        // Separate catalogue entry from `moonshotai` — different product,
+        // different models (`kimi-for-coding`, `k3`), different limits.
+        ProviderKind::KimiCoding => "kimi-for-coding",
         // Ollama serves local models that aren't in models.dev — keep it
-        // on the live `/models` path.
-        ProviderKind::Ollama => return None,
+        // on the live `/models` path. Custom endpoints are by definition
+        // not in the community catalogue.
+        ProviderKind::Ollama | ProviderKind::CustomOpenAi | ProviderKind::CustomAnthropic => {
+            return None;
+        }
     })
 }
 
@@ -270,6 +349,23 @@ pub fn static_models(kind: ProviderKind) -> &'static [(&'static str, &'static st
             ("MiniMax-M2", "MiniMax-M2"),
             ("MiniMax-Text-01", "MiniMax-Text-01"),
             ("abab6.5s-chat", "abab6.5s"),
+        ],
+        // Moonshot — offline / cold-start fallback only; the live
+        // `/models` endpoint is enumerable with a key and models.dev
+        // covers the rest. Ids mirror the public model index.
+        ProviderKind::Moonshot => &[
+            ("kimi-k2.5", "Kimi K2.5"),
+            ("kimi-k2-thinking", "Kimi K2 Thinking"),
+            ("kimi-k2-0905-preview", "Kimi K2 (0905 preview)"),
+            ("moonshot-v1-128k", "Moonshot v1 128k"),
+        ],
+        // Kimi For Coding — offline fallback only; live `/v1/models` is
+        // enumerable with a key (verified).
+        ProviderKind::KimiCoding => &[
+            ("kimi-for-coding", "K2.7 Coding"),
+            ("kimi-for-coding-highspeed", "K2.7 Coding Highspeed"),
+            ("k3", "K3 (1M)"),
+            ("k3-256k", "K3 256k"),
         ],
         // Anthropic — used by the Anthropic provider when the live
         // catalogue call fails. Names mirror the public model index.
@@ -310,5 +406,67 @@ mod tests {
         // Ollama serves local models absent from models.dev — must stay on
         // the live `/models` path.
         assert_eq!(models_dev_id(ProviderKind::Ollama), None);
+    }
+
+    #[test]
+    fn moonshot_metadata_points_at_enumerable_openai_endpoint() {
+        let m = for_kind(ProviderKind::Moonshot);
+        assert_eq!(m.id, "moonshot");
+        assert_eq!(m.default_base_url, "https://api.moonshot.ai/v1");
+        assert!(matches!(
+            m.models_endpoint,
+            ModelsEndpoint::OpenAiCompatible
+        ));
+        assert!(matches!(m.flavor, ProviderFlavor::OpenAiCompat));
+        assert_eq!(models_dev_id(ProviderKind::Moonshot), Some("moonshotai"));
+        assert!(!static_models(ProviderKind::Moonshot).is_empty());
+    }
+
+    #[test]
+    fn custom_providers_have_no_catalogue_and_unique_ids() {
+        // Custom endpoints aren't on models.dev (catalogue enrichment /
+        // fallback list would be wrong for an arbitrary gateway), and
+        // their keychain account ids must not collide with built-ins.
+        for kind in [ProviderKind::CustomOpenAi, ProviderKind::CustomAnthropic] {
+            assert_eq!(models_dev_id(kind), None);
+            assert!(static_models(kind).is_empty());
+        }
+        let ids: std::collections::HashSet<&str> = ProviderKind::all()
+            .iter()
+            .map(|k| for_kind(*k).id)
+            .collect();
+        assert_eq!(ids.len(), ProviderKind::all().len());
+        assert!(matches!(
+            for_kind(ProviderKind::CustomAnthropic).flavor,
+            ProviderFlavor::AnthropicMessages
+        ));
+    }
+
+    #[test]
+    fn kimi_coding_is_anthropic_wired_with_own_catalogue() {
+        // The kimi.com coding subscription is a separate product from
+        // the Moonshot platform: Anthropic-Messages wire, its own
+        // models.dev entry, its own keychain id. Verified against the
+        // live API (2026-07): `GET /coding/v1/models` + `/messages` SSE
+        // both speak the Anthropic shapes with `x-api-key` auth.
+        let m = for_kind(ProviderKind::KimiCoding);
+        assert_eq!(m.id, "kimi_coding");
+        assert_eq!(m.default_base_url, "https://api.kimi.com/coding/v1");
+        assert!(matches!(
+            m.models_endpoint,
+            ModelsEndpoint::AnthropicCatalogue
+        ));
+        assert!(matches!(m.flavor, ProviderFlavor::AnthropicMessages));
+        assert_eq!(
+            models_dev_id(ProviderKind::KimiCoding),
+            Some("kimi-for-coding")
+        );
+        assert!(static_models(ProviderKind::KimiCoding)
+            .iter()
+            .any(|(id, _)| *id == "kimi-for-coding"));
+        assert_eq!(
+            serde_json::to_string(&ProviderKind::KimiCoding).unwrap(),
+            "\"kimi_coding\""
+        );
     }
 }

--- a/crates/agent/src/provider/openai_codex.rs
+++ b/crates/agent/src/provider/openai_codex.rs
@@ -389,8 +389,29 @@ impl ChatProvider for OpenAICodexProvider {
                     break;
                 }
                 "response.failed" | "response.cancelled" => {
+                    // In-stream failure: the HTTP status was 200, so the
+                    // only place the error exists is the terminal event's
+                    // payload (`response.error.code` — e.g.
+                    // `insufficient_quota`, `usage_not_included`).
+                    // Swallowing it here produces an empty turn, which
+                    // the loop retries — the operator watches
+                    // "thinking…" appear and vanish in a loop while a
+                    // hard quota error goes unreported. Surface it
+                    // instead so the classifier can stop the turn (or
+                    // retry with the reason visible). Mirrors opencode's
+                    // `parseStreamError` path.
+                    if let Some(err) = codex_stream_error(&value) {
+                        return Err(err);
+                    }
                     state.finish_reason = FinishReason::Other;
                     break;
+                }
+                // Bare error event (no `response.` prefix) — same
+                // reasoning: never let it degrade to an empty turn.
+                "error" => {
+                    if let Some(err) = codex_stream_error(&value) {
+                        return Err(err);
+                    }
                 }
                 _ => {}
             }
@@ -420,6 +441,44 @@ impl OpenAICodexProvider {
             .await
             .map_err(|e| ProviderError::transport(e.to_string()))
     }
+}
+
+/// Extract a `ProviderError` from an in-stream failure event. The Codex
+/// Responses endpoint can report errors two ways: a non-2xx HTTP status
+/// (handled at `send()` time) or, mid-stream on an HTTP 200, a terminal
+/// `response.failed` / bare `error` SSE event carrying
+/// `{ error: { code, message } }`. Probe the documented nesting spots:
+/// `response.error` (Responses-API object), `response.status_details.
+/// error` (earlier drafts), and the bare event's own `error` / `message`.
+/// `status: None` on the returned error is deliberate — the classifier
+/// keys on the vendor codes inside the body instead.
+fn codex_stream_error(v: &Value) -> Option<ProviderError> {
+    // Probe the documented nesting spots: `response.error` (Responses-API
+    // object), `response.status_details.error` (earlier drafts), and the
+    // bare event's own `error`.
+    let candidates = [
+        v.pointer("/response/error"),
+        v.pointer("/response/status_details/error"),
+        v.get("error"),
+    ];
+    let err = candidates.into_iter().flatten().next()?;
+    let code = err.get("code").and_then(|x| x.as_str());
+    let message = err
+        .get("message")
+        .and_then(|x| x.as_str())
+        .or_else(|| v.get("message").and_then(|x| x.as_str()));
+    if code.is_none() && message.is_none() {
+        return None;
+    }
+    // Render a compact single-line body: classifier substring-matches on
+    // it, and it's what the operator sees inside the error bubble.
+    let body = match (code, message) {
+        (Some(c), Some(m)) => format!("{c}: {m}"),
+        (Some(c), None) => c.to_string(),
+        (None, Some(m)) => m.to_string(),
+        (None, None) => unreachable!(),
+    };
+    Some(ProviderError::Http { status: None, body })
 }
 
 fn build_request_body(req: &CompletionRequest, instructions: &str, input: &[Value]) -> Value {
@@ -754,5 +813,70 @@ mod tests {
         assert!(evs
             .iter()
             .any(|e| matches!(e, CompletionEvent::ToolCallEnd{ id } if id == "c1")));
+    }
+
+    #[test]
+    fn stream_error_extracts_quota_code_from_response_failed() {
+        // The exact shape opencode's `parseStreamError` matches: a
+        // `response.failed` terminal event on an HTTP 200 carrying
+        // `response.error.code`. Must become a ProviderError whose body
+        // names the code — the app-layer classifier turns this into a
+        // terminal "usage limit reached" instead of an empty-turn retry
+        // loop.
+        let v = json!({
+            "type": "response.failed",
+            "response": {
+                "status": "failed",
+                "error": {
+                    "code": "insufficient_quota",
+                    "message": "You have used up your ChatGPT Codex allowance. Try again later."
+                }
+            }
+        });
+        let err = codex_stream_error(&v).expect("error extracted");
+        let text = err.to_string();
+        assert!(text.contains("insufficient_quota"), "{text}");
+        assert!(text.contains("allowance"), "{text}");
+        // No HTTP status — the stream was 200; classification must key
+        // on the body, not a status code.
+        match err {
+            ProviderError::Http { status, .. } => assert_eq!(status, None),
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_error_handles_bare_error_event_and_status_details() {
+        // Bare `{type:"error", error:{...}}` event (opencode's shape).
+        let v = json!({
+            "type": "error",
+            "error": { "code": "usage_not_included", "message": "upgrade to Plus" }
+        });
+        let err = codex_stream_error(&v).expect("bare error event");
+        assert!(err.to_string().contains("usage_not_included"));
+
+        // status_details nesting (earlier Responses drafts).
+        let v = json!({
+            "type": "response.failed",
+            "response": {
+                "status_details": {
+                    "error": { "code": "server_is_overloaded" }
+                }
+            }
+        });
+        let err = codex_stream_error(&v).expect("status_details error");
+        assert!(err.to_string().contains("server_is_overloaded"));
+    }
+
+    #[test]
+    fn stream_error_none_without_error_payload() {
+        // `response.cancelled` (operator abort) carries no error —
+        // must not fabricate one (the loop treats cancellation
+        // separately from failures).
+        let v = json!({ "type": "response.cancelled", "response": { "status": "cancelled" } });
+        assert!(codex_stream_error(&v).is_none());
+        // Empty error object → no code, no message → None.
+        let v = json!({ "type": "error", "error": {} });
+        assert!(codex_stream_error(&v).is_none());
     }
 }

--- a/crates/agent/src/provider/openai_compat.rs
+++ b/crates/agent/src/provider/openai_compat.rs
@@ -274,6 +274,12 @@ struct OaStreamEvent {
     choices: Vec<OaStreamChoice>,
     #[serde(default)]
     usage: Option<OaUsage>,
+    /// Mid-stream error payload (`{"error":{code,message}}` on an HTTP
+    /// 200). OpenAI-compat gateways deliver some failures this way —
+    /// without reading it, the stream looks like a clean-but-empty
+    /// completion and the caller retries a hard error in a loop.
+    #[serde(default)]
+    error: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -510,6 +516,22 @@ impl ChatProvider for OpenAICompatibleProvider {
                     continue;
                 }
             };
+
+            // In-stream error payload — fail the round with the raw body
+            // so the classifier sees the vendor code (status: None is
+            // deliberate; the HTTP status was 200).
+            if let Some(err) = parsed.error {
+                let code = err.get("code").and_then(|x| x.as_str()).unwrap_or("");
+                let msg = err.get("message").and_then(|x| x.as_str()).unwrap_or("");
+                return Err(ProviderError::Http {
+                    status: None,
+                    body: if code.is_empty() && msg.is_empty() {
+                        ev.data.clone()
+                    } else {
+                        format!("{code}: {msg}")
+                    },
+                });
+            }
 
             for choice in parsed.choices {
                 if let Some(text) = choice.delta.content {

--- a/crates/app/src/agent/classify.rs
+++ b/crates/app/src/agent/classify.rs
@@ -53,8 +53,28 @@ pub(crate) fn is_transient_error(e: &ProviderError) -> Option<String> {
         // timeouts, which are inherently retryable. (Envoy/Cloudflare 5xx
         // bodies like "upstream connect error" already match the 5xx status
         // branch above; these phrases catch the pre-response TCP failures.)
+        // In-stream vendor error codes arrive the same way (HTTP 200, then
+        // an SSE error payload → `Http { status: None }`): rate limits and
+        // overload codes are retryable; quota codes have already been
+        // pulled out by `classify_usage_limit` upstream of this call.
         _ => {
             let s = e.to_string().to_ascii_lowercase();
+            for code in [
+                // OpenAI rate limit (RPM/TPM) — self-heals.
+                "rate_limit_exceeded",
+                // Kimi / Moonshot RPM / concurrency / TPM variants.
+                "rate_limit_reached_error",
+                // OpenAI Codex + Kimi overload codes.
+                "server_is_overloaded",
+                "engine_overloaded",
+                // Anthropic mid-stream error-event types.
+                "rate_limit_error",
+                "overloaded_error",
+            ] {
+                if s.contains(code) {
+                    return Some("rate limited".into());
+                }
+            }
             for phrase in [
                 "upstream connect error",
                 "disconnect/reset before headers",
@@ -82,6 +102,96 @@ pub(crate) fn transient_retry_delay_ms(attempt: u8) -> u64 {
     let exp = u32::from(attempt.saturating_sub(1)).min(20);
     let raw = TRANSIENT_RETRY_INITIAL_DELAY_MS.saturating_mul(2u64.saturating_pow(exp));
     raw.min(TRANSIENT_RETRY_MAX_DELAY_MS)
+}
+
+/// Classify a `ProviderError` as an account-level **usage limit** — the
+/// operator is out of quota / credit / paid allowance, so silently
+/// retrying (the way we treat a 503 or a per-minute rate limit) just
+/// hides the real problem. Returns a short reason label when the error
+/// matches; the caller renders it, persists it, and stops the turn
+/// instead of entering the transient-retry loop.
+///
+/// Mirrors opencode's `retry.ts::retryable` distinction: plain 429s and
+/// "Overloaded" stay retryable there too, while quota-shaped bodies
+/// (`FreeUsageLimitError`, `GoUsageLimitError`, `insufficient_quota`)
+/// get surfaced to the operator as an actionable message. We go one
+/// step further and stop the turn — FerrisScope's retry budget is
+/// bounded (opencode retries forever), and burning five back-off
+/// attempts against a hard quota adds minutes of dead air for nothing.
+pub(crate) fn classify_usage_limit(e: &ProviderError) -> Option<String> {
+    let ProviderError::Http { status, body } = e else {
+        return None;
+    };
+    let code = status.unwrap_or(0);
+    // 402 is unambiguous: payment / billing problem. (Rare on the wire
+    // — most vendors fold it into 403/429 — but explicit when seen.)
+    if code == 402 {
+        return Some("billing / payment required (HTTP 402)".into());
+    }
+    let lower = body.to_ascii_lowercase();
+    // Vendor *codes* — machine tokens that only appear in structured
+    // error payloads, so they're safe to match even without an HTTP
+    // status. This is what saves the Codex/ChatGPT OAuth path: the
+    // Responses endpoint delivers `insufficient_quota` /
+    // `usage_not_included` as an in-stream SSE error on an HTTP 200,
+    // and Kimi/Moonshot uses `exceeded_current_quota_error` the same
+    // way. A transport error's prose can't trip these.
+    const CODE_MARKERS: &[&str] = &[
+        // OpenAI / OpenRouter quota exhaustion code (`insufficient_quota`,
+        // 429 "check your plan and billing details"; also 403
+        // `billing_hard_limit_reached`).
+        "insufficient_quota",
+        "billing_hard_limit_reached",
+        // OpenAI Codex (ChatGPT OAuth): plan doesn't include Codex
+        // usage — upgrade required (opencode's `usage_not_included`,
+        // isRetryable: false).
+        "usage_not_included",
+        // OpenCode Zen free-tier / Go-tier limit markers (opencode's
+        // own upstream surfaces these in the error body).
+        "freeusagelimiterror",
+        "gousagelimiterror",
+        // Moonshot / Kimi: balance / token quota / per-day cap
+        // (`exceeded_current_quota_error`; the TPD variant of
+        // `rate_limit_reached_error` resets "the next day", so it
+        // counts as a usage limit, not a slow-down).
+        "exceeded_current_quota",
+        "tpd limit reached",
+        // Anthropic `billing_error` (can arrive as a mid-stream error
+        // event with no HTTP status).
+        "billing_error",
+    ];
+    if CODE_MARKERS.iter().any(|m| lower.contains(m)) {
+        return Some(match code {
+            0 => "account limit reached (usage quota exhausted)".into(),
+            429 => "usage limit / quota exhausted (HTTP 429)".into(),
+            403 => "access denied — quota or plan restriction (HTTP 403)".into(),
+            other => format!("account limit reached (HTTP {other})"),
+        });
+    }
+    // Prose markers — matched only on real 4xx responses, where the
+    // body is the provider's error document. Requiring the status keeps
+    // transport-error prose from false-positiving.
+    const PROSE_MARKERS: &[&str] = &[
+        "usage limit",
+        // Anthropic credit exhaustion ("credit balance is too low").
+        "credit balance",
+        "quota is insufficient",
+        "balance is insufficient",
+        // Generic vendor phrasings (Google, Azure OpenAI, Mistral).
+        "quota exceeded",
+        "exceeded your current quota",
+        "exceed your quota",
+        "spend limit",
+        "billing",
+    ];
+    if (400..500).contains(&code) && PROSE_MARKERS.iter().any(|m| lower.contains(m)) {
+        return Some(match code {
+            429 => "usage limit / quota exhausted (HTTP 429)".into(),
+            403 => "access denied — quota or plan restriction (HTTP 403)".into(),
+            other => format!("account limit reached (HTTP {other})"),
+        });
+    }
+    None
 }
 
 /// Heuristic: does this provider error look like a context-window /
@@ -375,5 +485,135 @@ mod tests {
         // at 5 anyway, but the math has to be safe past that).
         assert_eq!(transient_retry_delay_ms(10), 30_000);
         assert_eq!(transient_retry_delay_ms(255), 30_000);
+    }
+
+    #[test]
+    fn usage_limit_openai_insufficient_quota_is_terminal() {
+        // OpenAI's canonical quota-exhausted shape: 429 + code.
+        let e = http(
+            429,
+            "{\"error\":{\"code\":\"insufficient_quota\",\"message\":\"You exceeded your current quota\"}}",
+        );
+        assert!(classify_usage_limit(&e).is_some());
+    }
+
+    #[test]
+    fn usage_limit_plain_429_stays_transient() {
+        // A per-minute rate limit with no quota marker must keep the
+        // transient-retry path — killing the turn on every 429 would be
+        // strictly worse for bursty providers (OpenRouter, Anthropic).
+        let e = http(
+            429,
+            "{\"error\":{\"message\":\"Rate limit reached, slow down\"}}",
+        );
+        assert!(classify_usage_limit(&e).is_none());
+        assert!(is_transient_error(&e).is_some());
+    }
+
+    #[test]
+    fn usage_limit_detected_across_vendor_shapes() {
+        for (status, body) in [
+            (402, "Payment required"),
+            (429, "FreeUsageLimitError: free tier exhausted"),
+            (429, "GoUsageLimitError"),
+            (400, "Your credit balance is too low to access the API"),
+            (403, "usage limit reached for this workspace"),
+            (429, "Quota exceeded for metric: generate_requests"),
+            // Moonshot / Kimi: balance / token quota / per-day cap.
+            (429, "{\"error\":{\"type\":\"exceeded_current_quota_error\",\"message\":\"Token quota is insufficient\"}}"),
+            (429, "Account balance is insufficient or the account has been disabled"),
+            (429, "Organization-level TPD limit reached"),
+            // OpenAI Codex (OAuth): ChatGPT plan doesn't include Codex.
+            (403, "{\"error\":{\"code\":\"usage_not_included\",\"message\":\"upgrade to Plus\"}}"),
+            // OpenAI platform: monthly billing hard cap (403).
+            (403, "{\"error\":{\"code\":\"billing_hard_limit_reached\"}}"),
+        ] {
+            assert!(
+                classify_usage_limit(&http(status, body)).is_some(),
+                "{status} {body} should classify as usage limit"
+            );
+        }
+    }
+
+    #[test]
+    fn usage_limit_rate_limit_codes_stay_transient() {
+        // Per-minute / per-token rate limits self-heal — they must keep
+        // the transient-retry path. Both vendor shapes in one: OpenAI's
+        // `rate_limit_exceeded` RPM and Kimi's `rate_limit_reached_error`
+        // RPM / concurrency / engine-overload variants.
+        for body in [
+            "{\"error\":{\"code\":\"rate_limit_exceeded\",\"message\":\"Rate limit reached for gpt-5: 50 RPM\"}}",
+            "{\"error\":{\"type\":\"rate_limit_reached_error\",\"message\":\"Organization-level RPM limit reached\"}}",
+            "{\"error\":{\"type\":\"rate_limit_reached_error\",\"message\":\"Organization-level concurrency limit reached\"}}",
+            "{\"error\":{\"type\":\"engine_overloaded_error\",\"message\":\"The engine is currently overloaded\"}}",
+        ] {
+            let e = http(429, body);
+            assert!(
+                classify_usage_limit(&e).is_none(),
+                "{body} should NOT be a terminal usage limit"
+            );
+            assert!(is_transient_error(&e).is_some(), "{body} stays transient");
+        }
+    }
+
+    #[test]
+    fn usage_limit_ignores_non_http_and_success_shaped_errors() {
+        assert!(classify_usage_limit(&ProviderError::Auth("nope".into())).is_none());
+        assert!(
+            classify_usage_limit(&ProviderError::transport("connection reset")).is_none(),
+            "transport errors have no status/body to classify"
+        );
+        // 5xx with the word "quota" is an upstream failure, not the
+        // operator's account limit — stay on the transient path.
+        assert!(classify_usage_limit(&http(503, "upstream quota exhausted")).is_none());
+    }
+
+    #[test]
+    fn usage_limit_in_stream_codes_without_http_status() {
+        // The Codex/ChatGPT OAuth regression: the Responses endpoint
+        // delivers quota failures as an SSE `response.failed` event on
+        // an HTTP 200, so the error reaches the classifier with
+        // `status: None`. Vendor codes must still classify terminal —
+        // this was the "thinking… appears and vanishes in a loop" bug.
+        let in_stream = |body: &str| ProviderError::Http {
+            status: None,
+            body: body.to_owned(),
+        };
+        for body in [
+            "insufficient_quota: You have used up your ChatGPT Codex allowance",
+            "usage_not_included: To use Codex with your ChatGPT plan, upgrade to Plus",
+            "exceeded_current_quota_error: Token quota is insufficient",
+            "billing_error: your account has no active billing relationship",
+            "billing_hard_limit_reached",
+        ] {
+            assert!(
+                classify_usage_limit(&in_stream(body)).is_some(),
+                "in-stream {body} should classify as usage limit"
+            );
+        }
+        // Rate-limit / overload codes with no status stay transient
+        // (and the usage-limit classifier must not claim them).
+        for body in [
+            "rate_limit_exceeded: Rate limit reached, 50 RPM",
+            "server_is_overloaded",
+            "rate_limit_error: too many requests",
+            "overloaded_error: Overloaded",
+        ] {
+            let e = in_stream(body);
+            assert!(
+                classify_usage_limit(&e).is_none(),
+                "in-stream {body} should NOT be a usage limit"
+            );
+            assert!(
+                is_transient_error(&e).is_some(),
+                "in-stream {body} stays transient"
+            );
+        }
+        // Prose markers still require a real status — a transport error
+        // mentioning "quota" must not classify.
+        assert!(classify_usage_limit(&ProviderError::transport(
+            "dns lookup failed for quota.example.com"
+        ))
+        .is_none());
     }
 }

--- a/crates/app/src/agent/commands.rs
+++ b/crates/app/src/agent/commands.rs
@@ -45,11 +45,11 @@ pub(crate) async fn ai_get_settings(
     let mut providers = HashMap::with_capacity(ProviderKind::all().len());
     for kind in ProviderKind::all() {
         let m: &ProviderMeta = meta::for_kind(*kind);
-        let base_url_override = p
-            .settings
-            .providers
-            .get(kind)
-            .and_then(|c| c.base_url.clone());
+        let provider_cfg = p.settings.providers.get(kind);
+        let base_url_override = provider_cfg.and_then(|c| c.base_url.clone());
+        let custom_models = provider_cfg
+            .map(|c| c.custom_models.clone())
+            .unwrap_or_default();
         let cred = read_credential(*kind).await;
         // Providers with a public fallback (OpenCode Zen's free tier)
         // report as configured even without an operator credential —
@@ -92,6 +92,7 @@ pub(crate) async fn ai_get_settings(
                 auth_mode,
                 configured: cred.is_some() || public_fallback_active,
                 account_label,
+                custom_models,
             },
         );
     }
@@ -126,6 +127,18 @@ pub(crate) async fn ai_set_settings(
         } else {
             Some(bu.base_url)
         };
+    }
+    if let Some(cm) = patch.provider_custom_models {
+        let cfg = p.settings.providers.entry(cm.provider).or_default();
+        // Normalise: trim, drop empties, dedupe preserving operator order.
+        let mut seen = HashSet::new();
+        cfg.custom_models = cm
+            .models
+            .into_iter()
+            .map(|m| m.trim().to_string())
+            .filter(|m| !m.is_empty())
+            .filter(|m| seen.insert(m.clone()))
+            .collect();
     }
     if let Some(m) = patch.default_model {
         p.settings.default_model = if m.is_empty() { None } else { Some(m) };
@@ -228,28 +241,102 @@ pub(crate) async fn ai_test_provider(
     req: ProviderTestRequest,
     _state: State<'_, AgentState>,
 ) -> Result<ProviderTestResult, String> {
-    let cred = Credential::ApiKey { key: req.api_key };
-    let provider = match build_provider(req.provider, &cred, req.base_url, None, None) {
-        Ok(p) => p,
-        Err(e) => {
-            return Ok(ProviderTestResult {
-                ok: false,
-                model_count: 0,
-                error: Some(e),
-            })
-        }
+    // Blank key = "test the saved credential" — the settings row lets the
+    // operator re-validate an already-persisted connection without
+    // re-pasting the secret (which never round-trips to the frontend).
+    // With nothing stored we still probe unauthenticated: open endpoints
+    // (local Ollama, some gateways) answer `GET /models` with no auth,
+    // and closed ones 401 — which is itself the correct test result.
+    let cred = if req.api_key.trim().is_empty() {
+        read_credential(req.provider)
+            .await
+            .unwrap_or(Credential::ApiKey { key: String::new() })
+    } else {
+        Credential::ApiKey { key: req.api_key }
     };
-    match provider.list_models().await {
-        Ok(models) => Ok(ProviderTestResult {
-            ok: true,
-            model_count: models.len(),
-            error: None,
-        }),
+
+    // Probe the live `GET /models` endpoint directly rather than going
+    // through `ChatProvider::list_models` — that path deliberately falls
+    // back to the models.dev catalogue / static list when the network
+    // fails, which would mask a bad key or wrong base URL behind a
+    // phantom "OK · N models". The test button exists to validate the
+    // *connection*, so only a live 200 counts.
+    let m: &ProviderMeta = meta::for_kind(req.provider);
+    let base_url = req
+        .base_url
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| m.default_base_url.to_string());
+    let url = format!("{}/models", base_url.trim_end_matches('/'));
+    let key = match &cred {
+        Credential::ApiKey { key } => key.trim().to_string(),
+        Credential::OAuth { access, .. } => access.clone(),
+    };
+    let mut http = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| e.to_string())?
+        .get(&url);
+    if !key.is_empty() {
+        http = match m.flavor {
+            // Anthropic's first-party auth style (`x-api-key` + version);
+            // every OpenAI-shaped endpoint takes a Bearer token.
+            ferrisscope_agent::ProviderFlavor::AnthropicMessages => http
+                .header("x-api-key", &key)
+                .header("anthropic-version", "2023-06-01"),
+            _ => http.bearer_auth(&key),
+        };
+    }
+    match http.send().await {
         Err(e) => Ok(ProviderTestResult {
             ok: false,
             model_count: 0,
-            error: Some(e.to_string()),
+            error: Some(format!("cannot reach {url}: {e}")),
         }),
+        Ok(resp) => {
+            let status = resp.status();
+            if !status.is_success() {
+                let code = status.as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                // Trim noisy HTML / long JSON error bodies for the chip.
+                let trimmed = body.trim();
+                let snippet = if trimmed.len() > 200 {
+                    format!("{}…", &trimmed[..200])
+                } else {
+                    trimmed.to_string()
+                };
+                return Ok(ProviderTestResult {
+                    ok: false,
+                    model_count: 0,
+                    error: Some(if snippet.is_empty() {
+                        format!("HTTP {code} from {url}")
+                    } else {
+                        format!("HTTP {code}: {snippet}")
+                    }),
+                });
+            }
+            // Both shapes we care about (`{data:[{id}]}` OpenAI-style and
+            // Anthropic's `{data:[{id, display_name}]}`) hang the list off
+            // `data`; count entries without parsing the full shape.
+            let body = resp.text().await.unwrap_or_default();
+            let count = serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| v.get("data")?.as_array().map(Vec::len));
+            match count {
+                Some(n) => Ok(ProviderTestResult {
+                    ok: true,
+                    model_count: n,
+                    error: None,
+                }),
+                None => Ok(ProviderTestResult {
+                    ok: false,
+                    model_count: 0,
+                    error: Some(
+                        "reachable but `GET /models` returned no `data` list — this endpoint may not enumerate models; add custom models below".to_string(),
+                    ),
+                }),
+            }
+        }
     }
 }
 
@@ -517,6 +604,27 @@ async fn mcp_test_remote(config: &McpServerConfig) -> McpTestResult {
     }
 }
 
+/// Merge the operator's custom model ids into an enumerated list. Ids
+/// already present (live `/models`, catalogue, or static) win so their
+/// display name / context length survive; new ids append bare. This is
+/// the only model source for endpoints that can't enumerate at all.
+fn merge_custom_models(
+    models: &mut Vec<ModelInfo>,
+    cfg: Option<&ferrisscope_agent::ProviderConfig>,
+) {
+    let Some(cfg) = cfg else { return };
+    let existing: HashSet<String> = models.iter().map(|m| m.id.clone()).collect();
+    for id in &cfg.custom_models {
+        if !existing.contains(id.as_str()) {
+            models.push(ModelInfo {
+                id: id.clone(),
+                name: None,
+                context_length: None,
+            });
+        }
+    }
+}
+
 /// List models for a provider. Defaults to `active_provider` when
 /// `provider` is absent so the existing single-provider call sites keep
 /// working. The provider must already be configured (credential set).
@@ -547,10 +655,24 @@ pub(crate) async fn ai_list_models(
         .get(&kind)
         .and_then(|c| c.base_url.clone());
     let provider_impl = build_provider(kind, &cred, base_url, None, None)?;
-    let mut models = provider_impl
-        .list_models()
-        .await
-        .map_err(|e| e.to_string())?;
+    let mut models = match provider_impl.list_models().await {
+        Ok(m) => m,
+        Err(e) => {
+            // Enumeration failed (endpoint down, bad key, or no `/models`
+            // at all). If the operator maintains a custom list, return
+            // that instead of erroring — for custom gateways it's the
+            // designed path, and for built-ins it still leaves the
+            // picker usable while surfacing nothing misleading (the
+            // custom ids are the operator's own).
+            let mut v = Vec::new();
+            merge_custom_models(&mut v, p.settings.providers.get(&kind));
+            if v.is_empty() {
+                return Err(e.to_string());
+            }
+            return Ok(v);
+        }
+    };
+    merge_custom_models(&mut models, p.settings.providers.get(&kind));
     // OpenCode Zen on the public tier — drop everything the catalogue
     // marks as paid. Mirrors opencode's `cost.input === 0` filter.
     // When the catalogue hasn't loaded yet for this provider we leave
@@ -607,6 +729,7 @@ pub(crate) async fn chat_create_session(
                 .and_then(|c| c.base_url.clone());
             if let Ok(provider_impl) = build_provider(kind, &cred, base_url, None, None) {
                 if let Ok(mut list) = provider_impl.list_models().await {
+                    merge_custom_models(&mut list, p.settings.providers.get(&kind));
                     let public_fallback_active = matches!(cred, Credential::ApiKey { ref key } if Some(key.as_str()) == kind.public_fallback_key());
                     if public_fallback_active
                         && ferrisscope_agent::provider::catalogue::has_data_for(kind)

--- a/crates/app/src/agent/settings.rs
+++ b/crates/app/src/agent/settings.rs
@@ -86,10 +86,10 @@ pub(crate) async fn load_persisted() -> PersistedSettings {
                                 .and_then(|x| x.as_str())
                                 .map(|s| s.to_string())
                                 .filter(|s| !s.is_empty());
-                            p.settings
-                                .providers
-                                .entry(kind)
-                                .or_insert(ProviderConfig { base_url });
+                            p.settings.providers.entry(kind).or_insert(ProviderConfig {
+                                base_url,
+                                ..ProviderConfig::default()
+                            });
                         }
                     }
                 }

--- a/crates/app/src/agent/turn.rs
+++ b/crates/app/src/agent/turn.rs
@@ -18,10 +18,10 @@ use crate::state::AppState;
 
 use super::{
     assemble_system_prompt, build_cluster_context_block, build_view_context_block,
-    context_limits_for, execute_tool_call, is_context_overflow_error, is_transient_error,
-    maybe_run_compaction, maybe_spill, redact_secrets, repair_orphan_tool_calls,
-    run_compaction_internal, tools_to_schemas, transient_retry_delay_ms, ChatEvent, ChatRuntime,
-    PersistedSettings,
+    classify_usage_limit, context_limits_for, execute_tool_call, is_context_overflow_error,
+    is_transient_error, maybe_run_compaction, maybe_spill, redact_secrets,
+    repair_orphan_tool_calls, run_compaction_internal, tools_to_schemas, transient_retry_delay_ms,
+    ChatEvent, ChatRuntime, PersistedSettings,
 };
 
 /// Hard cap on tool-call rounds within a single user turn. Defends against
@@ -183,7 +183,7 @@ pub(crate) fn build_provider(
             session_id.clone(),
         )),
         ProviderFlavor::AnthropicMessages => {
-            Box::new(AnthropicProvider::new(cred, base_url_override))
+            Box::new(AnthropicProvider::new(cred, base_url_override, kind))
         }
         ProviderFlavor::OpenAiResponses => {
             Box::new(OpenAICodexProvider::new(cred, session_id, on_refresh))
@@ -226,7 +226,13 @@ pub(crate) fn resolve_provider_options(
         // Effort is ignored — Anthropic doesn't have an `effort` field;
         // when only `effort` is set we use the Sonnet-recommended
         // 16k mid budget, scaling with the effort knob.
-        ProviderKind::Anthropic => {
+        // Anthropic Messages: `thinking: { type, budget_tokens }`.
+        // Effort is ignored — Anthropic doesn't have an `effort` field;
+        // when only `effort` is set we use the Sonnet-recommended
+        // 16k mid budget, scaling with the effort knob. Kimi For Coding
+        // shares the wire (verified: accepts `budget_tokens`, thinking
+        // is always-on there regardless).
+        ProviderKind::Anthropic | ProviderKind::CustomAnthropic | ProviderKind::KimiCoding => {
             let budget = r.budget_tokens.or_else(|| {
                 effort_label.map(|e| match e {
                     "low" => 4096,
@@ -291,8 +297,10 @@ pub(crate) fn resolve_provider_options(
         | ProviderKind::Together
         | ProviderKind::Zai
         | ProviderKind::Minimax
+        | ProviderKind::Moonshot
         | ProviderKind::Ollama
-        | ProviderKind::OpencodeZen => {
+        | ProviderKind::OpencodeZen
+        | ProviderKind::CustomOpenAi => {
             if let Some(label) = effort_label {
                 out.insert("reasoning_effort".to_string(), serde_json::json!(label));
             }
@@ -608,6 +616,15 @@ pub(crate) async fn run_turn_loop(
                 round = round.saturating_sub(1);
                 continue;
             }
+            ProviderRoundOutcome::UsageLimited => {
+                // The bubble content is already persisted + streamed by
+                // run_provider_round (TokenDelta + AssistantEnd), which
+                // also clears the frontend's streaming state — no Error
+                // event here or the message would double-render. All
+                // that's left is ending the turn without retrying.
+                runtime.lock().await.cancel = None;
+                return;
+            }
             ProviderRoundOutcome::TransientFailure {
                 reason,
                 original_error,
@@ -663,6 +680,18 @@ pub(crate) async fn run_turn_loop(
                     error = %original_error,
                     "agent: transient provider failure; backing off and retrying"
                 );
+                // Surface the retry to the operator — otherwise a 30s
+                // backoff looks identical to a hung turn. Cleared
+                // frontend-side by the next assistant_start / error.
+                {
+                    let g = runtime.lock().await;
+                    let _ = g.channel.send(ChatEvent::Retrying {
+                        attempt: transient_retries,
+                        max: MAX_TRANSIENT_RETRIES,
+                        reason: reason.clone(),
+                        delay_ms,
+                    });
+                }
                 tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
                 // Don't burn a round — the failed attempt produced no
                 // output. Next iteration re-issues the same transcript.
@@ -928,6 +957,15 @@ enum ProviderRoundOutcome {
     /// round against the unchanged transcript and the next attempt
     /// usually produces real content. Bounded by `MAX_EMPTY_RETRIES`.
     EmptyTurn,
+    /// Account-level usage limit (quota exhausted, billing required,
+    /// plan restriction). Terminal: retrying against a hard quota just
+    /// adds minutes of dead air, so `run_provider_round` renders +
+    /// persists the operator-facing message itself, and the loop stops
+    /// the turn immediately instead of entering the transient-retry
+    /// path. Mirrors opencode's `retry.ts` distinction between
+    /// retryable 429s and quota-shaped bodies, taken to its conclusion
+    /// (our retry budget is bounded).
+    UsageLimited,
     /// Transient infrastructure failure: 5xx from the provider, an
     /// upstream LB connection reset (Envoy "upstream connect error /
     /// disconnect/reset"), rate-limit (429), or a network timeout. The
@@ -1106,6 +1144,55 @@ async fn run_provider_round(
             return ProviderRoundOutcome::Stopped;
         }
         Err(e) => {
+            // Usage-limit (quota / billing / plan)? Terminal — don't
+            // enter the transient-retry loop for an error a backoff
+            // can't fix. Checked BEFORE context-overflow and transient:
+            // a 429-with-quota-body would otherwise be swallowed by
+            // "rate limited" and retried into the ground.
+            if let Some(limit_reason) = classify_usage_limit(&e) {
+                let err_text = format!(
+                    "**Usage limit reached.** {limit_reason}.\n\n\
+                     ```text\n{}\n```\n\n\
+                     _Retrying won't help until the limit resets. Wait it out, switch provider or \
+                     model in the chat header, or check your plan / billing on the provider's dashboard._",
+                    redact_secrets(&e.to_string())
+                );
+                if let Ok(mut g) = text_accum.lock() {
+                    g.push_str(&err_text);
+                }
+                send(ChatEvent::TokenDelta {
+                    delta: err_text.clone(),
+                })
+                .await;
+                runtime.lock().await.in_flight_message_id = None;
+                let assistant_msg = ChatMessage {
+                    role: MessageRole::Assistant,
+                    content: err_text.clone(),
+                    tool_calls: vec![],
+                    tool_call_id: None,
+                    name: None,
+                    reasoning_content: None,
+                    images: vec![],
+                };
+                let now = chrono::Utc::now().timestamp_millis();
+                let _ = store
+                    .append(
+                        cluster_id,
+                        session_id,
+                        SessionEvent::Message {
+                            message: assistant_msg.clone(),
+                            ts: now,
+                        },
+                    )
+                    .await;
+                runtime.lock().await.messages.push(assistant_msg);
+                send(ChatEvent::AssistantEnd {
+                    message_id: message_id.clone(),
+                    finish_reason: FinishReason::Other,
+                })
+                .await;
+                return ProviderRoundOutcome::UsageLimited;
+            }
             // Context-overflow-shaped error? Hand it back to the loop as a
             // recoverable signal: don't render anything, don't persist —
             // the loop will run a forced compaction and re-issue the round

--- a/crates/app/src/agent/wire.rs
+++ b/crates/app/src/agent/wire.rs
@@ -60,6 +60,10 @@ pub(crate) struct ProviderStatusWire {
     /// is the ChatGPT-Account-Id (helps operators tell their personal
     /// vs work subscription apart). For API key it's `None`.
     pub account_label: Option<String>,
+    /// Operator-supplied extra model ids, merged into the provider's
+    /// enumerated list (live `/models` / catalogue / static). The only
+    /// model source for endpoints that can't enumerate (custom gateways).
+    pub custom_models: Vec<String>,
 }
 
 /// What the frontend posts when changing global settings. Per-provider
@@ -72,6 +76,9 @@ pub(crate) struct AiSettingsPatch {
     /// Set the base URL override for `provider`. Empty string clears it.
     #[serde(default)]
     pub provider_base_url: Option<ProviderBaseUrlPatch>,
+    /// Replace the custom model list for `provider`.
+    #[serde(default)]
+    pub provider_custom_models: Option<ProviderCustomModelsPatch>,
     #[serde(default)]
     pub default_model: Option<String>,
     #[serde(default)]
@@ -98,6 +105,14 @@ pub(crate) struct AiSettingsPatch {
 pub(crate) struct ProviderBaseUrlPatch {
     pub provider: ProviderKind,
     pub base_url: String,
+}
+
+/// Whole-list replace of a provider's custom model ids. The backend
+/// normalises (trim, drop empties, dedupe) before persisting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ProviderCustomModelsPatch {
+    pub provider: ProviderKind,
+    pub models: Vec<String>,
 }
 
 /// Per-MCP-server status, emitted as part of `ChatEvent::McpStatus`. One
@@ -282,6 +297,22 @@ pub(crate) enum ChatEvent {
     /// Streaming error. The chat is left intact; the frontend can retry by
     /// sending another message.
     Error { message: String },
+    /// A transient provider failure (5xx, connection reset, plain 429)
+    /// is being retried after a backoff. Purely informational — the
+    /// frontend renders a small "retrying" note and clears it when the
+    /// next `assistant_start` (or terminal `error`) lands. Usage-limit
+    /// errors (quota / billing) do NOT take this path; they surface as
+    /// a terminal `Error` immediately instead of being retried.
+    Retrying {
+        /// 1-indexed attempt that just failed.
+        attempt: u8,
+        /// Cap after which the turn gives up (`MAX_TRANSIENT_RETRIES`).
+        max: u8,
+        /// Short label: "rate limited", "upstream 503", …
+        reason: String,
+        /// Backoff before the next attempt, in milliseconds.
+        delay_ms: u64,
+    },
     /// Auto-generated session title landed. Fired once per chat after the
     /// dedicated title-gen request (spawned the moment the operator's
     /// first message lands, in parallel with the assistant turn)

--- a/ui/src/components/chat/DockChat.tsx
+++ b/ui/src/components/chat/DockChat.tsx
@@ -73,6 +73,11 @@ type OpenChat = {
     totalTokens: number;
   } | null;
   compacting: number | null;
+  /// Transient provider retry in flight (429 / 5xx / connection reset),
+  /// from the `retrying` event. Cleared by the next assistant_start /
+  /// terminal error. Renders a small note so a 30s backoff doesn't look
+  /// like a hung turn.
+  retry: { attempt: number; max: number; reason: string } | null;
   /// Most recently observed context window for the chat's bound model.
   /// `0` ⇒ catalogue not loaded yet — UI falls back to "<used> tok" only.
   /// Updated by `ChatOpenResult`, the `usage` event (each turn re-resolves
@@ -162,6 +167,7 @@ export function DockChat({ mode, tab, visible }: Props) {
   const streaming = active?.streaming ?? false;
   const usage = active?.usage ?? null;
   const compacting = active?.compacting ?? null;
+  const retry = active?.retry ?? null;
   const activeChatId = active?.chatId ?? null;
   const contextLimit = active?.contextLimit ?? 0;
   const usableContext = active?.usableContext ?? 0;
@@ -185,14 +191,24 @@ export function DockChat({ mode, tab, visible }: Props) {
       let nextStreaming = cur.streaming;
       let nextUsage = cur.usage;
       let nextCompacting = cur.compacting;
+      let nextRetry = cur.retry;
       let nextMeta = cur.meta;
       let nextContextLimit = cur.contextLimit;
       let nextUsableContext = cur.usableContext;
       for (const e of queue) {
         nextView = applyChatEvent(nextView, e);
-        if (e.type === "assistant_start") nextStreaming = true;
-        else if (e.type === "assistant_end" || e.type === "error") {
+        if (e.type === "assistant_start") {
+          nextStreaming = true;
+          nextRetry = null;
+        } else if (e.type === "assistant_end" || e.type === "error") {
           nextStreaming = false;
+          if (e.type === "error") nextRetry = null;
+        } else if (e.type === "retrying") {
+          nextRetry = {
+            attempt: e.attempt,
+            max: e.max,
+            reason: e.reason,
+          };
         } else if (e.type === "usage") {
           nextUsage = {
             promptTokens: e.prompt_tokens,
@@ -234,6 +250,7 @@ export function DockChat({ mode, tab, visible }: Props) {
           streaming: nextStreaming,
           usage: nextUsage,
           compacting: nextCompacting,
+          retry: nextRetry,
           meta: nextMeta,
           contextLimit: nextContextLimit,
           usableContext: nextUsableContext,
@@ -440,6 +457,7 @@ export function DockChat({ mode, tab, visible }: Props) {
             streaming: false,
             usage: seededUsage,
             compacting: null,
+            retry: null,
             contextLimit: opened.contextLimit,
             usableContext: opened.usableContext,
           },
@@ -991,6 +1009,7 @@ export function DockChat({ mode, tab, visible }: Props) {
             streaming={streaming}
             chatId={activeChatId}
             compacting={compacting !== null}
+            retry={retry}
           />
         )}
       </div>

--- a/ui/src/components/chat/MessageList.tsx
+++ b/ui/src/components/chat/MessageList.tsx
@@ -32,6 +32,9 @@ type Props = {
   streaming: boolean;
   chatId: string | null;
   compacting: boolean;
+  /// Transient provider retry in flight — renders a small note under the
+  /// transcript so a multi-second backoff doesn't read as a hung turn.
+  retry: { attempt: number; max: number; reason: string } | null;
 };
 
 // 12 px between adjacent bubbles. The original render relied on the parent's
@@ -47,7 +50,7 @@ const ROW_GAP = 12;
 // tables). Footer surfaces (pending approvals, compacting bubble) sit
 // below the virtual container — small fixed count, easier than folding
 // them into the row array.
-export function MessageList({ mode, state, streaming, chatId, compacting }: Props) {
+export function MessageList({ mode, state, streaming, chatId, compacting, retry }: Props) {
   const t = useResolvedTheme().tokens;
   const { scrollRef, stuck, snapToBottom } = useStickToBottom();
   // Filter out messages that MessageBubble would render as null
@@ -308,6 +311,7 @@ export function MessageList({ mode, state, streaming, chatId, compacting }: Prop
           />
         )}
         {compacting && <CompactingBubble t={t} />}
+        {retry && !compacting && <RetryBubble t={t} retry={retry} />}
       </div>
       {showJumpButton && (
         <JumpToLatestButton t={t} streaming={streaming} onClick={snapToBottom} />
@@ -489,5 +493,70 @@ function Dot({
         animation: `fs-compact-dot 1.2s ${delay}ms infinite ease-in-out`,
       }}
     />
+  );
+}
+
+// Transient provider retry note — a 429 / 5xx / connection reset is
+// being backed off and re-issued. Distinct from CompactingBubble (muted
+// warn tone, no accent dots) and cleared the moment the next attempt
+// starts streaming (or the retry budget exhausts into an error bubble).
+// Usage-limit (quota/billing) failures never render this — they arrive
+// as a terminal assistant message instead.
+function RetryBubble({
+  t,
+  retry,
+}: {
+  t: ReturnType<typeof tokens>;
+  retry: { attempt: number; max: number; reason: string };
+}) {
+  return (
+    <div style={{ display: "flex", justifyContent: "flex-start", gap: 8 }}>
+      <div
+        style={{
+          maxWidth: "92%",
+          background: t.surface,
+          border: `1px solid ${t.border}`,
+          borderRadius: R_LG,
+          padding: "9px 13px 10px",
+          color: t.text,
+          fontSize: FS_MD,
+          lineHeight: 1.55,
+          boxShadow: "0 1px 3px rgba(15,20,30,0.05)",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: FF_MONO,
+            fontSize: FS_XS,
+            color: t.warn,
+            letterSpacing: 0.6,
+            textTransform: "uppercase",
+            marginBottom: 5,
+            fontWeight: 700,
+            opacity: 0.9,
+          }}
+        >
+          Provider hiccup
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            color: t.textDim,
+            fontSize: FS_MD,
+          }}
+        >
+          <span>
+            {retry.reason} — retrying (attempt {retry.attempt}/{retry.max})
+          </span>
+          <span style={{ display: "inline-flex", gap: 3 }}>
+            <Dot t={t} delay={0} />
+            <Dot t={t} delay={150} />
+            <Dot t={t} delay={300} />
+          </span>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/ui/src/components/chat/chatStreaming.test.ts
+++ b/ui/src/components/chat/chatStreaming.test.ts
@@ -3,7 +3,7 @@
 // never accidentally carry them.
 
 import { describe, it, expect } from "vitest";
-import { chatStateFromMessages } from "./chatStreaming";
+import { applyChatEvent, chatStateFromMessages } from "./chatStreaming";
 import type { AgentChatMessage } from "../../types";
 
 describe("chatStateFromMessages — image attachments", () => {
@@ -40,5 +40,24 @@ describe("chatStateFromMessages — image attachments", () => {
     const { messages } = chatStateFromMessages(msgs);
     expect(messages[0]!.role).toBe("assistant");
     expect(messages[0]!.images).toBeUndefined();
+  });
+});
+
+describe("applyChatEvent — retrying", () => {
+  it("leaves the view state untouched (handled at the session level)", () => {
+    // The `retrying` event drives the per-session RetryBubble in DockChat,
+    // not the transcript view — the reducer must not materialise a bubble
+    // or disturb an in-flight stream when it passes through applyChatEvent.
+    const prev = chatStateFromMessages([
+      { role: "user", content: "hi" },
+    ]);
+    const next = applyChatEvent(prev, {
+      type: "retrying",
+      attempt: 2,
+      max: 5,
+      reason: "rate limited",
+      delay_ms: 4000,
+    });
+    expect(next).toBe(prev);
   });
 });

--- a/ui/src/components/settings/AiSection.tsx
+++ b/ui/src/components/settings/AiSection.tsx
@@ -225,6 +225,11 @@ export function AiSection({}: { mode: ThemeMode }) {
                   provider_base_url: { provider: p.kind, base_url: url },
                 })
               }
+              onSetCustomModels={(models) =>
+                save({
+                  provider_custom_models: { provider: p.kind, models },
+                })
+              }
             />
           ))}
         </div>
@@ -452,6 +457,7 @@ function ProviderRow({
   onOauthLogin,
   onOauthCancel,
   onSetBaseUrl,
+  onSetCustomModels,
 }: {
   t: ReturnType<typeof tokens>;
   provider: ProviderStatusWire;
@@ -461,23 +467,36 @@ function ProviderRow({
   onOauthLogin: () => Promise<void>;
   onOauthCancel: () => Promise<void>;
   onSetBaseUrl: (url: string) => Promise<void>;
+  onSetCustomModels: (models: string[]) => Promise<void>;
 }) {
   const [open, setOpen] = useState(false);
   const [keyDraft, setKeyDraft] = useState("");
   const [baseUrlDraft, setBaseUrlDraft] = useState(
     provider.base_url_override ?? "",
   );
+  const [customModelDraft, setCustomModelDraft] = useState("");
   const [oauthInFlight, setOauthInFlight] = useState(false);
+  const [testRunning, setTestRunning] = useState(false);
   const [testResult, setTestResult] = useState<string | null>(null);
   const supportsOauth = provider.auth_modes.includes("oauth" as AuthMode);
   const supportsKey = provider.auth_modes.includes("api_key" as AuthMode);
+  // Endpoints that may legitimately be unauthenticated (local Ollama,
+  // open gateways) — the backend treats a blank key as "no auth header".
+  const allowsBlankKey =
+    provider.kind === "ollama" ||
+    provider.kind === "custom_openai" ||
+    provider.kind === "custom_anthropic";
 
   const onTest = async () => {
+    setTestRunning(true);
     setTestResult(null);
     try {
+      // Empty key = validate the already-saved credential backend-side.
+      // Base URL comes from the *draft* so the operator can probe an
+      // override before committing it (blur-save).
       const res = await api.aiTestProvider({
         provider: provider.kind,
-        base_url: provider.base_url_override,
+        base_url: baseUrlDraft.trim() ? baseUrlDraft.trim() : null,
         api_key: keyDraft.trim(),
       });
       setTestResult(
@@ -487,6 +506,8 @@ function ProviderRow({
       );
     } catch (e) {
       setTestResult(String(e));
+    } finally {
+      setTestRunning(false);
     }
   };
 
@@ -664,20 +685,31 @@ function ProviderRow({
                   variant="secondary"
                   size="sm"
                   onClick={onTest}
-                  disabled={busy || !keyDraft.trim()}
+                  disabled={
+                    testRunning ||
+                    busy ||
+                    (!keyDraft.trim() &&
+                      !provider.configured &&
+                      !allowsBlankKey)
+                  }
+                  title={
+                    keyDraft.trim()
+                      ? "Probe GET /models with the key in the field"
+                      : "Probe GET /models with the saved credential"
+                  }
                 >
-                  Test
+                  {testRunning ? "Testing…" : "Test"}
                 </Btn>
                 <Btn
                   t={t}
                   variant="primary"
                   size="sm"
                   onClick={async () => {
-                    if (!keyDraft.trim()) return;
+                    if (!keyDraft.trim() && !allowsBlankKey) return;
                     await onSetKey(keyDraft.trim());
                     setKeyDraft("");
                   }}
-                  disabled={busy || !keyDraft.trim()}
+                  disabled={busy || (!keyDraft.trim() && !allowsBlankKey)}
                 >
                   Save
                 </Btn>
@@ -732,6 +764,112 @@ function ProviderRow({
               }}
             />
           </div>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 4,
+            }}
+          >
+            <div
+              style={{
+                fontSize: FS_XS,
+                color: t.textMuted,
+                fontFamily: FF_MONO,
+              }}
+            >
+              Custom models — appended to whatever the provider enumerates.
+              Required for endpoints with no <span style={{ color: t.text }}>GET /models</span>.
+            </div>
+            {provider.custom_models.length > 0 && (
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                {provider.custom_models.map((id) => (
+                  <span
+                    key={id}
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 4,
+                      fontFamily: FF_MONO,
+                      fontSize: FS_SM,
+                      color: t.text,
+                      background: t.surface,
+                      border: `1px solid ${t.borderSoft}`,
+                      borderRadius: R_MD,
+                      padding: "2px 6px",
+                    }}
+                  >
+                    {id}
+                    <button
+                      type="button"
+                      title="Remove custom model"
+                      disabled={busy}
+                      onClick={() =>
+                        onSetCustomModels(
+                          provider.custom_models.filter((m) => m !== id),
+                        )
+                      }
+                      style={{
+                        background: "transparent",
+                        border: "none",
+                        color: t.bad,
+                        cursor: "pointer",
+                        fontFamily: FF_MONO,
+                        fontSize: FS_MD,
+                        padding: 0,
+                      }}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+              <input
+                type="text"
+                value={customModelDraft}
+                onChange={(e) => setCustomModelDraft(e.target.value)}
+                onKeyDown={async (e) => {
+                  if (e.key !== "Enter") return;
+                  const id = customModelDraft.trim();
+                  if (!id) return;
+                  if (!provider.custom_models.includes(id)) {
+                    await onSetCustomModels([...provider.custom_models, id]);
+                  }
+                  setCustomModelDraft("");
+                }}
+                placeholder="model id, e.g. kimi-k2.5"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  background: t.surface,
+                  border: `1px solid ${t.borderSoft}`,
+                  color: t.text,
+                  borderRadius: R_MD,
+                  padding: "6px 8px",
+                  fontFamily: FF_MONO,
+                  fontSize: FS_MD,
+                }}
+              />
+              <Btn
+                t={t}
+                variant="secondary"
+                size="sm"
+                disabled={busy || !customModelDraft.trim()}
+                onClick={async () => {
+                  const id = customModelDraft.trim();
+                  if (!id) return;
+                  if (!provider.custom_models.includes(id)) {
+                    await onSetCustomModels([...provider.custom_models, id]);
+                  }
+                  setCustomModelDraft("");
+                }}
+              >
+                Add
+              </Btn>
+            </div>
+          </div>
           {provider.configured && (
             <div>
               <Btn
@@ -781,6 +919,45 @@ function providerBlurb(kind: ProviderKind): ReactNode | null {
           to unlock the full catalogue.
         </>
       );
+    case "moonshot":
+      return (
+        <>
+          Moonshot AI's Kimi models over an OpenAI-compatible wire. The model
+          list is fetched live from the API once a key is saved. Operators in
+          mainland China can point the base URL at{" "}
+          <span style={{ fontFamily: FF_MONO }}>
+            https://api.moonshot.cn/v1
+          </span>
+          .
+        </>
+      );
+    case "kimi_coding":
+      return (
+        <>
+          The kimi.com <strong>coding subscription</strong> — a separate
+          product from the Moonshot platform, with its own keys and its own
+          model set (K2.7 Coding, K3). Speaks Anthropic's Messages API;
+          models are listed live once a key is saved.
+        </>
+      );
+    case "custom_openai":
+      return (
+        <>
+          Any endpoint speaking OpenAI's Chat Completions API (proxy,
+          gateway, self-hosted). Set the base URL and key, hit{" "}
+          <strong>Test</strong> to probe <strong>GET /models</strong>; if the
+          endpoint can't enumerate models, add model ids under{" "}
+          <strong>Custom models</strong> below.
+        </>
+      );
+    case "custom_anthropic":
+      return (
+        <>
+          Any endpoint speaking Anthropic's Messages API (e.g. a Claude
+          gateway or Kimi's <strong>/anthropic</strong> transport). Same
+          probing rules as the OpenAI-compatible entry.
+        </>
+      );
     default:
       return null;
   }
@@ -796,10 +973,17 @@ function keyPlaceholder(kind: ProviderKind): string {
       return "sk-or-v1-…";
     case "groq":
       return "gsk_…";
+    case "moonshot":
+      return "sk-…";
+    case "kimi_coding":
+      return "sk-kimi-…";
     case "opencode_zen":
       return "(blank = free tier)";
     case "ollama":
       return "(blank for local)";
+    case "custom_openai":
+    case "custom_anthropic":
+      return "(blank if endpoint is open)";
     default:
       return "API key";
   }

--- a/ui/src/lib/providers.test.ts
+++ b/ui/src/lib/providers.test.ts
@@ -26,9 +26,13 @@ describe("PROVIDER_ORDER", () => {
       "minimax",
       "groq",
       "deepseek",
+      "moonshot",
+      "kimi_coding",
       "mistral",
       "together",
       "ollama",
+      "custom_openai",
+      "custom_anthropic",
     ];
     expect([...PROVIDER_ORDER].sort()).toEqual([...expected].sort());
   });

--- a/ui/src/lib/providers.ts
+++ b/ui/src/lib/providers.ts
@@ -19,9 +19,13 @@ const ORDER_INDEX = {
   minimax: 5,
   groq: 6,
   deepseek: 7,
-  mistral: 8,
-  together: 9,
-  ollama: 10,
+  moonshot: 8,
+  kimi_coding: 9,
+  mistral: 10,
+  together: 11,
+  ollama: 12,
+  custom_openai: 13,
+  custom_anthropic: 14,
 } satisfies Record<ProviderKind, number>;
 
 export const PROVIDER_ORDER: readonly ProviderKind[] = (

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -2254,9 +2254,13 @@ export type ProviderKind =
   | "minimax"
   | "groq"
   | "deepseek"
+  | "moonshot"
+  | "kimi_coding"
   | "mistral"
   | "together"
-  | "ollama";
+  | "ollama"
+  | "custom_openai"
+  | "custom_anthropic";
 
 export type AuthMode = "api_key" | "oauth";
 
@@ -2280,6 +2284,9 @@ export type ProviderStatusWire = {
   auth_mode: AuthMode | null;
   configured: boolean;
   account_label: string | null;
+  /// Operator-supplied extra model ids, merged into the enumerated list.
+  /// The only model source for endpoints that can't enumerate models.
+  custom_models: string[];
 };
 
 export type ApprovalMode = "approve_per_write" | "allow_all_writes";
@@ -2346,9 +2353,16 @@ export type ProviderBaseUrlPatch = {
   base_url: string;
 };
 
+export type ProviderCustomModelsPatch = {
+  provider: ProviderKind;
+  /// Whole-list replace; the backend trims / drops empties / dedupes.
+  models: string[];
+};
+
 export type AiSettingsPatch = {
   active_provider?: ProviderKind;
   provider_base_url?: ProviderBaseUrlPatch;
+  provider_custom_models?: ProviderCustomModelsPatch;
   default_model?: string;
   default_approval_mode?: ApprovalMode;
   system_prompt_override?: string;
@@ -2363,6 +2377,7 @@ export type AiSettingsPatch = {
 export type ProviderTestRequest = {
   provider: ProviderKind;
   base_url: string | null;
+  /// Empty string = validate the already-saved credential instead.
   api_key: string;
 };
 
@@ -2634,4 +2649,15 @@ export type ChatEvent =
       summary: string;
     }
   | { type: "error"; message: string }
+  /// A transient provider failure is being retried after a backoff.
+  /// Informational only — cleared by the next assistant_start / error.
+  /// Usage-limit (quota/billing) errors don't use this; they arrive as a
+  /// terminal assistant message with no retries attempted.
+  | {
+      type: "retrying";
+      attempt: number;
+      max: number;
+      reason: string;
+      delay_ms: number;
+    }
   | { type: "title_updated"; title: string };


### PR DESCRIPTION
## What's in it

**New providers**
- **Moonshot (Kimi)** — OpenAI-compatible wire at `api.moonshot.ai/v1`, models fetched live from `GET /models` (verified), models.dev catalogue (`moonshotai`) as enrichment/fallback.
- **Kimi For Coding** — the kimi.com coding subscription, verified end-to-end with a live key: Anthropic Messages wire (`x-api-key` + `anthropic-version`), enumerable `/models`, always-on thinking blocks (skipped by our SSE machine), tolerant of history without thinking blocks, `budget_tokens` accepted.
- **Custom (OpenAI-compatible)** and **Custom (Anthropic-compatible)** — operator-supplied base URL + token; Test probes `GET /models`; blank key supported for open endpoints.

**Custom models** — per-provider custom model ids merged into whatever the provider enumerates (deduped; enumerated entries win). If enumeration fails but custom models exist, they're returned instead of an error.

**Test button** — now a raw `GET /models` probe (the old path masked failures behind catalogue/static fallbacks); blank key field = test the saved credential; uses the base-URL draft.

**Usage-limit detection** (opencode `retry.ts` parity + stop)
- Quota/billing vendor codes (`insufficient_quota`, `usage_not_included`, `exceeded_current_quota`, `billing_error`, `billing_hard_limit_reached`, Zen free/Go markers, `tpd limit reached`) → terminal 'Usage limit reached' message, **no retry**.
- Rate codes (`rate_limit_exceeded`, `rate_limit_reached_error`, `server_is_overloaded`, `engine_overloaded`, `rate_limit_error`, `overloaded_error`) stay transient — now with a visible 'Provider hiccup — retrying (N/5)' bubble instead of silence.

**Root-cause fix for the 'thinking… appears/vanishes in a loop' bug**
- Codex `response.failed` / bare `error` SSE events, OpenAI-compat `{"error":…}` chunks, and Anthropic `event: error` payloads are now extracted and classified (status-less, keyed on vendor codes) instead of degrading to empty-turn retries.

## Verification
- Live probes against api.moonshot.ai, api.kimi.com/coding (models list, /messages SSE, multi-turn, budget_tokens, error taxonomy from platform docs).
- `cargo fmt --check`, `clippy -D warnings`, 224 Rust tests, `tsc -b`, 1188 vitest tests — all green locally.