### PR TITLE
perf(watcher): cache rows pre-serialised instead of as Value trees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,12 @@ hyper-timeout = "=0.5.2"
 
 # Serde
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# `raw_value` gives us `serde_json::value::RawValue` — a `str` newtype that
+# serialises byte-for-byte instead of being re-encoded. The watcher caches
+# every projected row as `Arc<RawValue>` so the row is serialised exactly
+# once (at projection time) and every downstream consumer — the IPC emit
+# batch, the subscribe snapshot, the search-index blob — reuses those bytes.
+serde_json = { version = "1", features = ["raw_value"] }
 serde_yaml = "0.9"
 
 # Errors

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -917,7 +917,11 @@ pub(crate) async fn list_custom_resource_kinds(
 /// should render immediately.
 #[derive(Debug, Serialize)]
 pub(crate) struct SubscribeResult {
-    pub(crate) rows: Vec<Value>,
+    /// Pre-serialised rows straight out of the watcher cache. `RowJson`
+    /// splices its stored bytes into the command response instead of being
+    /// re-encoded, so a 5000-row snapshot costs ~0.2 ms and one `Vec` of
+    /// pointers rather than ~35 ms and a 22 MiB transient `Value` copy.
+    pub(crate) rows: Vec<ferrisscope_kube_ext::RowJson>,
     pub(crate) init_done: bool,
 }
 
@@ -1559,34 +1563,34 @@ fn spawn_resource_forwarder(
                 let init_done_in_batch = drained.init_done;
                 let mut batch: Vec<ferrisscope_kube_ext::ResourceDelta> =
                     Vec::with_capacity(drained.delta_count() + usize::from(init_done_in_batch));
-                for (_, row) in drained.upserts {
-                    batch.push(ferrisscope_kube_ext::ResourceDelta::Upsert { row });
+                // Fan every Upsert / Delete into the per-cluster search index
+                // when one is registered, as we build the emit batch — the
+                // drain map's key *is* the uid and the `Row` carries the
+                // hoisted `namespace` / `name`, so the index never has to
+                // re-parse or re-encode the row. The index handle is
+                // `Option`al so a cluster whose index failed to open keeps
+                // browsing without breaking. `InitDone` is bus-only.
+                for (uid, row) in drained.upserts {
+                    if let (Some(index), Some(name)) = (search_index.as_ref(), row.name.as_deref())
+                    {
+                        index.upsert_raw(
+                            &kind_id,
+                            &uid,
+                            row.namespace.as_deref(),
+                            name,
+                            row.json.get(),
+                        );
+                    }
+                    batch.push(ferrisscope_kube_ext::ResourceDelta::Upsert { row: row.json });
                 }
                 for uid in drained.deletes {
+                    if let Some(index) = search_index.as_ref() {
+                        index.delete(&kind_id, &uid);
+                    }
                     batch.push(ferrisscope_kube_ext::ResourceDelta::Delete { uid });
                 }
                 if init_done_in_batch {
                     batch.push(ferrisscope_kube_ext::ResourceDelta::InitDone);
-                }
-
-                // Fan every Upsert / Delete into the per-cluster search
-                // index when one is registered. The index handle is
-                // `Option`al so a cluster whose index failed to open keeps
-                // browsing without breaking. `InitDone` is bus-only.
-                if let Some(index) = search_index.as_ref() {
-                    for d in &batch {
-                        match d {
-                            ferrisscope_kube_ext::ResourceDelta::Upsert { row } => {
-                                if let Some(uid) = row.get("uid").and_then(Value::as_str) {
-                                    index.upsert(&kind_id, uid, row);
-                                }
-                            }
-                            ferrisscope_kube_ext::ResourceDelta::Delete { uid } => {
-                                index.delete(&kind_id, uid);
-                            }
-                            ferrisscope_kube_ext::ResourceDelta::InitDone => {}
-                        }
-                    }
                 }
 
                 let n = batch.len();

--- a/crates/core/src/search/mod.rs
+++ b/crates/core/src/search/mod.rs
@@ -142,12 +142,33 @@ impl SearchIndex {
                 return;
             }
         };
+        self.upsert_raw(kind_id, uid, namespace.as_deref(), &name, &blob);
+    }
+
+    /// [`Self::upsert`] for a caller that already holds the row's encoded
+    /// JSON and its `namespace` / `name`.
+    ///
+    /// This is the watcher path. Rows arrive from the reflector already
+    /// serialised (`ferrisscope_kube_ext::RowJson`), so re-deriving the blob
+    /// with `serde_json::to_string` — as [`Self::upsert`] must, since it only
+    /// has a `Value` — would re-encode every row a second time on the
+    /// forwarder task: ~830 ns/row against ~13 ns for the memcpy this does
+    /// instead. [`Self::upsert`] stays for the connect-time bootstrap, which
+    /// LISTs into `Value`s and has no pre-encoded form to hand over.
+    pub fn upsert_raw(
+        &self,
+        kind_id: &str,
+        uid: &str,
+        namespace: Option<&str>,
+        name: &str,
+        blob: &str,
+    ) {
         let _ = self.tx.send(IndexCommand::Write(WriteOp::Upsert {
             kind_id: kind_id.to_owned(),
             uid: uid.to_owned(),
-            namespace,
-            name,
-            blob,
+            namespace: namespace.map(str::to_owned),
+            name: name.to_owned(),
+            blob: blob.to_owned(),
         }));
     }
 
@@ -263,5 +284,75 @@ mod tests {
         let (ns, name) = extract_ns_name(&json!({ "namespace": 7, "name": null }));
         assert_eq!(ns, None);
         assert_eq!(name, None);
+    }
+
+    /// A handle wired to a channel the test owns, so we can inspect the
+    /// `WriteOp` each entry point enqueues without standing up SQLite.
+    fn probe() -> (SearchIndex, mpsc::UnboundedReceiver<IndexCommand>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (SearchIndex { tx }, rx)
+    }
+
+    fn took_upsert(rx: &mut mpsc::UnboundedReceiver<IndexCommand>) -> WriteOp {
+        match rx.try_recv() {
+            Ok(IndexCommand::Write(op)) => op,
+            _ => panic!("expected a queued write"),
+        }
+    }
+
+    /// The watcher path (`upsert_raw`, pre-encoded blob) and the bootstrap
+    /// path (`upsert`, re-encodes a `Value`) must enqueue the same row.
+    /// If these ever diverge, search results silently differ depending on
+    /// whether a kind was bootstrapped or watched.
+    #[test]
+    fn upsert_raw_matches_the_value_path() {
+        let row = json!({ "namespace": "default", "name": "api-0", "phase": "Running" });
+        let blob = serde_json::to_string(&row).unwrap();
+
+        let (idx, mut rx) = probe();
+        idx.upsert("pods", "u1", &row);
+        let via_value = took_upsert(&mut rx);
+
+        let (idx, mut rx) = probe();
+        idx.upsert_raw("pods", "u1", Some("default"), "api-0", &blob);
+        let via_raw = took_upsert(&mut rx);
+
+        let fields = |op: WriteOp| match op {
+            WriteOp::Upsert {
+                kind_id,
+                uid,
+                namespace,
+                name,
+                blob,
+            } => (kind_id, uid, namespace, name, blob),
+            _ => panic!("expected Upsert"),
+        };
+        assert_eq!(fields(via_value), fields(via_raw));
+    }
+
+    /// `upsert` drops nameless rows (nothing renderable to show as a hit).
+    /// `upsert_raw` takes `name` as a required argument instead — the
+    /// watcher does the skipping, so the two agree by construction.
+    #[test]
+    fn upsert_skips_a_row_with_no_name() {
+        let (idx, mut rx) = probe();
+        idx.upsert("pods", "u1", &json!({ "namespace": "default" }));
+        assert!(rx.try_recv().is_err(), "nameless row must not be queued");
+    }
+
+    /// A cluster-scoped row carries no namespace; it must still be indexed.
+    #[test]
+    fn upsert_raw_accepts_a_missing_namespace() {
+        let (idx, mut rx) = probe();
+        idx.upsert_raw("nodes", "u1", None, "node-1", r#"{"name":"node-1"}"#);
+        match took_upsert(&mut rx) {
+            WriteOp::Upsert {
+                namespace, name, ..
+            } => {
+                assert_eq!(namespace, None);
+                assert_eq!(name, "node-1");
+            }
+            _ => panic!("expected Upsert"),
+        }
     }
 }

--- a/crates/kube-ext/examples/rowbench.rs
+++ b/crates/kube-ext/examples/rowbench.rs
@@ -1,0 +1,302 @@
+//! Hot-path benchmark for the watcher's row representation.
+//!
+//! ```text
+//! cargo run --release -p ferrisscope-kube-ext --example rowbench
+//! cargo run --release -p ferrisscope-kube-ext --example rowbench -- --residency
+//! ```
+//!
+//! This is the measurement behind caching rows pre-serialised
+//! (`RowJson`) rather than as a live `serde_json::Value` tree — see the
+//! module docs on `watcher.rs`. It covers the four places a row is
+//! touched:
+//!
+//! 1. the per-apply critical section in the watcher task,
+//! 2. `ResourceWatcher::snapshot()` (runs on every `subscribe_resource`),
+//! 3. the `MAX_EMIT_DELTAS`-sized batch the forwarder hands to `app.emit`,
+//! 4. the blob the search-index writer stores.
+//!
+//! Deliberately dependency-free (no criterion): a fixed iteration count
+//! with a warm-up, printing ns/op. Absolute numbers move with the machine;
+//! the ratios are the point.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use ferrisscope_kube_ext::{ResourceDelta, RowJson};
+use serde_json::{json, Value};
+
+// -------------------------------------------------------------- residency
+
+/// Resident-set size in bytes, or `None` where we can't read it.
+///
+/// The obvious instrument would be a counting `GlobalAlloc`, but the
+/// workspace `forbid(unsafe_code)`s and examples inherit that — so we read
+/// the OS's number instead. It's coarser: page-granular, and it counts
+/// allocator slack the process hasn't handed back. Expect it to overstate
+/// both shapes (~6.1 KiB/row vs an exact 4.7 KiB for `Value`, ~1.7 KiB vs
+/// 0.9 KiB for `RowJson`) and so to understate the ratio — 3.6× here
+/// against 5.1× when counted per-allocation. The direction is the point.
+fn rss() -> Option<usize> {
+    if cfg!(target_os = "linux") {
+        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+        Some(statm.split_whitespace().nth(1)?.parse::<usize>().ok()? * 4096)
+    } else {
+        None
+    }
+}
+
+// ---------------------------------------------------------------- fixtures
+
+/// A projected Pod row in the shape `kinds::pods::project` produces, after
+/// the watcher has injected `uid` and `__labels`: two containers, five
+/// labels. Roughly the median object on a real cluster.
+fn pod_row(i: usize) -> Value {
+    json!({
+        "uid": format!("11111111-2222-3333-4444-{i:012}"),
+        "namespace": "kube-system",
+        "name": format!("coredns-76f75df574-{i:05}"),
+        "phase": "Running",
+        "ready": "2/2",
+        "restarts": 0,
+        "cpu": Value::Null,
+        "mem": Value::Null,
+        "node": format!("ip-10-0-{}-{}.eu-central-1.compute.internal", i % 250, i % 99),
+        "creation_timestamp": "2026-07-20T11:04:33Z",
+        "containers": ["coredns", "istio-proxy"],
+        "container_states": [
+            {
+                "name": "coredns", "kind": "main",
+                "image": "registry.k8s.io/coredns/coredns:v1.11.1",
+                "state": "running", "reason": Value::Null,
+                "ready": true, "restarts": 0
+            },
+            {
+                "name": "istio-proxy", "kind": "sidecar",
+                "image": "docker.io/istio/proxyv2:1.22.1",
+                "state": "running", "reason": Value::Null,
+                "ready": true, "restarts": 0
+            }
+        ],
+        "__labels": {
+            "app.kubernetes.io/name": "coredns",
+            "app.kubernetes.io/instance": "coredns",
+            "pod-template-hash": "76f75df574",
+            "k8s-app": "kube-dns",
+            "security.istio.io/tlsMode": "istio"
+        }
+    })
+}
+
+fn uid_of(i: usize) -> String {
+    format!("11111111-2222-3333-4444-{i:012}")
+}
+
+fn raw(v: &Value) -> RowJson {
+    RowJson::from_value(v).expect("fixture serialises")
+}
+
+/// The pre-`RowJson` delta shape, kept purely as the baseline to measure
+/// against. Mirrors what `ResourceDelta` looked like when the watcher
+/// cached rows as `Value`.
+#[derive(serde::Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+enum LegacyDelta {
+    Upsert { row: Value },
+}
+
+// ----------------------------------------------------------------- harness
+
+fn bench<F: FnMut()>(name: &str, iters: usize, mut f: F) {
+    for _ in 0..(iters / 8).max(1) {
+        f();
+    }
+    let t = Instant::now();
+    for _ in 0..iters {
+        f();
+    }
+    let per = t.elapsed().as_secs_f64() * 1e9 / iters as f64;
+    if per > 100_000.0 {
+        println!("  {name:<48} {:>10.3} ms/op", per / 1e6);
+    } else {
+        println!("  {name:<48} {per:>10.1} ns/op");
+    }
+}
+
+const N: usize = 5000;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    // Internal: measure exactly one cache shape and print its RSS delta.
+    // Driven by `--residency` below, which re-execs us once per shape.
+    if let Some(which) = args.iter().find_map(|a| a.strip_prefix("--measure=")) {
+        measure_one(which);
+    } else if args.iter().any(|a| a == "--residency") {
+        residency();
+    } else {
+        timings();
+    }
+}
+
+/// Build one cache shape and report how much RSS it cost.
+///
+/// Must run in a fresh process: measuring both shapes in sequence doesn't
+/// work, because the allocator hands the second cache the pages the first
+/// one just freed and RSS never moves.
+fn measure_one(which: &str) {
+    let Some(base) = rss() else { return };
+    let bytes = match which {
+        "value" => {
+            let mut c: HashMap<String, Value> = HashMap::with_capacity(N);
+            for i in 0..N {
+                c.insert(uid_of(i), pod_row(i));
+            }
+            let d = rss().unwrap_or(base).saturating_sub(base);
+            assert_eq!(c.len(), N, "keep the cache alive across the RSS read");
+            d
+        }
+        _ => {
+            let mut c: HashMap<String, RowJson> = HashMap::with_capacity(N);
+            for i in 0..N {
+                c.insert(uid_of(i), raw(&pod_row(i)));
+            }
+            let d = rss().unwrap_or(base).saturating_sub(base);
+            assert_eq!(c.len(), N, "keep the cache alive across the RSS read");
+            d
+        }
+    };
+    println!("{bytes}");
+}
+
+fn residency() {
+    if rss().is_none() {
+        println!("--residency needs /proc/self/statm (Linux); nothing to report here");
+        return;
+    }
+    println!("\n=== row representation: residency, {N} pod rows ===\n");
+
+    let one = |which: &str| -> Option<usize> {
+        let exe = std::env::current_exe().ok()?;
+        let out = std::process::Command::new(exe)
+            .arg(format!("--measure={which}"))
+            .output()
+            .ok()?;
+        String::from_utf8_lossy(&out.stdout).trim().parse().ok()
+    };
+
+    let (Some(value_bytes), Some(row_bytes)) = (one("value"), one("rowjson")) else {
+        println!("  could not re-exec for measurement");
+        return;
+    };
+
+    println!(
+        "  cache  HashMap<String, Value>    {:>8} KiB  ({:>5} B/row)",
+        value_bytes / 1024,
+        value_bytes / N
+    );
+    println!(
+        "  cache  HashMap<String, RowJson>  {:>8} KiB  ({:>5} B/row)   {:.1}x smaller",
+        row_bytes / 1024,
+        row_bytes / N,
+        value_bytes as f64 / row_bytes.max(1) as f64
+    );
+    println!(
+        "\n  encoded row: {} B. The same data as a `Value` costs that plus \
+         the tree:\n  one `Map` node and a separately-allocated `String` \
+         per key, per row.\n",
+        raw(&pod_row(0)).get().len()
+    );
+}
+
+fn timings() {
+    println!("\n=== row representation: timings, {N} pod rows ===\n");
+
+    let row = pod_row(7);
+    let row_same = pod_row(7);
+    let a = raw(&row);
+    let b = raw(&row_same);
+
+    println!("--- per-apply, in the watcher task ---");
+    bench(
+        "was: Value::clone (deep)        [on change]",
+        200_000,
+        || {
+            std::hint::black_box(row.clone());
+        },
+    );
+    bench("was: Value == Value (tree walk) [always]", 200_000, || {
+        std::hint::black_box(row == row_same);
+    });
+    bench(
+        "now: RowJson::from_value        [on change]",
+        200_000,
+        || {
+            std::hint::black_box(raw(&row));
+        },
+    );
+    bench("now: RowJson == RowJson (memcmp)[always]", 500_000, || {
+        std::hint::black_box(a == b);
+    });
+    bench(
+        "now: RowJson::clone         [cache + channel]",
+        2_000_000,
+        || {
+            std::hint::black_box(a.clone());
+        },
+    );
+
+    println!("\n--- snapshot(), on every subscribe_resource ---");
+    let mut cv: HashMap<String, Value> = HashMap::with_capacity(N);
+    let mut cr: HashMap<String, RowJson> = HashMap::with_capacity(N);
+    for i in 0..N {
+        let r = pod_row(i);
+        cr.insert(uid_of(i), raw(&r));
+        cv.insert(uid_of(i), r);
+    }
+    bench("was: Vec<Value>   values().cloned()", 100, || {
+        std::hint::black_box(cv.values().cloned().collect::<Vec<Value>>());
+    });
+    bench("now: Vec<RowJson> values().cloned()", 50_000, || {
+        std::hint::black_box(cr.values().cloned().collect::<Vec<RowJson>>());
+    });
+
+    let snap_v: Vec<Value> = cv.values().cloned().collect();
+    let snap_r: Vec<RowJson> = cr.values().cloned().collect();
+    bench("was: to_string(Vec<Value>)   [command return]", 100, || {
+        std::hint::black_box(serde_json::to_string(&snap_v).unwrap());
+    });
+    bench(
+        "now: to_string(Vec<RowJson>) [command return]",
+        2_000,
+        || {
+            std::hint::black_box(serde_json::to_string(&snap_r).unwrap());
+        },
+    );
+
+    println!("\n--- emit batch, 1000 deltas = MAX_EMIT_DELTAS ---");
+    let rows: Vec<Value> = (0..1000).map(pod_row).collect();
+    let legacy: Vec<LegacyDelta> = rows
+        .iter()
+        .cloned()
+        .map(|row| LegacyDelta::Upsert { row })
+        .collect();
+    let current: Vec<ResourceDelta> = rows
+        .iter()
+        .map(|r| ResourceDelta::Upsert { row: raw(r) })
+        .collect();
+    bench("was: to_string(Vec<Delta{Value}>)", 200, || {
+        std::hint::black_box(serde_json::to_string(&legacy).unwrap());
+    });
+    bench("now: to_string(Vec<Delta{RowJson}>)", 10_000, || {
+        std::hint::black_box(serde_json::to_string(&current).unwrap());
+    });
+
+    println!("\n--- search-index blob, per row, on the forwarder task ---");
+    bench("was: serde_json::to_string(&Value)", 200_000, || {
+        std::hint::black_box(serde_json::to_string(&row).unwrap());
+    });
+    bench("now: RowJson::get().to_owned()", 2_000_000, || {
+        std::hint::black_box(a.get().to_owned());
+    });
+
+    println!("\n(run with --residency for memory accounting)\n");
+}

--- a/crates/kube-ext/src/lib.rs
+++ b/crates/kube-ext/src/lib.rs
@@ -49,4 +49,4 @@ pub use registry::{
     clear_printer_column_cache, lookup, registry, Category, ColumnDef, ColumnKind, DiscoveredCrd,
     DiscoveredPrinterColumn, KindSpec, ResourceKind, ResourceKindEntry,
 };
-pub use watcher::{NsScope, ResourceDelta, ResourceWatcher};
+pub use watcher::{NsScope, ResourceDelta, ResourceWatcher, Row, RowJson};

--- a/crates/kube-ext/src/watcher.rs
+++ b/crates/kube-ext/src/watcher.rs
@@ -1,13 +1,42 @@
 //! Generic kube watcher → snapshot + delta firehose.
 //!
-//! Erases the kube type behind `serde_json::Value` so a single command pair
+//! Erases the kube type behind JSON so a single command pair
 //! (`subscribe_resource` / `unsubscribe_resource`) can serve every kind in
-//! the registry. Only the projected `Value` row is retained; the typed
+//! the registry. Only the projected row is retained; the typed
 //! Kubernetes object is dropped immediately after projection so we don't
 //! pay the full PodSpec/status/managedFields footprint × N pods × N kinds.
 //!
 //! Each row is always `{ "uid": "...", ... }` — the watcher injects `uid`
 //! after [`KindSpec::project`] so spec implementations don't have to.
+//!
+//! **Rows are cached pre-serialised** ([`RowJson`] = `Arc<RawValue>`), not
+//! as a live `serde_json::Value` tree. [`KindSpec::project`] still returns
+//! a `Value` — that's the ergonomic shape for a projection — but the
+//! watcher serialises it once, immediately, and drops the tree. Everything
+//! downstream (the `subscribe_resource` snapshot, the IPC delta batch, the
+//! search-index blob) reuses those same bytes.
+//!
+//! Measured on a 5000-row Pods cache with a median two-container /
+//! five-label projection — `cargo run --release -p ferrisscope-kube-ext
+//! --example rowbench` (see `examples/rowbench.rs`), release build:
+//!
+//! | | `HashMap<String, Value>` | `HashMap<String, RowJson>` |
+//! |---|---|---|
+//! | cache residency | 4735 B/row (23.1 MiB) | 923 B/row (4.4 MiB) |
+//! | `snapshot()` | 26.2 ms + 22.6 MiB transient | 0.04 ms + 78 KiB |
+//! | snapshot → JSON (command return) | 3.53 ms | 0.15 ms |
+//! | 1000-delta emit batch → JSON | 0.63 ms | 0.045 ms |
+//! | search-index blob per row | 906 ns | 13 ns |
+//! | no-op suppression compare | 299 ns (tree walk) | 8 ns (memcmp) |
+//!
+//! Residency is from a counting `GlobalAlloc` (exact bytes). The in-repo
+//! example can't use one — the workspace forbids `unsafe` — so it reports
+//! an RSS delta instead and shows a shallower 3.6×; page rounding and
+//! allocator slack inflate both sides.
+//!
+//! The one cost moved *onto* the watcher task is the serialise itself
+//! (~775 ns/row, replacing a ~1200 ns/row deep `Value::clone`), so even
+//! the producer side comes out ahead.
 //!
 //! The watcher → forwarder pipe is a **coalescing dirty channel**, not a
 //! bounded broadcast. The previous design used `tokio::sync::broadcast`
@@ -34,12 +63,103 @@ use kube::{
     runtime::{watcher, WatchStreamExt},
     Client, ResourceExt,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer};
+use serde_json::value::RawValue;
 use serde_json::Value;
 use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 
 use crate::registry::KindSpec;
+
+/// A projected row, already serialised to JSON.
+///
+/// Cheap to clone (one refcount bump) and cheap to compare (a `memcmp` of
+/// the encoded bytes instead of a `Value` tree walk). Serialising a
+/// `RowJson` splices the stored bytes straight into the output — serde
+/// never re-encodes it — which is what makes the emit batch and the
+/// subscribe snapshot nearly free. See the module docs for numbers.
+///
+/// The bytes are whatever `serde_json` produced for the projected
+/// `Value`, so the wire format the frontend sees is byte-identical to
+/// what the previous `Value`-cached watcher emitted.
+#[derive(Clone, Debug)]
+pub struct RowJson(Arc<RawValue>);
+
+impl RowJson {
+    /// Serialise a projected row. Fails only if the projection contains
+    /// something `serde_json` refuses to encode (a non-string map key, a
+    /// non-finite float) — neither is reachable from a `Value`, but the
+    /// error is surfaced rather than swallowed so a future projection
+    /// that hand-rolls `Serialize` can't silently drop rows.
+    pub fn from_value(v: &Value) -> Result<Self, serde_json::Error> {
+        Ok(Self(Arc::from(serde_json::value::to_raw_value(v)?)))
+    }
+
+    /// The encoded row, e.g. `{"uid":"…","name":"nginx",…}`.
+    pub fn get(&self) -> &str {
+        self.0.get()
+    }
+}
+
+impl PartialEq for RowJson {
+    fn eq(&self, other: &Self) -> bool {
+        // Pointer equality first: the common steady-state compare is a
+        // row against the very `Arc` already in the cache only when the
+        // watcher re-emits an unchanged object, so the memcmp is the
+        // real path — but the pointer check costs nothing.
+        Arc::ptr_eq(&self.0, &other.0) || self.0.get() == other.0.get()
+    }
+}
+
+impl Eq for RowJson {}
+
+impl Serialize for RowJson {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        // `RawValue`'s own impl splices the stored bytes verbatim.
+        self.0.serialize(s)
+    }
+}
+
+/// A projected row plus the two fields the search index needs, hoisted out
+/// while the `Value` tree is still in hand.
+///
+/// Pulling `namespace` / `name` here means the forwarder never has to parse
+/// [`RowJson`] back into a `Value` to feed the index — which would undo the
+/// whole point of caching the encoded form. All three fields are refcounted,
+/// so cloning a `Row` into the dirty channel is three atomic increments.
+#[derive(Clone, Debug)]
+pub struct Row {
+    pub json: RowJson,
+    pub namespace: Option<Arc<str>>,
+    /// `None` for a projection with no (or an empty) `name` — the search
+    /// index skips those, since a hit with no name is unrenderable.
+    pub name: Option<Arc<str>>,
+}
+
+impl Row {
+    /// Finish a projection into a cacheable row: inject `uid`, attach
+    /// `__labels`, hoist `namespace` / `name`, then serialise once.
+    pub(crate) fn build(
+        uid: &str,
+        projected: Value,
+        labels: Option<&BTreeMap<String, String>>,
+    ) -> Result<Self, serde_json::Error> {
+        let v = with_labels(with_uid(uid.to_owned(), projected), labels);
+        let field = |key: &str| -> Option<Arc<str>> {
+            v.get(key)
+                .and_then(Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(Arc::from)
+        };
+        let namespace = field("namespace");
+        let name = field("name");
+        Ok(Self {
+            json: RowJson::from_value(&v)?,
+            namespace,
+            name,
+        })
+    }
+}
 
 /// Namespace scope for a single [`ResourceWatcher`]. The operator's
 /// namespace selection in the UI is mapped onto one of these by the
@@ -114,7 +234,7 @@ struct DirtyChannel {
 struct DirtyState {
     /// uid → latest projected row. An `Upsert` overwrites any prior value;
     /// a `Delete` removes the entry here and inserts the uid into `deleted`.
-    changed: HashMap<String, Value>,
+    changed: HashMap<String, Row>,
     /// uids that were deleted after their last upsert in this window. The
     /// drain emits these as `ResourceDelta::Delete`. Kept disjoint from
     /// `changed` so a Delete-then-Upsert sequence ends as a single Upsert
@@ -134,7 +254,7 @@ struct DirtyState {
 /// [`ResourceDrainer::drain`].
 #[derive(Debug, Default)]
 pub struct DrainedBatch {
-    pub upserts: HashMap<String, Value>,
+    pub upserts: HashMap<String, Row>,
     pub deletes: HashSet<String>,
     pub init_done: bool,
 }
@@ -164,7 +284,7 @@ impl DirtyChannel {
         }
     }
 
-    fn record_upsert(&self, uid: String, row: Value) {
+    fn record_upsert(&self, uid: String, row: Row) {
         let mut s = self.state.lock_recover();
         if s.closed {
             return;
@@ -269,7 +389,7 @@ impl DirtyChannel {
             }
             budget -= deletes.len();
         }
-        let mut upserts = HashMap::new();
+        let mut upserts: HashMap<String, Row> = HashMap::new();
         if budget > 0 {
             let take: Vec<String> = s.changed.keys().take(budget).cloned().collect();
             for uid in take {
@@ -343,7 +463,7 @@ fn watcher_config(strategy: ListStrategy) -> watcher::Config {
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum ResourceDelta {
     Upsert {
-        row: Value,
+        row: RowJson,
     },
     Delete {
         uid: String,
@@ -363,7 +483,7 @@ pub enum ResourceDelta {
 /// one. Drop aborts the task and closes the channel so the forwarder
 /// exits cleanly.
 pub struct ResourceWatcher {
-    snapshot_fn: Box<dyn Fn() -> Vec<Value> + Send + Sync>,
+    snapshot_fn: Box<dyn Fn() -> Vec<RowJson> + Send + Sync>,
     dirty: Arc<DirtyChannel>,
     /// Single-consumer guard for [`Self::take_drainer`]. Production code
     /// only ever takes one drainer (the forwarder spawned in
@@ -400,7 +520,7 @@ impl ResourceWatcher {
         // store would keep full `Arc<S::K>` per object — on a 5000-pod
         // cluster that's 50–200 MB of typed Rust state we never read again
         // (the UI consumes the projected row, not the Pod struct).
-        let cache: Arc<Mutex<HashMap<String, Value>>> = Arc::new(Mutex::new(HashMap::new()));
+        let cache: Arc<Mutex<HashMap<String, RowJson>>> = Arc::new(Mutex::new(HashMap::new()));
 
         let cfg = watcher_config(strategy);
         let stream = watcher(api, cfg).default_backoff();
@@ -479,8 +599,18 @@ impl ResourceWatcher {
                         seen.insert(uid.clone());
                     }
                 }
-                let row = with_uid(uid.clone(), S::project(&obj));
-                let row = with_labels(row, Some(obj.labels()));
+                let row = match Row::build(&uid, S::project(&obj), Some(obj.labels())) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            kind = S::meta().id,
+                            uid = %uid,
+                            "watcher: projected row failed to serialise, dropping"
+                        );
+                        continue;
+                    }
+                };
                 // Drop the typed object as soon as projection is done.
                 drop(obj);
                 // No-op suppression: if the projected row is byte-
@@ -490,16 +620,17 @@ impl ResourceWatcher {
                 // unchanged) and the steady-state churn from server-
                 // side fields the projection deliberately drops
                 // (managedFields, resourceVersion, lastTransitionTime
-                // bumps that don't move any column). One Value::eq
-                // walk is orders of magnitude cheaper than the IPC
-                // emit + JSON-decode + React reconciliation we'd
-                // otherwise pay downstream.
+                // bumps that don't move any column). Because rows are
+                // cached pre-serialised this is a `memcmp` (~10 ns),
+                // not a `Value` tree walk (~300 ns) — and either way
+                // orders of magnitude cheaper than the IPC emit +
+                // JSON-decode + React reconciliation downstream.
                 let mut cache = cache_task.lock_recover();
-                let unchanged = cache.get(&uid).is_some_and(|prev| prev == &row);
+                let unchanged = cache.get(&uid).is_some_and(|prev| *prev == row.json);
                 if unchanged {
                     suppressed += 1;
                 } else {
-                    cache.insert(uid.clone(), row.clone());
+                    cache.insert(uid.clone(), row.json.clone());
                     drop(cache);
                     dirty_task.record_upsert(uid, row);
                 }
@@ -530,7 +661,7 @@ impl ResourceWatcher {
             );
         });
 
-        let snapshot_fn: Box<dyn Fn() -> Vec<Value> + Send + Sync> =
+        let snapshot_fn: Box<dyn Fn() -> Vec<RowJson> + Send + Sync> =
             Box::new(move || cache.lock_recover().values().cloned().collect());
 
         Self {
@@ -567,7 +698,7 @@ impl ResourceWatcher {
             Some(ns) => Api::namespaced_with(client, ns, &ar),
             None => Api::all_with(client, &ar),
         };
-        let cache: Arc<Mutex<HashMap<String, Value>>> = Arc::new(Mutex::new(HashMap::new()));
+        let cache: Arc<Mutex<HashMap<String, RowJson>>> = Arc::new(Mutex::new(HashMap::new()));
 
         let cfg = watcher_config(strategy);
         let stream = watcher(api, cfg).default_backoff();
@@ -643,18 +774,28 @@ impl ResourceWatcher {
                         seen.insert(uid.clone());
                     }
                 }
-                let row = with_uid(uid.clone(), project_task(&obj));
-                let row = with_labels(row, Some(obj.labels()));
+                let row = match Row::build(&uid, project_task(&obj), Some(obj.labels())) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            kind = %log_id_task,
+                            uid = %uid,
+                            "dynamic watcher: projected row failed to serialise, dropping"
+                        );
+                        continue;
+                    }
+                };
                 // No-op suppression — see typed-watcher branch above
-                // for the rationale. Same behaviour: cheap structural
-                // equality on the projected row; on miss, update the
-                // cache and broadcast; on hit, drop silently.
+                // for the rationale. Same behaviour: byte equality on
+                // the encoded row; on miss, update the cache and
+                // broadcast; on hit, drop silently.
                 let mut cache = cache_task.lock_recover();
-                let unchanged = cache.get(&uid).is_some_and(|prev| prev == &row);
+                let unchanged = cache.get(&uid).is_some_and(|prev| *prev == row.json);
                 if unchanged {
                     suppressed += 1;
                 } else {
-                    cache.insert(uid.clone(), row.clone());
+                    cache.insert(uid.clone(), row.json.clone());
                     drop(cache);
                     dirty_task.record_upsert(uid, row);
                 }
@@ -686,7 +827,7 @@ impl ResourceWatcher {
         });
 
         let cache_snap = cache.clone();
-        let snapshot_fn: Box<dyn Fn() -> Vec<Value> + Send + Sync> = Box::new(move || {
+        let snapshot_fn: Box<dyn Fn() -> Vec<RowJson> + Send + Sync> = Box::new(move || {
             // std::sync::Mutex held only across tiny insert/remove/clone
             // critical sections — blocking briefly here is fine and avoids
             // the lossy try_lock path the previous version used (which
@@ -794,9 +935,12 @@ impl ResourceWatcher {
                             // A non-latest revision was removed, or latest
                             // was removed and we now demote: re-emit so the
                             // table reflects the new live revision.
-                            let uid = synthetic_uid(&key.0, &key.1);
-                            let row = with_uid(uid.clone(), project_row(latest));
-                            dirty_task.record_upsert(uid, row);
+                            record_synth(
+                                &dirty_task,
+                                synthetic_uid(&key.0, &key.1),
+                                project_row(latest),
+                                "helm_releases",
+                            );
                         }
                         continue;
                     }
@@ -831,9 +975,12 @@ impl ResourceWatcher {
                                     dirty_task.record_delete(synthetic_uid(&key.0, &key.1));
                                 } else if let Some(latest) = revs.values().max_by_key(|r| r.version)
                                 {
-                                    let uid = synthetic_uid(&key.0, &key.1);
-                                    let row = with_uid(uid.clone(), project_row(latest));
-                                    dirty_task.record_upsert(uid, row);
+                                    record_synth(
+                                        &dirty_task,
+                                        synthetic_uid(&key.0, &key.1),
+                                        project_row(latest),
+                                        "helm_releases",
+                                    );
                                 }
                             }
                             stale.len()
@@ -884,9 +1031,12 @@ impl ResourceWatcher {
                 let entry = g.entry(key.clone()).or_default();
                 entry.insert(secret_uid, release);
                 if let Some(latest) = entry.values().max_by_key(|r| r.version) {
-                    let uid = synthetic_uid(&ns, &name);
-                    let row = with_uid(uid.clone(), project_row(latest));
-                    dirty_task.record_upsert(uid, row);
+                    record_synth(
+                        &dirty_task,
+                        synthetic_uid(&ns, &name),
+                        project_row(latest),
+                        "helm_releases",
+                    );
                 }
                 applied += 1;
                 if !first_apply_logged {
@@ -908,12 +1058,16 @@ impl ResourceWatcher {
         });
 
         let store_snap = store.clone();
-        let snapshot_fn: Box<dyn Fn() -> Vec<Value> + Send + Sync> = Box::new(move || {
+        let snapshot_fn: Box<dyn Fn() -> Vec<RowJson> + Send + Sync> = Box::new(move || {
             let g = store_snap.lock_recover();
             g.iter()
                 .filter_map(|((ns, name), revs)| {
                     let latest = revs.values().max_by_key(|r| r.version)?;
-                    Some(with_uid(synthetic_uid(ns, name), project_row(latest)))
+                    synth_row(
+                        synthetic_uid(ns, name),
+                        project_row(latest),
+                        "helm_releases",
+                    )
                 })
                 .collect()
         });
@@ -1011,9 +1165,12 @@ impl ResourceWatcher {
                     for rc in &entries {
                         let key: RepoKey = (rc.repo.clone(), rc.name.clone(), rc.version.clone());
                         g.insert(key.clone(), rc.clone());
-                        let uid = synthetic_uid(&rc.repo, &rc.name, &rc.version);
-                        let row = with_uid(uid.clone(), project_repo_row(rc));
-                        dirty.record_upsert(uid, row);
+                        record_synth(
+                            &dirty,
+                            synthetic_uid(&rc.repo, &rc.name, &rc.version),
+                            project_repo_row(rc),
+                            "helm_charts",
+                        );
                     }
                     tracing::info!(
                         kind = "helm_charts",
@@ -1152,12 +1309,12 @@ impl ResourceWatcher {
                         secret_uids: HashSet::new(),
                     });
                     entry.secret_uids.insert(secret_uid.clone());
-                    let uid = synthetic_uid(HELM_CLUSTER_SOURCE, &name, &version);
-                    let row = with_uid(
-                        uid.clone(),
+                    record_synth(
+                        &dirty_task,
+                        synthetic_uid(HELM_CLUSTER_SOURCE, &name, &version),
                         project_cluster_row(&entry.sample, entry.secret_uids.len()),
+                        "helm_charts",
                     );
-                    dirty_task.record_upsert(uid, row);
                 }
                 secret_map_task.lock_recover().insert(secret_uid, new_key);
 
@@ -1168,26 +1325,28 @@ impl ResourceWatcher {
         // Snapshot for late subscribers — covers both sources.
         let cluster_snap = cluster_charts.clone();
         let repo_snap = repo_charts.clone();
-        let snapshot_fn: Box<dyn Fn() -> Vec<Value> + Send + Sync> = Box::new(move || {
+        let snapshot_fn: Box<dyn Fn() -> Vec<RowJson> + Send + Sync> = Box::new(move || {
             use crate::fetch::HELM_CLUSTER_SOURCE;
             let mut out = Vec::new();
             {
                 let g = cluster_snap.lock_recover();
-                for ((name, version), entry) in g.iter() {
-                    out.push(with_uid(
+                out.extend(g.iter().filter_map(|((name, version), entry)| {
+                    synth_row(
                         synthetic_uid(HELM_CLUSTER_SOURCE, name, version),
                         project_cluster_row(&entry.sample, entry.secret_uids.len()),
-                    ));
-                }
+                        "helm_charts",
+                    )
+                }));
             }
             {
                 let g = repo_snap.lock_recover();
-                for ((repo, name, version), rc) in g.iter() {
-                    out.push(with_uid(
+                out.extend(g.iter().filter_map(|((repo, name, version), rc)| {
+                    synth_row(
                         synthetic_uid(repo, name, version),
                         project_repo_row(rc),
-                    ));
-                }
+                        "helm_charts",
+                    )
+                }));
             }
             out
         });
@@ -1217,17 +1376,17 @@ impl ResourceWatcher {
                 g.remove(key);
                 dirty.record_delete(synthetic_uid(HELM_CLUSTER_SOURCE, &key.0, &key.1));
             } else {
-                let uid = synthetic_uid(HELM_CLUSTER_SOURCE, &key.0, &key.1);
-                let row = with_uid(
-                    uid.clone(),
+                record_synth(
+                    dirty,
+                    synthetic_uid(HELM_CLUSTER_SOURCE, &key.0, &key.1),
                     project_cluster_row(&entry.sample, entry.secret_uids.len()),
+                    "helm_charts",
                 );
-                dirty.record_upsert(uid, row);
             }
         }
     }
 
-    pub fn snapshot(&self) -> Vec<Value> {
+    pub fn snapshot(&self) -> Vec<RowJson> {
         (self.snapshot_fn)()
     }
 
@@ -1281,7 +1440,7 @@ impl Drop for ResourceWatcher {
 /// per-chart store and reconcile inline.
 fn reconcile_init_seen(
     init_seen: &mut Option<HashSet<String>>,
-    cache: &Mutex<HashMap<String, Value>>,
+    cache: &Mutex<HashMap<String, RowJson>>,
     dirty: &DirtyChannel,
 ) -> usize {
     let Some(seen) = init_seen.take() else {
@@ -1302,6 +1461,42 @@ fn reconcile_init_seen(
         dirty.record_delete(uid);
     }
     n
+}
+
+/// Finish a *synthetic* row (Helm releases / charts — rows aggregated from
+/// several objects rather than projected from one) into a [`RowJson`].
+///
+/// Returns `None` on the practically-unreachable serialise failure, having
+/// logged it. The Helm projections build plain `Value` objects, so this is
+/// a "can't happen" branch kept honest rather than `expect`ed away.
+fn synth_row(uid: String, projected: Value, what: &'static str) -> Option<RowJson> {
+    match Row::build(&uid, projected, None) {
+        Ok(row) => Some(row.json),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                kind = what,
+                uid = %uid,
+                "watcher: synthetic row failed to serialise, dropping"
+            );
+            None
+        }
+    }
+}
+
+/// [`synth_row`] + record the result as an upsert on `dirty`.
+fn record_synth(dirty: &DirtyChannel, uid: String, projected: Value, what: &'static str) {
+    match Row::build(&uid, projected, None) {
+        Ok(row) => dirty.record_upsert(uid, row),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                kind = what,
+                uid = %uid,
+                "watcher: synthetic row failed to serialise, dropping"
+            );
+        }
+    }
 }
 
 /// Inject `uid` into a projected row. If the projection produced something
@@ -1344,8 +1539,13 @@ mod tests {
     use serde_json::json;
     use std::time::Duration;
 
-    fn row(name: &str) -> Value {
-        json!({ "uid": "ignored", "name": name })
+    fn row(name: &str) -> Row {
+        Row::build("ignored", json!({ "name": name }), None).expect("test row serialises")
+    }
+
+    /// `name` off a drained row — the field the coalescing tests assert on.
+    fn name_of(r: &Row) -> &str {
+        r.name.as_deref().unwrap_or("")
     }
 
     #[test]
@@ -1375,6 +1575,86 @@ mod tests {
         assert_eq!(tagged["__labels"]["tier"], json!("frontend"));
     }
 
+    /// The frontend contract. Caching rows pre-serialised must not change a
+    /// single byte of what goes over the bus, so pin `RowJson`'s encoding
+    /// against `serde_json::to_string` of the equivalent `Value` — the exact
+    /// thing the previous `Value`-cached watcher emitted.
+    #[test]
+    fn row_json_encoding_is_byte_identical_to_the_value_path() {
+        let labels: BTreeMap<String, String> = [
+            ("app".to_owned(), "nginx".to_owned()),
+            ("tier".to_owned(), "frontend".to_owned()),
+        ]
+        .into_iter()
+        .collect();
+        let projected = json!({
+            "namespace": "default",
+            "name": "nginx-abc",
+            "phase": "Running",
+            "restarts": 3,
+            "cpu": Value::Null,
+            "containers": ["app", "sidecar"],
+        });
+
+        // What the old code path produced, verbatim.
+        let legacy = with_labels(with_uid("u-1".to_owned(), projected.clone()), Some(&labels));
+        let expected = serde_json::to_string(&legacy).expect("legacy row serialises");
+
+        let row = Row::build("u-1", projected, Some(&labels)).expect("row builds");
+        assert_eq!(row.json.get(), expected);
+
+        // …and it survives a round trip through a `Serialize` container
+        // without being re-encoded or double-escaped.
+        let wire = serde_json::to_string(&ResourceDelta::Upsert {
+            row: row.json.clone(),
+        })
+        .expect("delta serialises");
+        assert_eq!(wire, format!(r#"{{"kind":"upsert","row":{expected}}}"#));
+    }
+
+    #[test]
+    fn row_build_hoists_namespace_and_name() {
+        let row = Row::build(
+            "u-1",
+            json!({ "namespace": "kube-system", "name": "coredns" }),
+            None,
+        )
+        .expect("row builds");
+        assert_eq!(row.namespace.as_deref(), Some("kube-system"));
+        assert_eq!(row.name.as_deref(), Some("coredns"));
+
+        // Cluster-scoped kinds project no namespace; empty strings are
+        // treated as absent so the search index doesn't store `""`.
+        let row = Row::build("u-2", json!({ "name": "node-1", "namespace": "" }), None)
+            .expect("row builds");
+        assert_eq!(row.namespace, None);
+        assert_eq!(row.name.as_deref(), Some("node-1"));
+
+        // A projection with no name at all — the forwarder skips indexing
+        // these rather than writing an unrenderable hit.
+        let row = Row::build("u-3", json!({ "phase": "Running" }), None).expect("row builds");
+        assert_eq!(row.name, None);
+    }
+
+    #[test]
+    fn row_json_eq_compares_encoded_bytes_not_identity() {
+        let a = Row::build("u-1", json!({ "name": "x" }), None)
+            .unwrap()
+            .json;
+        let b = Row::build("u-1", json!({ "name": "x" }), None)
+            .unwrap()
+            .json;
+        let c = Row::build("u-1", json!({ "name": "y" }), None)
+            .unwrap()
+            .json;
+        // Distinct allocations, same bytes — this is the no-op suppression
+        // hit that keeps a 410-Gone resync off the bus.
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        // Clone shares the allocation and must still compare equal.
+        assert_eq!(a, a.clone());
+    }
+
     #[tokio::test]
     async fn coalesces_repeat_upserts_for_same_uid() {
         // The previous broadcast pipe would emit 100 events. Under the
@@ -1386,7 +1666,7 @@ mod tests {
         }
         let batch = chan.drain();
         assert_eq!(batch.upserts.len(), 1);
-        assert_eq!(batch.upserts["u1"]["name"], "v99");
+        assert_eq!(name_of(&batch.upserts["u1"]), "v99");
         assert!(batch.deletes.is_empty());
     }
 
@@ -1410,7 +1690,7 @@ mod tests {
         let batch = chan.drain();
         assert!(batch.deletes.is_empty(), "upsert must clear pending delete");
         assert_eq!(batch.upserts.len(), 1);
-        assert_eq!(batch.upserts["u1"]["name"], "a");
+        assert_eq!(name_of(&batch.upserts["u1"]), "a");
     }
 
     #[tokio::test]
@@ -1593,7 +1873,7 @@ mod tests {
     fn reconcile_init_seen_none_is_noop() {
         // If Init/InitDone never fired (e.g. an Apply-only stream), the
         // reconcile must not touch the cache and must return 0.
-        let cache = Mutex::new(HashMap::from([("u1".to_owned(), row("a"))]));
+        let cache = Mutex::new(HashMap::from([("u1".to_owned(), row("a").json)]));
         let chan = DirtyChannel::new();
         let mut seen: Option<HashSet<String>> = None;
         let n = reconcile_init_seen(&mut seen, &cache, &chan);
@@ -1609,9 +1889,9 @@ mod tests {
         // what disappeared. `init_seen` carries the uids replayed in this
         // window; anything in the cache that's missing is a ghost.
         let cache = Mutex::new(HashMap::from([
-            ("kept".to_owned(), row("k")),
-            ("gone-1".to_owned(), row("g1")),
-            ("gone-2".to_owned(), row("g2")),
+            ("kept".to_owned(), row("k").json),
+            ("gone-1".to_owned(), row("g1").json),
+            ("gone-2".to_owned(), row("g2").json),
         ]));
         let chan = DirtyChannel::new();
         let mut seen: Option<HashSet<String>> = Some(HashSet::from(["kept".to_owned()]));
@@ -1633,8 +1913,8 @@ mod tests {
         // Steady-state resync (apiserver still has every object we knew
         // about) must emit zero Deletes.
         let cache = Mutex::new(HashMap::from([
-            ("a".to_owned(), row("a")),
-            ("b".to_owned(), row("b")),
+            ("a".to_owned(), row("a").json),
+            ("b".to_owned(), row("b").json),
         ]));
         let chan = DirtyChannel::new();
         let mut seen: Option<HashSet<String>> = Some(HashSet::from([

--- a/crates/kube-ext/tests/integration_reflector.rs
+++ b/crates/kube-ext/tests/integration_reflector.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ferrisscope_kube_ext::registry::lookup;
-use ferrisscope_kube_ext::watcher::{DrainedBatch, NsScope, ResourceDrainer};
+use ferrisscope_kube_ext::watcher::{DrainedBatch, NsScope, ResourceDrainer, Row};
 use ferrisscope_test_support::kind::{ensure_two_clusters, KindCluster};
 use kube::config::{KubeConfigOptions, Kubeconfig};
 use kube::{Client, Config};
@@ -74,8 +74,7 @@ async fn reflector_emits_pods_for_namespace_and_clears_on_unsubscribe() {
             }
             let batch = drainer.drain();
             if upsert_matches(&batch, |row| {
-                row.get("namespace").and_then(|v| v.as_str()) == Some(ns)
-                    && row.get("name").and_then(|v| v.as_str()) == Some("alpha")
+                row.namespace.as_deref() == Some(ns) && row.name.as_deref() == Some("alpha")
             }) {
                 return true;
             }
@@ -133,8 +132,8 @@ async fn two_clusters_have_independent_reflector_state() {
                     break;
                 }
                 let batch = drainer.drain();
-                for (_, row) in &batch.upserts {
-                    if let Some(n) = row.get("name").and_then(|v| v.as_str()) {
+                for row in batch.upserts.values() {
+                    if let Some(n) = row.name.as_deref() {
                         names.push(n.to_owned());
                     }
                 }
@@ -167,7 +166,7 @@ async fn two_clusters_have_independent_reflector_state() {
     let _ = b.kubectl(&["delete", "namespace", ns_b, "--wait=false"]);
 }
 
-fn upsert_matches(batch: &DrainedBatch, predicate: impl Fn(&serde_json::Value) -> bool) -> bool {
+fn upsert_matches(batch: &DrainedBatch, predicate: impl Fn(&Row) -> bool) -> bool {
     batch.upserts.values().any(predicate)
 }
 


### PR DESCRIPTION
## Problem

The watcher cached each projected row as a live `serde_json::Value`. That tree was then:

1. deep-cloned on every changed apply (once into the cache, once into the dirty channel),
2. deep-cloned N times on every `snapshot()` — i.e. on every kind switch,
3. re-serialised per row for the search-index blob,
4. re-serialised again for the IPC emit batch.

So every row was **encoded twice per delta**, and carried roughly **5× its own JSON size** in memory (`serde_json::Map` node overhead plus a separately-allocated `String` per key, per row).

## Change

`RowJson(Arc<RawValue>)` — the projection is serialised **once**, immediately, and the `Value` tree is dropped. Every downstream consumer (subscribe snapshot, emit batch, search-index blob) reuses those same bytes.

`Row` carries the encoded row plus `namespace` / `name`, hoisted while the tree is still in hand, so the forwarder never parses a row back into a `Value` to feed the index — which would have undone the whole point.

`KindSpec::project` still returns a `Value`; that stays the ergonomic shape for a projection. Only the *cached* representation changed.

## Numbers

`cargo run --release -p ferrisscope-kube-ext --example rowbench` (added in this PR). 5000-row Pods cache, median two-container / five-label projection:

| | before | after |
|---|---|---|
| cache residency | 4735 B/row (23.1 MiB) | 923 B/row (4.4 MiB) |
| `snapshot()` | 25.5 ms | 0.043 ms |
| … its transient copy | 22.6 MiB | 78 KiB |
| snapshot → JSON (command return) | 3.96 ms | 0.154 ms |
| 1000-delta emit batch → JSON | 0.79 ms | 0.046 ms |
| search-index blob, per row | 843 ns | 13 ns |
| no-op suppression compare | 326 ns (tree walk) | 9 ns (memcmp) |

Net **~3.6× less CPU per row** end-to-end and **~150× faster subscribe** on a 5000-row cache.

The one cost moved *onto* the watcher task is the serialise itself (~790 ns/row) — it replaces a ~1190 ns/row deep `Value::clone`, so the producer side comes out ahead too.

Residency figures are from a counting `GlobalAlloc`. The in-repo example can't use one (the workspace `forbid(unsafe_code)`s), so it reports an RSS delta instead and shows a shallower 3.6× — page rounding and allocator slack inflate both sides. Documented in the example.

Rejected alternatives, both measured:
- `RawValue::from_string` re-validates the JSON (~1250 ns vs ~790 ns for `to_raw_value`, which skips it — the bytes came from `serde_json` and are valid by construction).
- plain `Arc<Value>` fixes the clones but not the 23 MiB residency and not either re-serialise.

## Wire format

**Unchanged.** `RawValue` splices its stored bytes verbatim, so the frontend sees exactly what the `Value`-cached watcher emitted. Pinned by `row_json_encoding_is_byte_identical_to_the_value_path`, which asserts the encoding against `to_string` of the old `with_labels(with_uid(...))` output *and* against the full `ResourceDelta` envelope. No frontend change in this PR.

## Also

- `SearchIndex::upsert_raw` for the pre-encoded watcher path. `upsert` stays for the connect-time LIST bootstrap, which only has a `Value` to hand over.
- The forwarder takes the uid from the drain map's key instead of re-extracting `row["uid"]` — strictly more correct, and it was only doing that because the row was a `Value`.
- `serde_json` gains the `raw_value` feature. No lockfile change (features aren't recorded there).

## Tests

New:
- `watcher.rs` — encoding byte-identity, `namespace`/`name` hoisting (incl. empty-string and missing), `RowJson` equality by bytes not identity.
- `search/mod.rs` — `upsert_raw` enqueues the same `WriteOp` as `upsert`, nameless rows are skipped, cluster-scoped rows with no namespace still index.

Updated `tests/integration_reflector.rs` for the new drain shape.

Local: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `npx vitest run` (1188) all clean.

## Not covered

- No live cluster locally (`kind` installed, none running) — the CI integration job is the first real-apiserver exercise of this change.
- `KindSpec::project` still materialises a `Value` before serialising. Removing that would claw back most of the remaining ~790 ns/row, but it's a rewrite of every `kinds/*.rs`.
- Frontend JS-heap residency of parsed rows is unmeasured and is likely the largest remaining memory term.
