### PR TITLE
feat(auth): explain a 403 caused by cloud identity drift, and offer to pin

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -440,6 +440,110 @@ pub(crate) async fn diagnose_connection_cmd(
     .map_err(|e| e.to_string())
 }
 
+/// Explain a *failed* connect when the cause looks like the "wrong Google
+/// account" trap: a context whose `gke-gcloud-auth-plugin` entry carries no
+/// `--account`, on a machine with several gcloud accounts, hitting an RBAC 403.
+///
+/// Returns `None` for every other failure — the caller renders nothing. Runs
+/// only after a connect has already failed, so the kubeconfig + gcloud config
+/// reads never touch the happy path.
+///
+/// SSH-sourced contexts are skipped: their kubeconfig lives on the remote host,
+/// so a local exec entry (and a local gcloud install) says nothing about them.
+#[tauri::command]
+pub(crate) async fn connect_hint_cmd(
+    name: String,
+    error: String,
+    state: State<'_, AppState>,
+) -> Result<Option<ferrisscope_core::cloud_identity::ConnectHint>, String> {
+    let context_name = kubeconfig::context_name_from_id(&name).to_owned();
+    let (is_ssh, source_path) = {
+        let s = state.sources.lock().await;
+        (
+            kubeconfig::ssh_for(&name, &s).is_some(),
+            kubeconfig::resolve_path_for(&name, &s),
+        )
+    };
+    if is_ssh {
+        return Ok(None);
+    }
+    // `resolve_path_for` is `None` only when the id names no source we know —
+    // a stale panel for a source the operator has since removed, or an SSH
+    // source with a null `ssh` block. Reading the *default* kubeconfig in that
+    // case would classify whatever context happens to share the name and
+    // produce a confident note about the wrong cluster, so render nothing.
+    //
+    // Resolving to a concrete file (rather than passing `None` and letting
+    // kube-rs merge every `KUBECONFIG` entry) also keeps this in step with the
+    // pin, which can only ever write one file: if the failing context lives in
+    // the second entry of a multi-file `KUBECONFIG`, the lookup misses here and
+    // no note is offered, instead of offering a pin that always fails.
+    let Some(source_path) = source_path else {
+        return Ok(None);
+    };
+    // Reads the kubeconfig + gcloud config dir from disk → keep off the async
+    // worker, same as `diagnose_connection_cmd`.
+    tokio::task::spawn_blocking(move || {
+        ferrisscope_core::cloud_identity::hint_for_context(
+            &context_name,
+            Some(source_path.as_path()),
+            &error,
+        )
+    })
+    .await
+    .map_err(|e| format!("connect hint task failed: {e}"))?
+    .map_err(|e| e.to_string())
+}
+
+/// Pin a context's exec entry to an explicit cloud identity — a gcloud
+/// `--account` or an AWS `AWS_PROFILE`, whichever the exec command calls for.
+///
+/// The kubeconfig is backed up before the first edit. For gcloud (and only
+/// gcloud) the pin also drops `~/.kube/gke_gcloud_auth_plugin_cache`, which can
+/// still be holding a token minted under the previous identity; see
+/// `cloud_identity::pin_identity`. Azure is refused there — kubelogin has no
+/// per-context account flag.
+///
+/// Refuses SSH-sourced contexts — the kubeconfig being described lives on
+/// another host and isn't ours to rewrite.
+#[tauri::command]
+pub(crate) async fn pin_cloud_identity_cmd(
+    name: String,
+    identity: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    let context_name = kubeconfig::context_name_from_id(&name).to_owned();
+    let (is_ssh, source_path) = {
+        let s = state.sources.lock().await;
+        (
+            kubeconfig::ssh_for(&name, &s).is_some(),
+            kubeconfig::resolve_path_for(&name, &s),
+        )
+    };
+    if is_ssh {
+        return Err(
+            "this context comes from a remote kubeconfig over SSH — pin the identity on that host"
+                .to_owned(),
+        );
+    }
+    // `resolve_path_for` applies the default-kubeconfig fallback *only* for
+    // ids from the implicit default source. Falling back on a bare
+    // `source_path_for` miss would be wrong three ways out of four: an unknown
+    // source id, a removed source, and an SSH source whose `ssh` block is null
+    // (representable — the field is `#[serde(default)] Option`, so the
+    // `is_ssh` check above misses it) would each rewrite the operator's *local*
+    // kubeconfig for a context that does not live there.
+    let path = source_path.ok_or_else(|| {
+        format!("could not locate the kubeconfig file backing {name} — nothing was written")
+    })?;
+    tokio::task::spawn_blocking(move || {
+        ferrisscope_core::cloud_identity::pin_identity(&path, &context_name, &identity)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("pin identity task failed: {e}"))?
+}
+
 /// Wall-clock budget for `connect_context`. Long enough for slow auth plugins
 /// (gke/aws/oidc shell out and can be sluggish on a cold cache) but short
 /// enough that a wedged apiserver doesn't pin the panel forever. The frontend

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -158,6 +158,8 @@ fn main() {
             commands::list_contexts,
             commands::connect_context,
             commands::diagnose_connection_cmd,
+            commands::connect_hint_cmd,
+            commands::pin_cloud_identity_cmd,
             commands::cancel_connect,
             commands::list_resource_kinds,
             commands::list_custom_resource_kinds,

--- a/crates/core/src/atomic_write.rs
+++ b/crates/core/src/atomic_write.rs
@@ -8,14 +8,23 @@
 //! (`decode: trailing characters at line N column M`). The same hazard
 //! exists on a crash mid-write — the file is left half-overwritten.
 //!
-//! `atomic_write` writes the payload to a sibling tempfile, then renames
-//! it onto the final path. `rename` is atomic on POSIX (and Windows under
-//! `ReplaceFileW`, which `tokio::fs::rename` uses), so concurrent readers
-//! either see the previous file or the new file in full — never a
-//! partially-overwritten head.
+//! `atomic_write` writes the payload to a sibling tempfile, `fsync`s it,
+//! then renames it onto the final path and `fsync`s the parent directory.
+//! `rename` is atomic on POSIX (and Windows under `ReplaceFileW`, which
+//! `tokio::fs::rename` uses), so concurrent readers either see the previous
+//! file or the new file in full — never a partially-overwritten head.
+//!
+//! The `fsync`s are what make the *crash* half of that claim true. Without
+//! them the rename is a metadata operation that can reach disk ahead of the
+//! data it points at, so a power loss inside the writeback window leaves a
+//! zero-length file where the old one used to be. ext4's `auto_da_alloc`
+//! usually papers over this; XFS, btrfs, and ext4 mounted `noauto_da_alloc`
+//! do not.
 
+use std::io::Write as _;
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::io::AsyncWriteExt as _;
 
 /// Monotonic counter so concurrent writers to the same final path each
 /// land their bytes in a distinct tempfile. Without this, two in-flight
@@ -34,19 +43,141 @@ pub async fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
         tokio::fs::create_dir_all(parent).await?;
     }
     let tmp = tmp_sibling(path);
-    tokio::fs::write(&tmp, bytes).await?;
-    tokio::fs::rename(&tmp, path).await
+    let res = async {
+        let mut f = tokio::fs::File::create(&tmp).await?;
+        f.write_all(bytes).await?;
+        // Without this the rename is only atomic against concurrent *readers*.
+        // A crash can still reorder the (metadata) rename ahead of the (data)
+        // writeback and leave a zero-length file where the old one was.
+        f.sync_all().await?;
+        drop(f);
+        tokio::fs::rename(&tmp, path).await?;
+        Ok(())
+    }
+    .await;
+    if res.is_err() {
+        // Never leave the payload behind under a temp name: for the kubeconfig
+        // path that payload is the operator's certs and tokens.
+        let _ = tokio::fs::remove_file(&tmp).await;
+    } else {
+        sync_parent_dir(path);
+    }
+    res
 }
 
 /// Sync atomic replace. Use from std-only call sites (sync command
 /// handlers, scratch-file writers, anywhere already on `std::fs`).
 pub fn atomic_write_sync(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    atomic_write_sync_mode(path, bytes, None)
+}
+
+/// [`atomic_write_sync`] that also pins the resulting file's unix mode.
+///
+/// The rename that makes this atomic **replaces the target's inode**, so the
+/// final file carries the *tempfile's* permissions, not the ones the target had
+/// before. For ordinary config that's fine (0644 either way). For a file the
+/// user has deliberately locked down — a kubeconfig at 0600, holding client
+/// certs and bearer tokens — silently rewriting it as 0644 would be a
+/// credential leak caused purely by an unrelated edit.
+///
+/// Passing `Some(mode)` chmods the tempfile *before* the rename, so the target
+/// is never observable with looser permissions than it started with. `None`
+/// keeps the previous behaviour.
+///
+/// The mode is a no-op on Windows, where the inherited ACL governs access.
+pub fn atomic_write_sync_mode(path: &Path, bytes: &[u8], mode: Option<u32>) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
     let tmp = tmp_sibling(path);
-    std::fs::write(&tmp, bytes)?;
-    std::fs::rename(&tmp, path)
+    let res = write_tmp_then_rename(&tmp, path, bytes, mode);
+    if res.is_err() {
+        // Every error return below leaves a tempfile holding the full payload.
+        // For the kubeconfig that payload is `client-key-data` and bearer
+        // tokens, and the tempfile is a sibling in `~/.kube/`, which is 0755 on
+        // a stock install. Orphaning one is a credential leak that outlives the
+        // failure, so clean up on every path out.
+        let _ = std::fs::remove_file(&tmp);
+    } else {
+        sync_parent_dir(path);
+    }
+    res
+}
+
+fn write_tmp_then_rename(
+    tmp: &Path,
+    path: &Path,
+    bytes: &[u8],
+    mode: Option<u32>,
+) -> std::io::Result<()> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        // Create *already* restricted rather than chmod-after-write. The old
+        // order (`fs::write` then `set_permissions`) published the full payload
+        // at `0o666 & !umask` — 0644 on a stock box — for the duration of the
+        // write, and left it there permanently if the chmod or the rename then
+        // failed. `None` keeps the historical default for ordinary app config.
+        opts.mode(mode.unwrap_or(0o666));
+    }
+    let mut f = opts.open(tmp)?;
+    #[cfg(unix)]
+    if let Some(mode) = mode {
+        // `open`'s mode argument is masked by umask, so a restrictive umask
+        // could land *tighter* than asked. Set the exact bits now, while the
+        // file is still empty.
+        use std::os::unix::fs::PermissionsExt as _;
+        f.set_permissions(std::fs::Permissions::from_mode(mode))?;
+    }
+    #[cfg(not(unix))]
+    let _ = mode;
+    f.write_all(bytes)?;
+    // See the async twin: rename alone is race-safe, not crash-safe.
+    f.sync_all()?;
+    drop(f);
+    std::fs::rename(tmp, path)
+}
+
+/// `fsync` the directory holding `path`, so the rename itself survives a crash.
+///
+/// Best-effort and deliberately infallible: the bytes are already durable at
+/// this point, and on Windows a directory can't be opened as a file at all.
+/// Failing the whole write because the parent couldn't be synced would turn a
+/// weaker durability guarantee into a hard error.
+fn sync_parent_dir(path: &Path) {
+    #[cfg(unix)]
+    if let Some(parent) = path.parent() {
+        let parent = if parent.as_os_str().is_empty() {
+            Path::new(".")
+        } else {
+            parent
+        };
+        if let Ok(dir) = std::fs::File::open(parent) {
+            let _ = dir.sync_all();
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+/// The unix mode of an existing file, for round-tripping through
+/// [`atomic_write_sync_mode`]. `None` on Windows or when the file is gone.
+#[must_use]
+pub fn file_mode(path: &Path) -> Option<u32> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::metadata(path)
+            .ok()
+            .map(|m| m.permissions().mode() & 0o777)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
 }
 
 fn tmp_sibling(path: &Path) -> std::path::PathBuf {
@@ -108,5 +239,117 @@ mod tests {
         atomic_write_sync(&path, b"{\"k\":1}").unwrap();
         let got = std::fs::read(&path).unwrap();
         assert_eq!(got, b"{\"k\":1}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn mode_variant_pins_permissions_through_the_rename() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.yaml");
+        std::fs::write(&path, b"before").unwrap();
+
+        let mode = |p: &Path| std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+
+        // The plain variant renames a default-mode tempfile over the target, so
+        // the target's own mode is lost. This is the trap the mode variant
+        // exists to close — asserted so a future refactor of
+        // `atomic_write_sync` can't silently make the two behave alike.
+        //
+        // The probe mode is 0o700 rather than the realistic 0o600 on purpose.
+        // A tempfile's default is `0o666 & !umask`, which can never carry an
+        // execute bit — so this assertion holds under any umask. Probing with
+        // 0o600 would pass only because the ambient umask happens to be 022:
+        // under `umask 077` the default *is* 0o600, and the test would fail
+        // against entirely correct code.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700)).unwrap();
+        atomic_write_sync(&path, b"loosened").unwrap();
+        assert_ne!(mode(&path), 0o700);
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        atomic_write_sync_mode(&path, b"kept", Some(0o600)).unwrap();
+        assert_eq!(mode(&path), 0o600);
+        assert_eq!(std::fs::read(&path).unwrap(), b"kept");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_failed_write_leaves_no_tempfile_behind() {
+        // The tempfile holds the *whole* payload — for the kubeconfig, certs
+        // and bearer tokens — and lands beside the target in a directory that
+        // is 0755 on a stock install. An orphan is a credential leak that
+        // outlives the failure, so no error path may leave one.
+        //
+        // A directory as the target makes `rename` fail after the bytes are
+        // already written, which is the exact shape being guarded.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("adir");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        let err = atomic_write_sync_mode(&target, b"secret-bearer-token", Some(0o600))
+            .expect_err("rename onto a non-empty directory must fail");
+        assert!(
+            err.kind() != std::io::ErrorKind::NotFound,
+            "expected the rename to fail, not the open: {err}"
+        );
+
+        let strays: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            // `.fs.` is the distinctive marker `tmp_sibling` stamps in, so this
+            // can't be fooled by an unrelated `.tmp` the test didn't create.
+            .filter(|n| n.contains(".fs."))
+            .collect();
+        assert!(
+            strays.is_empty(),
+            "tempfile orphaned after failure: {strays:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_tempfile_is_never_observable_with_loose_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // Regression for the create-then-chmod ordering: `fs::write` published
+        // the payload at `0o666 & !umask` and only tightened it afterwards, so
+        // the credentials were world-readable for the length of the write and
+        // stayed that way if the chmod or rename then failed. Creating the file
+        // already-restricted closes both windows at once.
+        //
+        // Observed via the orphan a failed rename would have left, since the
+        // in-flight window itself isn't addressable from a test.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("adir");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("occupant"), b"x").unwrap();
+
+        // Same failure, but with cleanup suppressed by making the temp
+        // undeletable is not portable — instead assert the mode the helper
+        // opens with, directly.
+        let tmp = dir.path().join("probe.tmp");
+        write_tmp_then_rename(&tmp, &target, b"secret", Some(0o600))
+            .expect_err("rename onto a non-empty directory must fail");
+        let mode = std::fs::metadata(&tmp).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "payload was observable at {mode:o} before the rename"
+        );
+        assert_eq!(std::fs::read(&tmp).unwrap(), b"secret");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_mode_reads_back_what_was_set() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("f");
+        std::fs::write(&path, b"x").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+        assert_eq!(file_mode(&path), Some(0o640));
+        assert_eq!(file_mode(&dir.path().join("missing")), None);
     }
 }

--- a/crates/core/src/cloud_identity/aws.rs
+++ b/crates/core/src/cloud_identity/aws.rs
@@ -1,0 +1,379 @@
+//! AWS: profile discovery, the "wrong profile" diagnosis, and the `AWS_PROFILE`
+//! pin.
+//!
+//! An EKS context whose exec entry names no profile authenticates as whatever
+//! `AWS_PROFILE` / `AWS_DEFAULT_PROFILE` says, falling back to `default`. That
+//! is the same drift trap as [`super::gcloud`] — a profile exported for
+//! unrelated work in the app's environment silently changes who this cluster
+//! connects as.
+//!
+//! **Two things are deliberately different from gcloud:**
+//!
+//! * **No stale token cache.** `aws eks get-token` mints a presigned STS URL on
+//!   every call, so an unpinned context at least uses the profile that is
+//!   active *right now*. The note must not claim a cache, and there is no cache
+//!   for the pin to clear. (An expired SSO session is a different failure: the
+//!   plugin exits non-zero, which surfaces as `Error::ExecPluginFailed`, not a
+//!   403.)
+//! * **The pin writes `AWS_PROFILE` into the exec `env` block, not
+//!   `--profile`.** `aws-iam-authenticator` has no `--profile` flag but honours
+//!   the environment variable, and `aws eks get-token` honours both — so one
+//!   mechanism covers both binaries instead of forking per command.
+//!
+//! Filesystem-only: profiles come from the shared config/credentials INI files,
+//! never from `aws configure list-profiles`.
+//!
+//! Untested against a live EKS cluster — the parsing follows the documented
+//! file formats, and every classifier fails closed, so the worst case is a
+//! missing note rather than a wrong one.
+
+use std::path::PathBuf;
+
+use super::{
+    env_nonempty, exec_env, flag_value, home_dir, ini_sections, set_exec_env, Binding, ConnectHint,
+    Identities, PinOffer, Provider,
+};
+use crate::Result;
+
+/// Exec commands this provider owns.
+pub const OWNS_COMMANDS: &[&str] = &["aws", "aws-iam-authenticator"];
+
+/// Profile every AWS tool falls back to when nothing selects one.
+const DEFAULT_PROFILE: &str = "default";
+
+/// Shared config file: `AWS_CONFIG_FILE`, else `~/.aws/config`. Sections are
+/// `[profile foo]`, except the default profile which is bare `[default]`.
+#[must_use]
+pub fn config_file() -> Option<PathBuf> {
+    if let Some(explicit) = env_nonempty("AWS_CONFIG_FILE") {
+        return Some(PathBuf::from(explicit));
+    }
+    home_dir().map(|h| h.join(".aws").join("config"))
+}
+
+/// Shared credentials file: `AWS_SHARED_CREDENTIALS_FILE`, else
+/// `~/.aws/credentials`. Sections are bare profile names — no `profile ` prefix.
+#[must_use]
+pub fn credentials_file() -> Option<PathBuf> {
+    if let Some(explicit) = env_nonempty("AWS_SHARED_CREDENTIALS_FILE") {
+        return Some(PathBuf::from(explicit));
+    }
+    home_dir().map(|h| h.join(".aws").join("credentials"))
+}
+
+/// Profile names out of a `~/.aws/config`-shaped INI.
+///
+/// The prefix rule is asymmetric and easy to get wrong: `[profile dev]` means
+/// the profile `dev`, but the default profile is written bare as `[default]`,
+/// *not* `[profile default]`. Non-profile sections (`[sso-session x]`,
+/// `[services x]`) are skipped.
+#[must_use]
+pub fn profiles_from_config(ini: &str) -> Vec<String> {
+    ini_sections(ini)
+        .into_iter()
+        .filter_map(|s| {
+            if s == DEFAULT_PROFILE {
+                return Some(DEFAULT_PROFILE.to_owned());
+            }
+            let rest = s.strip_prefix("profile ")?.trim().to_owned();
+            (!rest.is_empty()).then_some(rest)
+        })
+        .collect()
+}
+
+/// Profile names out of a `~/.aws/credentials`-shaped INI, where every section
+/// is a bare profile name.
+#[must_use]
+pub fn profiles_from_credentials(ini: &str) -> Vec<String> {
+    ini_sections(ini)
+}
+
+/// Every configured profile plus the one an unpinned context uses right now.
+///
+/// The active profile is `AWS_PROFILE`, else `AWS_DEFAULT_PROFILE`, else
+/// `default` — reported only when a profile by that name actually exists, so we
+/// never claim an active profile the operator hasn't configured.
+#[must_use]
+pub fn probe() -> Identities {
+    let mut identities: Vec<String> = Vec::new();
+    if let Some(text) = config_file().and_then(|p| std::fs::read_to_string(p).ok()) {
+        identities.extend(profiles_from_config(&text));
+    }
+    if let Some(text) = credentials_file().and_then(|p| std::fs::read_to_string(p).ok()) {
+        identities.extend(profiles_from_credentials(&text));
+    }
+    identities.sort();
+    identities.dedup();
+
+    let named = env_nonempty("AWS_PROFILE")
+        .or_else(|| env_nonempty("AWS_DEFAULT_PROFILE"))
+        .unwrap_or_else(|| DEFAULT_PROFILE.to_owned());
+    let active = identities.contains(&named).then_some(named);
+
+    Identities { identities, active }
+}
+
+/// Classify an AWS-family exec entry. `None` when the command isn't ours.
+#[must_use]
+pub fn binding_for(basename: &str, args: &[String], env: &[(String, String)]) -> Option<Binding> {
+    if !OWNS_COMMANDS.contains(&basename) {
+        return None;
+    }
+    // `--profile` only exists on the `aws` CLI; `AWS_PROFILE` in the exec env
+    // pins either binary. Check both regardless — a `--profile` on
+    // aws-iam-authenticator would be inert, but treating it as unpinned would
+    // be a worse guess than treating it as intent.
+    // `AWS_DEFAULT_PROFILE` is checked too, and *first*: botocore resolves the
+    // profile from the ordered list `['AWS_DEFAULT_PROFILE', 'AWS_PROFILE']`,
+    // first match wins. Omitting it here would classify a context pinned via
+    // that variable as unpinned, then offer a pin that writes `AWS_PROFILE` —
+    // which the pre-existing `AWS_DEFAULT_PROFILE` would keep overriding. The
+    // file would change, the operator would reconnect, and nothing would.
+    let pinned = flag_value(args, "--profile")
+        .or_else(|| exec_env(env, "AWS_DEFAULT_PROFILE"))
+        .or_else(|| exec_env(env, "AWS_PROFILE"));
+    Some(match pinned {
+        Some(identity) => Binding::Pinned { identity },
+        None => Binding::FollowsActive,
+    })
+}
+
+/// Build the "unpinned AWS profile" note, or `None` when this isn't that
+/// problem. Callers have already established a 403 and an unpinned binding.
+///
+/// Gated on more than one profile: with a single profile there is nothing to
+/// drift between, and the 403 is a plain RBAC / access-entry gap.
+#[must_use]
+pub fn compose_hint(error: &str, profiles: &Identities) -> Option<ConnectHint> {
+    if profiles.identities.len() < 2 {
+        return None;
+    }
+
+    let authenticated_as = super::forbidden_user(error);
+    let active = profiles.active.clone();
+    let current = active
+        .clone()
+        .unwrap_or_else(|| format!("the {DEFAULT_PROFILE} profile"));
+    // Note the wording: no claim of a stale cache. `aws eks get-token` mints
+    // fresh every call, so whatever the apiserver saw *is* what this profile
+    // resolves to today — the surprise is which profile, not which token.
+    let seen = authenticated_as
+        .as_ref()
+        .map_or_else(String::new, |u| format!(" The apiserver saw {u}."));
+    let detail = format!(
+        "This context names no profile, so it authenticates as {current} — whatever \
+         AWS_PROFILE happens to be set to when the app launches, falling back to \
+         {DEFAULT_PROFILE}.{seen} With {} profiles configured, exporting a different one for \
+         unrelated work silently changes who this cluster connects as. Pin a profile below to \
+         give this context its own credentials.",
+        profiles.identities.len()
+    );
+
+    Some(ConnectHint {
+        provider: Provider::Aws,
+        title: "Unpinned AWS profile".to_owned(),
+        detail,
+        authenticated_as,
+        identities: profiles.identities.clone(),
+        active_identity: active,
+        pin: Some(PinOffer {
+            noun: "profile".to_owned(),
+            effects: vec![
+                "set AWS_PROFILE in this context's exec env block in your kubeconfig".to_owned(),
+                "keep a .ferrisscope-backup copy next to the kubeconfig it edits — if yours \
+                 is a symlink, that is the real file's directory, not the link's"
+                    .to_owned(),
+                "rewrite the file through a YAML parser, which drops comments and \
+                 expands any anchors/aliases — the backup holds the file as it was \
+                 immediately before this edit, so comments an earlier pin already \
+                 removed are not in it either"
+                    .to_owned(),
+            ],
+        }),
+    })
+}
+
+/// Write `AWS_PROFILE=<identity>` into an exec mapping's `env` block.
+///
+/// Env rather than `--profile` on purpose — see the module docs.
+///
+/// # Errors
+///
+/// Never — the signature matches the other providers' so the dispatcher can
+/// treat them uniformly.
+pub fn write_pin(exec: &mut serde_yaml::Mapping, identity: &str) -> Result<()> {
+    set_exec_env(exec, "AWS_PROFILE", identity);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_identity::tests::FORBIDDEN_403;
+
+    const EKS_403: &str = r#"ApiError: namespaces is forbidden: User "arn:aws:sts::111122223333:assumed-role/Dev/session" cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden"#;
+
+    #[test]
+    fn profiles_from_config_handles_the_asymmetric_default_section() {
+        let ini = "\
+[default]
+region = us-east-1
+
+[profile dev]
+region = us-west-2
+
+[profile  prod ]
+region = eu-west-1
+
+[sso-session corp]
+sso_region = us-east-1
+
+[services shared]
+";
+        // `[default]` is bare while every other profile carries the prefix;
+        // non-profile sections are skipped entirely.
+        assert_eq!(profiles_from_config(ini), vec!["default", "dev", "prod"]);
+    }
+
+    #[test]
+    fn profiles_from_credentials_uses_bare_sections() {
+        assert_eq!(
+            profiles_from_credentials("[default]\n[dev]\n"),
+            vec!["default", "dev"]
+        );
+    }
+
+    #[test]
+    fn binding_for_honours_aws_default_profile() {
+        // `probe` already treats AWS_DEFAULT_PROFILE as selecting the profile;
+        // the classifier has to agree. If it doesn't, a context pinned via that
+        // variable is reported as unpinned, and the pin we then offer writes
+        // AWS_PROFILE — which botocore resolves *second*, so the pre-existing
+        // AWS_DEFAULT_PROFILE keeps winning. The file changes and nothing else
+        // does, which is the worst possible outcome for a trust-building
+        // feature.
+        assert_eq!(
+            binding_for(
+                "aws",
+                &[],
+                &[("AWS_DEFAULT_PROFILE".to_owned(), "prod".to_owned())]
+            ),
+            Some(Binding::Pinned {
+                identity: "prod".to_owned()
+            })
+        );
+        // Resolution order matches botocore's: AWS_DEFAULT_PROFILE first.
+        assert_eq!(
+            binding_for(
+                "aws",
+                &[],
+                &[
+                    ("AWS_PROFILE".to_owned(), "second".to_owned()),
+                    ("AWS_DEFAULT_PROFILE".to_owned(), "first".to_owned()),
+                ]
+            ),
+            Some(Binding::Pinned {
+                identity: "first".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn binding_for_detects_both_pinning_forms() {
+        assert_eq!(
+            binding_for("aws", &["--profile=dev".to_owned()], &[]),
+            Some(Binding::Pinned {
+                identity: "dev".to_owned()
+            })
+        );
+        assert_eq!(
+            binding_for(
+                "aws",
+                &[
+                    "eks".to_owned(),
+                    "get-token".to_owned(),
+                    "--profile".to_owned(),
+                    "dev".to_owned()
+                ],
+                &[]
+            ),
+            Some(Binding::Pinned {
+                identity: "dev".to_owned()
+            })
+        );
+        // aws-iam-authenticator has no --profile flag, so the env is the pin.
+        assert_eq!(
+            binding_for(
+                "aws-iam-authenticator",
+                &["token".to_owned(), "-i".to_owned(), "prod".to_owned()],
+                &[("AWS_PROFILE".to_owned(), "dev".to_owned())]
+            ),
+            Some(Binding::Pinned {
+                identity: "dev".to_owned()
+            })
+        );
+        assert_eq!(
+            binding_for("aws", &["eks".to_owned(), "get-token".to_owned()], &[]),
+            Some(Binding::FollowsActive)
+        );
+        // An unrelated env var doesn't count as a pin.
+        assert_eq!(
+            binding_for(
+                "aws",
+                &[],
+                &[("AWS_REGION".to_owned(), "us-east-1".to_owned())]
+            ),
+            Some(Binding::FollowsActive)
+        );
+        assert_eq!(binding_for("gke-gcloud-auth-plugin", &[], &[]), None);
+    }
+
+    fn two_profiles() -> Identities {
+        Identities {
+            identities: vec!["default".to_owned(), "dev".to_owned()],
+            active: Some("dev".to_owned()),
+        }
+    }
+
+    #[test]
+    fn compose_hint_names_the_profile_and_never_claims_a_stale_cache() {
+        let hint = compose_hint(EKS_403, &two_profiles()).expect("hint expected");
+        assert_eq!(hint.provider, Provider::Aws);
+        assert_eq!(
+            hint.authenticated_as.as_deref(),
+            Some("arn:aws:sts::111122223333:assumed-role/Dev/session")
+        );
+        assert!(hint.detail.contains("dev"));
+        assert!(hint.detail.contains("AWS_PROFILE"));
+        // The gcloud-only failure mode must not leak into AWS wording: there is
+        // no shared token cache here, and nothing for a pin to clear.
+        assert!(!hint.detail.to_lowercase().contains("cache"));
+        assert!(!hint.detail.contains("stale"));
+        let pin = hint.pin.expect("aws can pin");
+        assert_eq!(pin.noun, "profile");
+        assert!(pin.effects.iter().any(|e| e.contains("AWS_PROFILE")));
+        assert!(!pin.effects.iter().any(|e| e.contains("cache")));
+    }
+
+    #[test]
+    fn compose_hint_tolerates_an_unparseable_identity_and_unknown_active() {
+        let unknown_active = Identities {
+            identities: vec!["default".to_owned(), "dev".to_owned()],
+            // AWS_PROFILE pointed at a profile that isn't configured, so we
+            // decline to name one rather than assert something false.
+            active: None,
+        };
+        let hint = compose_hint(FORBIDDEN_403, &unknown_active).expect("hint expected");
+        assert!(hint.detail.contains("the default profile"));
+        assert_eq!(hint.active_identity, None);
+    }
+
+    #[test]
+    fn compose_hint_is_silent_on_a_single_profile_machine() {
+        let single = Identities {
+            identities: vec!["default".to_owned()],
+            active: Some("default".to_owned()),
+        };
+        assert_eq!(compose_hint(EKS_403, &single), None);
+    }
+}

--- a/crates/core/src/cloud_identity/azure.rs
+++ b/crates/core/src/cloud_identity/azure.rs
@@ -1,0 +1,294 @@
+//! Azure: account discovery and the "wrong `az` account" diagnosis.
+//!
+//! **Detection only — there is no pin here, and that is not an oversight.**
+//!
+//! `kubelogin get-token --login azurecli` (what `az aks get-credentials
+//! --format azure && kubelogin convert-kubeconfig` writes) resolves its identity
+//! from `az`'s own state. kubelogin exposes `--tenant-id`, `--client-id` and
+//! `--server-id`, but **none of them selects an account** — the only way to
+//! change who it authenticates as is `az account set --subscription <x>`, which
+//! is a global mutation, not a kubeconfig edit. So this module offers the
+//! operator the command to run instead of a button that would quietly rewrite
+//! the wrong thing.
+//!
+//! The other `--login` modes (`spn`, `msi`, `workloadidentity`, `devicecode`,
+//! `interactive`) either carry their own credentials or prompt per-connect, so
+//! ambient-account drift doesn't apply. Those are classified as "not our
+//! problem" and produce no note at all.
+//!
+//! Unlike gcloud, kubelogin's token cache (`~/.kube/cache/kubelogin/*.json`) is
+//! keyed by tenant / client / server id, so it does **not** bleed one account's
+//! token into another context. No cache-clearing story here either.
+//!
+//! Untested against a live AKS cluster — the `azureProfile.json` parsing follows
+//! the documented shape, and the classifier fails closed, so the worst case is a
+//! missing note rather than a wrong one.
+
+use std::path::PathBuf;
+
+use super::{
+    env_nonempty, exec_env, flag_value, home_dir, Binding, ConnectHint, Identities, Provider,
+};
+
+/// Exec commands this provider owns.
+pub const OWNS_COMMANDS: &[&str] = &["kubelogin"];
+
+/// The only `--login` mode that inherits an ambient account, and therefore the
+/// only one that can drift under the operator.
+const AZURECLI_LOGIN: &str = "azurecli";
+
+/// `az`'s config directory: `AZURE_CONFIG_DIR`, else `~/.azure`.
+#[must_use]
+pub fn config_root() -> Option<PathBuf> {
+    if let Some(explicit) = env_nonempty("AZURE_CONFIG_DIR") {
+        return Some(PathBuf::from(explicit));
+    }
+    home_dir().map(|h| h.join(".azure"))
+}
+
+/// Signed-in accounts out of `azureProfile.json`.
+///
+/// Shape (trimmed):
+///
+/// ```json
+/// { "subscriptions": [
+///     { "name": "Prod", "isDefault": true, "user": { "name": "ops@example.net" } }
+/// ] }
+/// ```
+///
+/// One account signs in to many subscriptions, so the list is deduped by user
+/// name; the active account is the one on the default subscription. Anything
+/// that doesn't parse yields empty rather than an error — this only feeds a
+/// diagnostic.
+#[must_use]
+pub fn accounts_from_profile(json: &str) -> Identities {
+    // `az` writes this file with a UTF-8 BOM on some platforms, which
+    // serde_json rejects outright.
+    let json = json.trim_start_matches('\u{feff}');
+    let Ok(doc) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Identities::default();
+    };
+    let Some(subs) = doc.get("subscriptions").and_then(|s| s.as_array()) else {
+        return Identities::default();
+    };
+
+    let user_of = |s: &serde_json::Value| -> Option<String> {
+        let name = s.get("user")?.get("name")?.as_str()?.trim();
+        (!name.is_empty()).then(|| name.to_owned())
+    };
+
+    let mut identities: Vec<String> = subs.iter().filter_map(user_of).collect();
+    identities.sort();
+    identities.dedup();
+
+    let active = subs
+        .iter()
+        .find(|s| s.get("isDefault").and_then(serde_json::Value::as_bool) == Some(true))
+        .and_then(user_of);
+
+    Identities { identities, active }
+}
+
+/// [`accounts_from_profile`] against the real [`config_root`].
+#[must_use]
+pub fn probe() -> Option<Identities> {
+    let path = config_root()?.join("azureProfile.json");
+    let text = std::fs::read_to_string(path).ok()?;
+    Some(accounts_from_profile(&text))
+}
+
+/// Classify a kubelogin exec entry.
+///
+/// `None` both when the command isn't ours **and** when it is ours but runs a
+/// `--login` mode that carries its own credentials — neither can suffer ambient
+/// account drift, so neither should produce a note.
+#[must_use]
+pub fn binding_for(basename: &str, args: &[String], env: &[(String, String)]) -> Option<Binding> {
+    if !OWNS_COMMANDS.contains(&basename) {
+        return None;
+    }
+    // kubelogin takes its login mode from `AAD_LOGIN_METHOD` as well as
+    // `--login`/`-l`. An entry using the env form drifts under `az account set`
+    // exactly like the flag form, so ignoring it would just silently withhold
+    // the note.
+    let mode = flag_value(args, "--login")
+        .or_else(|| flag_value(args, "-l"))
+        .or_else(|| exec_env(env, "AAD_LOGIN_METHOD"))?;
+    // Only azurecli login follows `az account set`. Everything else is either
+    // self-contained (spn/msi/workloadidentity) or prompts per connect
+    // (devicecode/interactive).
+    (mode == AZURECLI_LOGIN).then_some(Binding::FollowsActive)
+}
+
+/// Build the "wrong Azure account" note, or `None` when this isn't that
+/// problem. Callers have already established a 403 and an azurecli binding.
+///
+/// Always returns `pin: None` — see the module docs. The remedy goes in the
+/// prose instead, as the exact command to run.
+#[must_use]
+pub fn compose_hint(error: &str, accounts: &Identities) -> Option<ConnectHint> {
+    if accounts.identities.len() < 2 {
+        return None;
+    }
+
+    let authenticated_as = super::forbidden_user(error);
+    let active = accounts.active.clone();
+    let current = active
+        .clone()
+        .unwrap_or_else(|| "your default subscription's account".to_owned());
+    let seen = authenticated_as
+        .as_ref()
+        .map_or_else(String::new, |u| format!(" The apiserver saw {u}."));
+    let detail = format!(
+        "This context uses kubelogin --login azurecli, so it authenticates as {current} — \
+         whichever account owns your default `az` subscription.{seen} With {} accounts signed \
+         in, `az account set` run for unrelated work silently changes who this cluster connects \
+         as. kubelogin has no per-context account flag, so switch with \
+         `az account set --subscription <id>` and reconnect.",
+        accounts.identities.len()
+    );
+
+    Some(ConnectHint {
+        provider: Provider::Azure,
+        title: "Ambient Azure account".to_owned(),
+        detail,
+        authenticated_as,
+        identities: accounts.identities.clone(),
+        active_identity: active,
+        // No per-context pin exists for kubelogin. Offering one would mean
+        // mutating global `az` state behind a button that looks like a
+        // kubeconfig edit.
+        pin: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PROFILE_JSON: &str = r#"{
+      "installationId": "x",
+      "subscriptions": [
+        { "id": "1", "name": "Prod", "isDefault": true,
+          "user": { "name": "ops@example.net", "type": "user" } },
+        { "id": "2", "name": "Dev", "isDefault": false,
+          "user": { "name": "ops@example.net", "type": "user" } },
+        { "id": "3", "name": "Partner", "isDefault": false,
+          "user": { "name": "guest@example.com", "type": "user" } }
+      ]
+    }"#;
+
+    #[test]
+    fn accounts_from_profile_dedupes_by_user_and_finds_the_default() {
+        let got = accounts_from_profile(PROFILE_JSON);
+        // Two subscriptions share one account — it must appear once.
+        assert_eq!(got.identities, vec!["guest@example.com", "ops@example.net"]);
+        assert_eq!(got.active.as_deref(), Some("ops@example.net"));
+    }
+
+    #[test]
+    fn accounts_from_profile_survives_a_bom_and_junk() {
+        let with_bom = format!("\u{feff}{PROFILE_JSON}");
+        assert_eq!(
+            accounts_from_profile(&with_bom).active.as_deref(),
+            Some("ops@example.net")
+        );
+        assert_eq!(accounts_from_profile("not json"), Identities::default());
+        assert_eq!(accounts_from_profile("{}"), Identities::default());
+        // Subscription with no user block is skipped, not fatal.
+        assert_eq!(
+            accounts_from_profile(r#"{"subscriptions":[{"id":"1"}]}"#),
+            Identities::default()
+        );
+    }
+
+    #[test]
+    fn binding_for_reads_the_login_mode_from_the_env_too() {
+        // kubelogin accepts AAD_LOGIN_METHOD as well as --login. An entry using
+        // the env form drifts under `az account set` exactly like the flag
+        // form, so ignoring it silently withholds the note from the operators
+        // who need it.
+        assert_eq!(
+            binding_for(
+                "kubelogin",
+                &["get-token".to_owned()],
+                &[("AAD_LOGIN_METHOD".to_owned(), "azurecli".to_owned())]
+            ),
+            Some(Binding::FollowsActive)
+        );
+        // The self-contained modes stay silent through the env form as well.
+        assert_eq!(
+            binding_for(
+                "kubelogin",
+                &["get-token".to_owned()],
+                &[("AAD_LOGIN_METHOD".to_owned(), "workloadidentity".to_owned())]
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn binding_for_claims_only_azurecli_login() {
+        assert_eq!(
+            binding_for(
+                "kubelogin",
+                &[
+                    "get-token".to_owned(),
+                    "--login".to_owned(),
+                    "azurecli".to_owned()
+                ],
+                &[]
+            ),
+            Some(Binding::FollowsActive)
+        );
+        assert_eq!(
+            binding_for("kubelogin", &["-l".to_owned(), "azurecli".to_owned()], &[]),
+            Some(Binding::FollowsActive)
+        );
+        // Self-contained / per-connect modes can't drift — no note.
+        for mode in [
+            "spn",
+            "msi",
+            "workloadidentity",
+            "devicecode",
+            "interactive",
+        ] {
+            assert_eq!(
+                binding_for("kubelogin", &["--login".to_owned(), mode.to_owned()], &[]),
+                None,
+                "{mode}"
+            );
+        }
+        // No --login at all: we can't tell, so we say nothing.
+        assert_eq!(
+            binding_for("kubelogin", &["get-token".to_owned()], &[]),
+            None
+        );
+        assert_eq!(binding_for("aws", &[], &[]), None);
+    }
+
+    #[test]
+    fn compose_hint_offers_the_az_command_instead_of_a_pin() {
+        let accounts = accounts_from_profile(PROFILE_JSON);
+        let hint = compose_hint(
+            r#"User "ops@example.net" cannot list resource "namespaces": Forbidden"#,
+            &accounts,
+        )
+        .expect("hint expected");
+        assert_eq!(hint.provider, Provider::Azure);
+        // The whole point: no button, and the remedy is spelled out instead.
+        assert!(hint.pin.is_none());
+        assert!(hint.detail.contains("az account set"));
+        assert!(hint.detail.contains("no per-context account flag"));
+        assert_eq!(hint.active_identity.as_deref(), Some("ops@example.net"));
+    }
+
+    #[test]
+    fn compose_hint_is_silent_on_a_single_account_machine() {
+        let single = Identities {
+            identities: vec!["ops@example.net".to_owned()],
+            active: Some("ops@example.net".to_owned()),
+        };
+        assert_eq!(compose_hint("403 Forbidden", &single), None);
+    }
+}

--- a/crates/core/src/cloud_identity/gcloud.rs
+++ b/crates/core/src/cloud_identity/gcloud.rs
@@ -1,0 +1,513 @@
+//! Google Cloud: account discovery, the "wrong gcloud account" diagnosis, and
+//! the `--account` pin.
+//!
+//! A kubeconfig context whose exec entry is `gke-gcloud-auth-plugin` **without**
+//! `--account=<x>` authenticates as whatever `gcloud config set account` last
+//! selected. On top of that, the plugin keeps a single global token cache at
+//! `~/.kube/gke_gcloud_auth_plugin_cache`:
+//!
+//! ```json
+//! { "current_context": "...", "access_token": "...", "token_expiry": "...", "extra_args": "" }
+//! ```
+//!
+//! It is keyed only on `extra_args`, not on the identity the token was minted
+//! for. So a token issued while account A was active keeps being served to every
+//! *unpinned* context after the operator switches to account B, until it
+//! expires. **This staleness is unique to gcloud** — AWS mints fresh on every
+//! call, and kubelogin's cache is keyed by tenant/client/server. Only this
+//! module's wording claims a stale cache, and only this module clears one.
+//!
+//! Nothing in this app caches those credentials: [`crate::cluster::Cluster::connect`]
+//! rebuilds `Config` on every reconnect, so the exec plugin is re-run each time.
+//! The fix is therefore not to change the auth path but to *explain* what
+//! happened and let the operator pin the account.
+//!
+//! Filesystem-only — no subprocess. Spawning `gcloud` would be self-defeating:
+//! "the binary isn't on the PATH the app sees" is the exact class of bug the
+//! diagnostics surfaces exist to explain.
+
+use std::path::{Path, PathBuf};
+
+use super::{
+    env_nonempty, exec_args, exec_env, flag_value, home_dir, ini_value, set_exec_args, Binding,
+    ConnectHint, Identities, PinOffer, Provider,
+};
+use crate::Result;
+
+/// Exec commands this provider owns.
+pub const OWNS_COMMANDS: &[&str] = &["gke-gcloud-auth-plugin", "gcloud"];
+
+/// Directory under the gcloud config root holding one directory per account
+/// that has credentials on this machine.
+const LEGACY_CREDENTIALS_DIR: &str = "legacy_credentials";
+
+/// File under the gcloud config root naming the active configuration. Written
+/// without a trailing newline by gcloud, but trimmed defensively.
+const ACTIVE_CONFIG_FILE: &str = "active_config";
+
+/// Directory holding one INI file per configuration, named `config_<name>`.
+const CONFIGURATIONS_DIR: &str = "configurations";
+
+/// Configuration gcloud falls back to when [`ACTIVE_CONFIG_FILE`] is absent.
+const DEFAULT_CONFIG_NAME: &str = "default";
+
+/// The `gke-gcloud-auth-plugin` global token cache. Shared by every tool on the
+/// machine (kubectl included) and regenerated on the next plugin run, which is
+/// what makes deleting it a safe recovery step.
+const PLUGIN_CACHE_FILE: &str = "gke_gcloud_auth_plugin_cache";
+
+/// gcloud's config directory: `CLOUDSDK_CONFIG` when set, else the per-platform
+/// default. `None` when neither the override nor a home directory is resolvable.
+#[must_use]
+pub fn config_root() -> Option<PathBuf> {
+    if let Some(explicit) = env_nonempty("CLOUDSDK_CONFIG") {
+        return Some(PathBuf::from(explicit));
+    }
+    #[cfg(windows)]
+    {
+        // gcloud on Windows uses %APPDATA%\gcloud, not the unix-style dotdir.
+        std::env::var_os("APPDATA").map(|a| PathBuf::from(a).join("gcloud"))
+    }
+    #[cfg(not(windows))]
+    {
+        home_dir().map(|h| h.join(".config").join("gcloud"))
+    }
+}
+
+/// Read accounts and the active account out of an explicit gcloud config root.
+/// Purely filesystem-driven — the env overrides live in [`probe`] so this stays
+/// testable against a tempdir.
+///
+/// Every read is best-effort: a missing or unreadable file yields an empty list
+/// / `None` rather than an error, because this only ever feeds a diagnostic.
+#[must_use]
+pub fn read_accounts(root: &Path) -> Identities {
+    let mut identities: Vec<String> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(root.join(LEGACY_CREDENTIALS_DIR)) {
+        for entry in entries.flatten() {
+            // Account directories only; gcloud writes nothing else here, but a
+            // stray file shouldn't show up as an "account".
+            if !entry.file_type().is_ok_and(|t| t.is_dir()) {
+                continue;
+            }
+            if let Some(name) = entry.file_name().to_str() {
+                identities.push(name.to_owned());
+            }
+        }
+    }
+    identities.sort();
+    identities.dedup();
+
+    let config_name = std::fs::read_to_string(root.join(ACTIVE_CONFIG_FILE))
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_CONFIG_NAME.to_owned());
+    let active = account_in_configuration(root, &config_name);
+
+    Identities { identities, active }
+}
+
+/// `[core] account` of one named configuration.
+fn account_in_configuration(root: &Path, config_name: &str) -> Option<String> {
+    std::fs::read_to_string(
+        root.join(CONFIGURATIONS_DIR)
+            .join(format!("config_{config_name}")),
+    )
+    .ok()
+    .and_then(|ini| ini_value(&ini, "core", "account"))
+}
+
+/// [`read_accounts`] against the real [`config_root`], with the environment
+/// overrides gcloud itself honours layered on top. `None` when there is no
+/// resolvable config root at all.
+#[must_use]
+pub fn probe() -> Option<Identities> {
+    let root = config_root()?;
+    let mut out = read_accounts(&root);
+    // `CLOUDSDK_ACTIVE_CONFIG_NAME` wins over the `active_config` file, so
+    // re-resolve the active account from the named configuration.
+    if let Some(name) = env_nonempty("CLOUDSDK_ACTIVE_CONFIG_NAME") {
+        out.active = account_in_configuration(&root, &name);
+    }
+    // `CLOUDSDK_CORE_ACCOUNT` wins over everything.
+    if let Some(account) = env_nonempty("CLOUDSDK_CORE_ACCOUNT") {
+        out.active = Some(account);
+    }
+    Some(out)
+}
+
+/// Classify a gcloud-family exec entry. `None` when the command isn't ours.
+#[must_use]
+pub fn binding_for(basename: &str, args: &[String], env: &[(String, String)]) -> Option<Binding> {
+    if !OWNS_COMMANDS.contains(&basename) {
+        return None;
+    }
+    // The exec `env` block is applied to the plugin process, so a
+    // CLOUDSDK_CORE_ACCOUNT there pins the identity just as firmly as the flag.
+    let pinned = flag_value(args, "--account").or_else(|| exec_env(env, "CLOUDSDK_CORE_ACCOUNT"));
+    Some(match pinned {
+        Some(identity) => Binding::Pinned { identity },
+        None => Binding::FollowsActive,
+    })
+}
+
+/// Build the "wrong Google account" note, or `None` when this isn't that
+/// problem. Callers have already established a 403 and an unpinned binding.
+///
+/// The remaining gate is "more than one account", because a single-account
+/// machine can still hit a 403 — it's a plain RBAC gap there, and this note
+/// would be noise.
+#[must_use]
+pub fn compose_hint(error: &str, accounts: &Identities) -> Option<ConnectHint> {
+    if accounts.identities.len() < 2 {
+        return None;
+    }
+
+    let authenticated_as = super::forbidden_user(error);
+    let active = accounts.active.clone();
+    // The strongest signal we can offer: the apiserver named an identity that
+    // is *not* the one gcloud would hand out today. That mismatch can only come
+    // from the plugin's global token cache, so say so and name the file.
+    let stale = match (authenticated_as.as_deref(), active.as_deref()) {
+        (Some(user), Some(current)) => user != current,
+        _ => false,
+    };
+
+    let detail = if stale {
+        let user = authenticated_as.clone().unwrap_or_default();
+        let current = active.clone().unwrap_or_default();
+        format!(
+            "This context has no --account, so it authenticates as your active gcloud account. \
+             The apiserver saw {user}, but your active account is now {current} — a stale token \
+             from ~/.kube/gke_gcloud_auth_plugin_cache (one global cache shared by every unpinned \
+             context). Pin an account below to give this context its own credentials."
+        )
+    } else {
+        let current = active
+            .clone()
+            .unwrap_or_else(|| "your active gcloud account".to_owned());
+        format!(
+            "This context has no --account, so it authenticates as {current} and shares one token \
+             cache with every other unpinned context. With {} accounts on this machine, switching \
+             accounts elsewhere silently changes who this cluster connects as. Pin an account \
+             below to give this context its own credentials.",
+            accounts.identities.len()
+        )
+    };
+
+    Some(ConnectHint {
+        provider: Provider::Gcloud,
+        title: "Unpinned Google account".to_owned(),
+        detail,
+        authenticated_as,
+        identities: accounts.identities.clone(),
+        active_identity: active,
+        pin: Some(PinOffer {
+            noun: "account".to_owned(),
+            effects: vec![
+                "add --account to this context's exec entry in your kubeconfig".to_owned(),
+                "keep a .ferrisscope-backup copy next to the kubeconfig it edits — if yours \
+                 is a symlink, that is the real file's directory, not the link's"
+                    .to_owned(),
+                "rewrite the file through a YAML parser, which drops comments and \
+                 expands any anchors/aliases — the backup holds the file as it was \
+                 immediately before this edit, so comments an earlier pin already \
+                 removed are not in it either"
+                    .to_owned(),
+                "delete ~/.kube/gke_gcloud_auth_plugin_cache, which every gcloud-authenticated \
+                 tool regenerates on its next run"
+                    .to_owned(),
+            ],
+        }),
+    })
+}
+
+/// Write `--account=<identity>` into an exec mapping, replacing any prior form.
+///
+/// # Errors
+///
+/// Never — the signature matches the other providers' so the dispatcher can
+/// treat them uniformly.
+pub fn write_pin(exec: &mut serde_yaml::Mapping, identity: &str) -> Result<()> {
+    let args = set_account_arg(&exec_args(exec), identity);
+    set_exec_args(exec, args);
+    Ok(())
+}
+
+/// Replace or append `--account=<account>`, dropping any prior form.
+fn set_account_arg(args: &[String], account: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(args.len() + 1);
+    let mut skip_next = false;
+    for arg in args {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if arg.starts_with("--account=") {
+            continue;
+        }
+        if arg == "--account" {
+            // Drop the flag and its detached value.
+            skip_next = true;
+            continue;
+        }
+        out.push(arg.clone());
+    }
+    out.push(format!("--account={account}"));
+    out
+}
+
+/// Delete the `gke-gcloud-auth-plugin` global token cache.
+///
+/// The file is a cache: every tool that needs it (kubectl included) re-mints on
+/// the next plugin run, so removing it costs one extra token exchange and
+/// nothing else. Removing it is what actually clears a token minted under the
+/// wrong identity. A missing file is success.
+///
+/// # Errors
+///
+/// Propagates any I/O error other than `NotFound`.
+pub fn clear_plugin_cache() -> std::io::Result<()> {
+    let Some(path) = plugin_cache_path() else {
+        return Ok(());
+    };
+    clear_plugin_cache_at(&path)
+}
+
+/// [`clear_plugin_cache`] against an explicit path, so callers (and tests) can
+/// aim it somewhere other than the real `$HOME`.
+///
+/// # Errors
+///
+/// Propagates any I/O error other than `NotFound`.
+pub fn clear_plugin_cache_at(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// `~/.kube/gke_gcloud_auth_plugin_cache`. Deliberately *not* derived from
+/// `KUBECONFIG` — the plugin always writes it next to the default kube home,
+/// regardless of which kubeconfig is in play.
+#[must_use]
+pub fn plugin_cache_path() -> Option<PathBuf> {
+    home_dir().map(|h| h.join(".kube").join(PLUGIN_CACHE_FILE))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_identity::tests::{
+        kubeconfig_fixture, read_args, FORBIDDEN_403, KUBECONFIG_YAML,
+    };
+    use crate::cloud_identity::{backup_path, tests::pin};
+
+    fn write(path: &Path, body: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("mkdir");
+        }
+        std::fs::write(path, body).expect("write");
+    }
+
+    fn fake_root(dir: &Path, active_config: &str, accounts: &[&str]) {
+        // No trailing newline — that's how gcloud writes it.
+        std::fs::write(dir.join(ACTIVE_CONFIG_FILE), active_config).expect("active_config");
+        for a in accounts {
+            std::fs::create_dir_all(dir.join(LEGACY_CREDENTIALS_DIR).join(a)).expect("account dir");
+        }
+    }
+
+    #[test]
+    fn read_accounts_collects_accounts_and_active() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fake_root(tmp.path(), "work", &["ops@example.net", "dev@example.com"]);
+        write(
+            &tmp.path().join(CONFIGURATIONS_DIR).join("config_work"),
+            "[core]\naccount = dev@example.com\nproject = infra-1\n",
+        );
+
+        let got = read_accounts(tmp.path());
+        // Sorted, so the assertion doesn't depend on readdir order.
+        assert_eq!(got.identities, vec!["dev@example.com", "ops@example.net"]);
+        assert_eq!(got.active.as_deref(), Some("dev@example.com"));
+    }
+
+    #[test]
+    fn read_accounts_falls_back_to_default_configuration() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // No active_config file at all → gcloud uses `default`.
+        std::fs::create_dir_all(
+            tmp.path()
+                .join(LEGACY_CREDENTIALS_DIR)
+                .join("a@example.com"),
+        )
+        .expect("account dir");
+        write(
+            &tmp.path().join(CONFIGURATIONS_DIR).join("config_default"),
+            "[core]\naccount = a@example.com\n",
+        );
+
+        assert_eq!(
+            read_accounts(tmp.path()).active.as_deref(),
+            Some("a@example.com")
+        );
+    }
+
+    #[test]
+    fn read_accounts_tolerates_a_missing_root() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            read_accounts(&tmp.path().join("nope")),
+            Identities::default()
+        );
+    }
+
+    #[test]
+    fn read_accounts_ignores_stray_files_in_legacy_credentials() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        fake_root(tmp.path(), "default", &["a@example.com"]);
+        write(
+            &tmp.path().join(LEGACY_CREDENTIALS_DIR).join("README"),
+            "not an account",
+        );
+        assert_eq!(read_accounts(tmp.path()).identities, vec!["a@example.com"]);
+    }
+
+    #[test]
+    fn binding_for_detects_every_pinning_form() {
+        assert_eq!(
+            binding_for(
+                "gke-gcloud-auth-plugin",
+                &["--account=a@example.com".to_owned()],
+                &[]
+            ),
+            Some(Binding::Pinned {
+                identity: "a@example.com".to_owned()
+            })
+        );
+        assert_eq!(
+            binding_for(
+                "gke-gcloud-auth-plugin",
+                &["--account".to_owned(), "a@example.com".to_owned()],
+                &[]
+            ),
+            Some(Binding::Pinned {
+                identity: "a@example.com".to_owned()
+            })
+        );
+        assert_eq!(
+            binding_for(
+                "gcloud",
+                &[],
+                &[(
+                    "CLOUDSDK_CORE_ACCOUNT".to_owned(),
+                    "a@example.com".to_owned()
+                )]
+            ),
+            Some(Binding::Pinned {
+                identity: "a@example.com".to_owned()
+            })
+        );
+        assert_eq!(
+            binding_for("gke-gcloud-auth-plugin", &[], &[]),
+            Some(Binding::FollowsActive)
+        );
+        // A dangling `--account` with no value is not a pin.
+        assert_eq!(
+            binding_for("gke-gcloud-auth-plugin", &["--account".to_owned()], &[]),
+            Some(Binding::FollowsActive)
+        );
+        assert_eq!(binding_for("aws-iam-authenticator", &[], &[]), None);
+    }
+
+    fn two_accounts() -> Identities {
+        Identities {
+            identities: vec!["ops@example.net".to_owned(), "dev@example.com".to_owned()],
+            active: Some("dev@example.com".to_owned()),
+        }
+    }
+
+    #[test]
+    fn compose_hint_flags_the_stale_cache_mismatch() {
+        let hint = compose_hint(FORBIDDEN_403, &two_accounts()).expect("hint expected");
+        assert_eq!(hint.provider, Provider::Gcloud);
+        assert_eq!(hint.authenticated_as.as_deref(), Some("ops@example.net"));
+        assert_eq!(hint.active_identity.as_deref(), Some("dev@example.com"));
+        // Names both identities and the cache file, so the operator can act
+        // without reading the source.
+        assert!(hint.detail.contains("ops@example.net"));
+        assert!(hint.detail.contains("dev@example.com"));
+        assert!(hint.detail.contains("gke_gcloud_auth_plugin_cache"));
+        let pin = hint.pin.expect("gcloud can pin");
+        assert_eq!(pin.noun, "account");
+        // The cache deletion is disclosed up front, not buried.
+        assert!(pin
+            .effects
+            .iter()
+            .any(|e| e.contains("gke_gcloud_auth_plugin_cache")));
+    }
+
+    #[test]
+    fn compose_hint_still_fires_without_a_parseable_identity() {
+        let hint = compose_hint("403 Forbidden", &two_accounts()).expect("hint expected");
+        assert_eq!(hint.authenticated_as, None);
+        assert!(hint.detail.contains("dev@example.com"));
+    }
+
+    #[test]
+    fn compose_hint_is_silent_on_a_single_account_machine() {
+        // A 403 here is a plain RBAC gap, not an identity mixup.
+        let single = Identities {
+            identities: vec!["dev@example.com".to_owned()],
+            active: Some("dev@example.com".to_owned()),
+        };
+        assert_eq!(compose_hint(FORBIDDEN_403, &single), None);
+    }
+
+    #[test]
+    fn set_account_arg_replaces_every_prior_form() {
+        assert_eq!(set_account_arg(&[], "a@b.io"), vec!["--account=a@b.io"]);
+        assert_eq!(
+            set_account_arg(&["--account=old@b.io".to_owned()], "a@b.io"),
+            vec!["--account=a@b.io"]
+        );
+        assert_eq!(
+            set_account_arg(&["--account".to_owned(), "old@b.io".to_owned()], "a@b.io"),
+            vec!["--account=a@b.io"]
+        );
+        // Unrelated args survive, in order.
+        assert_eq!(
+            set_account_arg(
+                &[
+                    "--verbosity=debug".to_owned(),
+                    "--account=old@b.io".to_owned(),
+                    "--quiet".to_owned()
+                ],
+                "a@b.io"
+            ),
+            vec!["--verbosity=debug", "--quiet", "--account=a@b.io"]
+        );
+    }
+
+    #[test]
+    fn pin_writes_the_account_flag_and_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+
+        pin(&path, "gke", "a@example.com").expect("pin");
+        assert_eq!(
+            read_args(&path, "gke-user"),
+            vec!["--account=a@example.com"]
+        );
+
+        pin(&path, "gke", "b@example.com").expect("re-pin");
+        assert_eq!(
+            read_args(&path, "gke-user"),
+            vec!["--account=b@example.com"]
+        );
+        assert!(backup_path(&path).exists());
+    }
+}

--- a/crates/core/src/cloud_identity/mod.rs
+++ b/crates/core/src/cloud_identity/mod.rs
@@ -1,0 +1,1454 @@
+//! "Which cloud identity is this context actually using?" — detection, an
+//! actionable note for RBAC 403s, and (where the provider allows it) a pin.
+//!
+//! Every managed-Kubernetes provider has the same trap: the kubeconfig exec
+//! entry can either **pin** an identity or **inherit** whichever one the cloud
+//! CLI last selected. Inherited identities silently change under the operator —
+//! they run one `gcloud config set account` / `export AWS_PROFILE` /
+//! `az account set` for unrelated work, and the next connect authenticates as
+//! somebody else. The apiserver's reply is a bare RBAC wall that names an
+//! identity but explains nothing:
+//!
+//! ```text
+//! namespaces is forbidden: User "ops@example.net" cannot list resource "namespaces"
+//! ```
+//!
+//! The providers are **not** symmetric, and this module doesn't pretend they
+//! are — see each submodule's docs:
+//!
+//! | | pins with | inherits from | shared token cache |
+//! |---|---|---|---|
+//! | [`gcloud`] | `--account` arg | `gcloud config set account` | one global file, **not** keyed by identity |
+//! | [`aws`] | `AWS_PROFILE` exec env | `AWS_PROFILE` / `default` profile | none — every call mints fresh |
+//! | [`azure`] | *nothing* | `az account set` | keyed by tenant/client/server, so it doesn't bleed |
+//!
+//! Only gcloud has the cache-staleness failure mode, only gcloud and AWS can be
+//! pinned per-context, and Azure gets detection only. Nothing here is
+//! speculative about the others' mechanics: where a provider has no equivalent,
+//! this module says so rather than inventing one.
+//!
+//! **Fail closed.** Every classifier returns `None` when it can't place a
+//! context confidently, and [`hint_for_context`] emits nothing on `None`. A
+//! missed note is invisible; a wrong one sends the operator chasing an identity
+//! problem they don't have.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::{Error, Result};
+
+pub mod aws;
+pub mod azure;
+pub mod gcloud;
+
+/// Suffix for the backup taken before each pin edit of a kubeconfig. Refreshed
+/// on every edit — see the rationale in [`edit_exec`].
+const BACKUP_SUFFIX: &str = ".ferrisscope-backup";
+
+/// Which cloud CLI's identity model a context is on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provider {
+    Gcloud,
+    Aws,
+    Azure,
+}
+
+/// How a context's exec entry decides which cloud identity to authenticate as.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Binding {
+    /// The exec entry names an identity, so it can't drift.
+    Pinned { identity: String },
+    /// Nothing is named: this context inherits whatever the cloud CLI has
+    /// selected right now, and that changes under it.
+    FollowsActive,
+}
+
+/// What a provider can offer to write, when the operator asks to pin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PinOffer {
+    /// What the identity is called for this provider — "account", "profile".
+    /// Drives the button label so the UI doesn't hardcode per-provider wording.
+    pub noun: String,
+    /// Everything the pin will do, one complete phrase per effect, rendered
+    /// verbatim in the confirm step. Kept free of the chosen identity so the
+    /// frontend doesn't have to interpolate into backend prose.
+    pub effects: Vec<String>,
+}
+
+/// An actionable note to render alongside a failed connect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConnectHint {
+    pub provider: Provider,
+    /// Short headline for the note.
+    pub title: String,
+    /// One or two sentences explaining what happened and what to do.
+    pub detail: String,
+    /// Identity the apiserver reported, when the 403 carried one.
+    pub authenticated_as: Option<String>,
+    /// Identities configured on this machine — the choices offered by the pin.
+    pub identities: Vec<String>,
+    /// The identity an unpinned context currently authenticates as.
+    pub active_identity: Option<String>,
+    /// `None` when the provider has no per-context pin at all (Azure): the note
+    /// then explains the CLI command to run instead.
+    pub pin: Option<PinOffer>,
+}
+
+/// Pull the identity out of an apiserver RBAC denial (`User "x" cannot …`).
+/// Longest plausible identity: an AWS profile name, a Google account, an Azure
+/// UPN, or an assumed-role ARN. Generous by an order of magnitude, and shared
+/// by [`validate_identity`] (what we're willing to *write*) and
+/// [`forbidden_user`] (what we're willing to *believe* from an apiserver).
+const MAX_LEN: usize = 256;
+
+/// `None` when the message carries no such clause.
+///
+/// Provider-agnostic on purpose — GKE reports an email, EKS an IAM/STS ARN, AKS
+/// an object id, but all three arrive in the same `User "…"` clause.
+#[must_use]
+pub fn forbidden_user(message: &str) -> Option<String> {
+    // The message reaches us both raw and inside a Rust `Debug` rendering of
+    // `Status`, where the quotes are backslash-escaped. Accept either.
+    let marker = "User ";
+    let mut rest = message;
+    while let Some(idx) = rest.find(marker) {
+        let after = &rest[idx + marker.len()..];
+        let after = after.strip_prefix('\\').unwrap_or(after);
+        // `find` returning None means an unterminated quote — keep scanning for
+        // a later, well-formed clause rather than bailing out of the whole walk.
+        if let Some(inner) = after.strip_prefix('"') {
+            if let Some(end) = inner.find(['"', '\\']) {
+                let user = &inner[..end];
+                // Bounded because the apiserver writes this. The message is
+                // whatever the cluster chose to return, and this string gets
+                // rendered in the note that sits directly above a button which
+                // rewrites the operator's kubeconfig. An unbounded clause is a
+                // multi-megabyte allocation cloned through the hint, over IPC,
+                // and into the DOM; control characters would let it forge line
+                // breaks in that prose. Same reflex as `redact_and_truncate`
+                // in `cluster.rs` for exec-plugin stderr.
+                if !user.is_empty() && user.len() <= MAX_LEN && !user.chars().any(char::is_control)
+                {
+                    return Some(user.to_owned());
+                }
+            }
+        }
+        rest = &rest[idx + marker.len()..];
+    }
+    None
+}
+
+/// Does this error string look like a genuine RBAC 403?
+///
+/// Kubernetes also embeds `Forbidden:` *inside* HTTP 422 validation messages to
+/// mean "this field can't be changed", so the 422 shapes are excluded first —
+/// the same ordering guard the frontend's `classifyDetailError` applies.
+#[must_use]
+pub fn is_forbidden(message: &str) -> bool {
+    let m = message.to_ascii_lowercase();
+    // The 422 test needs the same word boundaries as the 403 test below, and
+    // for a sharper reason: a 403 message is *full* of long digit runs that can
+    // contain "422" by chance — a 12-digit AWS account id in an assumed-role
+    // ARN, a 21-digit GCP service-account id, a resourceVersion. A bare
+    // `contains("422")` on any of those misfiles a real RBAC denial as a
+    // validation error, which silently disables this whole feature for that
+    // operator, permanently, and only for them.
+    if m.contains("is invalid")
+        || contains_word(&m, "422")
+        || m.contains("may not change")
+        || m.contains("immutable")
+    {
+        return false;
+    }
+    // Word boundaries, not bare substrings: `contains("403")` matches the port
+    // in "connection refused (127.0.0.1:8403)". Kept in step with the
+    // frontend's `isPermanentConnectFailure`, which gates auto-reconnect on the
+    // same question.
+    contains_word(&m, "forbidden") || contains_word(&m, "403")
+}
+
+/// `haystack` contains `needle` bounded by non-alphanumeric characters on both
+/// sides. Hand-rolled so `core` doesn't take a regex dependency for two calls.
+fn contains_word(haystack: &str, needle: &str) -> bool {
+    // An empty needle matches at every position and would never advance `from`.
+    if needle.is_empty() {
+        return false;
+    }
+    let mut from = 0;
+    while let Some(rel) = haystack[from..].find(needle) {
+        let start = from + rel;
+        let end = start + needle.len();
+        // Boundaries are tested per `char`, not per byte: a byte-wise
+        // `is_ascii_alphanumeric` check reads any non-ASCII neighbour as a
+        // boundary, so "фффforbidden" and "日本語403日本語" would both count as
+        // whole-word hits. Apiserver messages are ASCII today, so this can't
+        // misfire in practice — but a boundary test that only understands ASCII
+        // is the kind of thing that silently starts lying the moment an error
+        // string carries a localized prefix.
+        let before_ok = haystack[..start]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric());
+        let after_ok = haystack[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !c.is_alphanumeric());
+        if before_ok && after_ok {
+            return true;
+        }
+        // Resume past this occurrence. `end` is a char boundary because the
+        // match started on one and `needle` is whole; `start + 1` would not be
+        // for a multi-byte needle.
+        from = end;
+    }
+    false
+}
+
+/// The basename of an exec command, minus any Windows `.exe`. Provider
+/// detection keys on this so an absolute path
+/// (`/opt/google-cloud-sdk/bin/gke-gcloud-auth-plugin`) still resolves.
+#[must_use]
+pub fn command_basename(command: &str) -> &str {
+    let base = command.rsplit(['/', '\\']).next().unwrap_or(command);
+    base.strip_suffix(".exe").unwrap_or(base)
+}
+
+/// Value of `--flag=x` or `--flag x` in an arg list, whichever form is used.
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    let eq = format!("{flag}=");
+    let mut it = args.iter();
+    while let Some(arg) = it.next() {
+        if let Some(value) = arg.strip_prefix(eq.as_str()) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_owned());
+            }
+        } else if arg == flag {
+            let value = it.next()?.trim();
+            if !value.is_empty() {
+                return Some(value.to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Value of an exec-block env var, ignoring blank values.
+fn exec_env(env: &[(String, String)], key: &str) -> Option<String> {
+    env.iter()
+        .find(|(k, v)| k == key && !v.trim().is_empty())
+        .map(|(_, v)| v.trim().to_owned())
+}
+
+/// Classify a context against every provider we know, in turn.
+///
+/// `None` when no provider claims the command, or when the one that does can't
+/// place this particular invocation (an unusual `kubelogin --login` mode, say).
+/// Both cases mean "say nothing".
+#[must_use]
+pub fn classify(
+    command: &str,
+    args: &[String],
+    env: &[(String, String)],
+) -> Option<(Provider, Binding)> {
+    let base = command_basename(command);
+    gcloud::binding_for(base, args, env)
+        .map(|b| (Provider::Gcloud, b))
+        .or_else(|| aws::binding_for(base, args, env).map(|b| (Provider::Aws, b)))
+        .or_else(|| azure::binding_for(base, args, env).map(|b| (Provider::Azure, b)))
+}
+
+/// Diagnose a failed connect for one context: read its exec entry off disk,
+/// classify the identity binding, probe the local CLI config, and compose the
+/// note — or `None` when this isn't an identity problem.
+///
+/// Runs only on a connect failure, so the disk reads never touch the happy path.
+///
+/// # Errors
+///
+/// Propagates kubeconfig read/parse failures. A context with no exec plugin, an
+/// unrecognised provider, or no resolvable CLI config is `Ok(None)` — not an
+/// error.
+pub fn hint_for_context(
+    context_name: &str,
+    source_path: Option<&Path>,
+    error: &str,
+) -> Result<Option<ConnectHint>> {
+    hint_for_context_with(
+        context_name,
+        source_path,
+        error,
+        &|provider| match provider {
+            Provider::Gcloud => gcloud::probe().unwrap_or_default(),
+            Provider::Aws => aws::probe(),
+            Provider::Azure => azure::probe().unwrap_or_default(),
+        },
+    )
+}
+
+/// [`hint_for_context`] with the CLI-config probe injected.
+///
+/// Exists so the gates above can be tested without reading whatever gcloud/AWS
+/// config the developer running the suite happens to have. The probe is only
+/// consulted *after* every refusal, which is the property most worth pinning:
+/// a test that had to stub a real config directory to reach those branches
+/// wouldn't be testing them.
+fn hint_for_context_with(
+    context_name: &str,
+    source_path: Option<&Path>,
+    error: &str,
+    probe: &dyn Fn(Provider) -> Identities,
+) -> Result<Option<ConnectHint>> {
+    // Cheapest gate first: most connect failures aren't 403s at all, and
+    // bailing here avoids reading the kubeconfig a second time.
+    if !is_forbidden(error) {
+        return Ok(None);
+    }
+    let Some(spec) = crate::cluster::exec_spec_for_context(context_name, source_path)? else {
+        return Ok(None);
+    };
+    let Some((provider, binding)) = classify(&spec.command, &spec.args, &spec.env) else {
+        return Ok(None);
+    };
+    // A pinned context can't be suffering identity drift, whatever the
+    // provider — the 403 is a plain RBAC gap.
+    if binding != Binding::FollowsActive {
+        return Ok(None);
+    }
+    let identities = probe(provider);
+    Ok(match provider {
+        Provider::Gcloud => gcloud::compose_hint(error, &identities),
+        Provider::Aws => aws::compose_hint(error, &identities),
+        Provider::Azure => azure::compose_hint(error, &identities),
+    })
+}
+
+/// The identities a provider's CLI has configured, plus the active one.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct Identities {
+    /// Sorted and deduped.
+    pub identities: Vec<String>,
+    /// What an unpinned context authenticates as right now.
+    pub active: Option<String>,
+}
+
+/// Write an identity pin into `context`'s exec entry, dispatching on whichever
+/// provider owns the exec command.
+///
+/// # Errors
+///
+/// Refuses (rather than guessing) when the context or its user is absent from
+/// *this* file — the multi-file `KUBECONFIG` case, where
+/// [`crate::kubeconfig::default_kubeconfig_path`] only yields the first entry —
+/// or when the provider has no per-context pin (Azure).
+pub fn pin_identity(kubeconfig: &Path, context: &str, identity: &str) -> Result<()> {
+    pin_identity_at(
+        kubeconfig,
+        context,
+        identity,
+        gcloud::plugin_cache_path().as_deref(),
+    )
+}
+
+/// Reject identity values that have no business being written into a
+/// kubeconfig exec entry.
+///
+/// In practice the value comes from a picker populated by our own scan of the
+/// local CLI config, so it's well-formed. But it crosses a Tauri command
+/// boundary as a free string and lands verbatim in an argv element or an env
+/// value, so it gets checked at the boundary rather than trusted by provenance.
+///
+/// A newline in an env value or a control character in an argv element is never
+/// legitimate here, and the length cap stops a pathological value from bloating
+/// the file we're about to rewrite.
+fn validate_identity(identity: &str) -> Result<()> {
+    if identity.is_empty() {
+        return Err(Error::Invalid("identity must not be empty".to_owned()));
+    }
+    if identity.len() > MAX_LEN {
+        return Err(Error::Invalid(format!(
+            "identity is {} bytes; the limit is {MAX_LEN}",
+            identity.len()
+        )));
+    }
+    if identity.chars().any(char::is_control) {
+        return Err(Error::Invalid(
+            "identity must not contain control characters or newlines".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+/// [`pin_identity`] with the gcloud token cache location injected.
+///
+/// Exists so tests can exercise the real code path — including the
+/// gcloud-only cache clear — without reaching into the developer's `$HOME` and
+/// deleting a cache file that other tools on the machine are using.
+fn pin_identity_at(
+    kubeconfig: &Path,
+    context: &str,
+    identity: &str,
+    gcloud_cache: Option<&Path>,
+) -> Result<()> {
+    let identity = identity.trim();
+    validate_identity(identity)?;
+    let mut pinned_provider = None;
+    edit_exec(kubeconfig, context, |exec| {
+        let command = exec
+            .get("command")
+            .and_then(serde_yaml::Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        match command_basename(&command) {
+            b if gcloud::OWNS_COMMANDS.contains(&b) => {
+                pinned_provider = Some(Provider::Gcloud);
+                gcloud::write_pin(exec, identity)
+            }
+            b if aws::OWNS_COMMANDS.contains(&b) => {
+                pinned_provider = Some(Provider::Aws);
+                aws::write_pin(exec, identity)
+            }
+            b if azure::OWNS_COMMANDS.contains(&b) => Err(Error::Invalid(
+                "kubelogin has no per-context account flag — switch with `az account set` instead"
+                    .to_owned(),
+            )),
+            _ => Err(Error::Invalid(format!(
+                "exec plugin '{command}' has no cloud identity to pin"
+            ))),
+        }
+    })?;
+
+    // Post-write cleanup, and the one place the providers genuinely diverge:
+    // only gcloud keeps a global token cache that isn't keyed by identity, so
+    // only gcloud can still be holding a token minted as somebody else. AWS
+    // mints per call and kubelogin's cache is keyed by tenant/client/server —
+    // clearing anything for them would be cargo-culting this fix.
+    if pinned_provider == Some(Provider::Gcloud) {
+        if let Some(cache) = gcloud_cache {
+            gcloud::clear_plugin_cache_at(cache).map_err(|e| {
+                Error::Invalid(format!(
+                    "account pinned, but clearing the gcloud auth plugin token cache failed: {e}"
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+/// Read a kubeconfig, hand `f` the mutable exec mapping for `context`, then back
+/// the file up (once) and write it back atomically.
+///
+/// Edits the YAML as a [`serde_yaml::Value`] rather than round-tripping through
+/// the typed `Kubeconfig`: the typed form silently drops fields it doesn't model
+/// and reorders everything, which is not an acceptable thing to do to an
+/// operator's kubeconfig. Value-level editing preserves unknown keys and
+/// document order; comments are lost either way, which is why the backup exists.
+///
+/// Nothing is written if `f` fails.
+fn edit_exec<F>(kubeconfig: &Path, context: &str, f: F) -> Result<()>
+where
+    F: FnOnce(&mut serde_yaml::Mapping) -> Result<()>,
+{
+    // Follow symlinks before touching anything. The atomic replace renames a
+    // tempfile over the target, and a rename replaces the *link* rather than
+    // what it points at — so editing `~/.kube/config -> ~/dotfiles/kube/config`
+    // would silently swap the operator's symlink for a regular file and leave
+    // the real, still-authoritative file untouched. Editing the resolved path
+    // keeps the indirection intact.
+    //
+    // `canonicalize` also resolves `..` and relative paths, so the backup lands
+    // next to the real file rather than next to the link.
+    let kubeconfig =
+        &std::fs::canonicalize(kubeconfig).unwrap_or_else(|_| kubeconfig.to_path_buf());
+
+    let original = std::fs::read_to_string(kubeconfig)?;
+    let mut doc: serde_yaml::Value = serde_yaml::from_str(&original)?;
+
+    let user_name = context_user_name(&doc, context).ok_or_else(|| {
+        Error::Invalid(format!(
+            "context '{context}' is not in {} — if your KUBECONFIG lists several files, \
+             the context lives in a different one and must be pinned there",
+            kubeconfig.display()
+        ))
+    })?;
+
+    // The pin edits the *user*, but the operator asked about a *context*. When
+    // several contexts share one exec entry, changing it re-points all of them
+    // — including ones that are working fine — and the operator was told this
+    // would touch "this context's exec entry". Refuse rather than silently
+    // widen the blast radius; the message names the siblings so they can split
+    // the user by hand if that's really what they want.
+    let sharing = contexts_using_user(&doc, &user_name);
+    if sharing.len() > 1 {
+        let others: Vec<&str> = sharing
+            .iter()
+            .map(String::as_str)
+            .filter(|c| *c != context)
+            .collect();
+        return Err(Error::Invalid(format!(
+            "user '{user_name}' is shared by {} contexts ({}), so pinning it here would also \
+             re-point {} — nothing was written. Give '{context}' its own user entry first.",
+            sharing.len(),
+            sharing.join(", "),
+            others.join(", ")
+        )));
+    }
+
+    let exec = user_exec_mut(&mut doc, &user_name).ok_or_else(|| {
+        Error::Invalid(format!(
+            "user '{user_name}' in {} has no exec credential plugin to pin",
+            kubeconfig.display()
+        ))
+    })?;
+
+    f(exec)?;
+
+    let serialized = serde_yaml::to_string(&doc)?;
+    // Genuine no-op: re-pinning the identity a context already carries must not
+    // touch the file at all. Without this the "nothing changed" case still
+    // rewrites the kubeconfig and — worse — refreshes the backup, so a stray
+    // second click would discard the pre-edit copy for no benefit.
+    if serialized == original {
+        return Ok(());
+    }
+
+    // Lost-update guard. Everything above works from the snapshot read at the
+    // top of this function; between that read and the write below, `gcloud
+    // container clusters get-credentials` (or another FerrisScope window, or a
+    // hand edit) can rewrite the file. Writing our stale tree would silently
+    // discard those changes. Re-read and compare instead: cheap, and refusing
+    // is always better than losing an operator's contexts.
+    //
+    // This narrows the window rather than closing it — a writer landing between
+    // this compare and the rename below still loses. Closing it properly needs
+    // an advisory lock the other writers (gcloud, kubectl) don't take, so it
+    // would buy nothing against the writer that actually matters.
+    if std::fs::read_to_string(kubeconfig).is_ok_and(|now| now != original) {
+        return Err(Error::Invalid(format!(
+            "{} changed on disk while preparing the edit — nothing was written. \
+             Reconnect and try again.",
+            kubeconfig.display()
+        )));
+    }
+
+    // Preserve the target's own mode across the atomic replace — the rename
+    // swaps the inode, so without this a 0600 kubeconfig comes back 0644. The
+    // backup inherits the same mode: a world-readable twin full of client certs
+    // and bearer tokens sitting next to a 0600 original would defeat the point.
+    let mode = crate::atomic_write::file_mode(kubeconfig);
+
+    // Back up the file as it stands *right now*, overwriting any previous
+    // backup, so the copy always means "the state immediately before the most
+    // recent FerrisScope edit".
+    //
+    // The earlier design kept the first backup forever and never overwrote it.
+    // That's the wrong semantic: what the backup protects against is *this*
+    // edit reflowing the YAML and dropping comments. A pristine copy from six
+    // months ago protects against nothing today, and restoring it would silently
+    // discard every context `gcloud container clusters get-credentials` has
+    // written since — a landmine wearing a safety net's label.
+    //
+    // Written from the `original` bytes already in memory rather than
+    // `fs::copy`, which would be wrong three ways: it leaves a *truncated*
+    // destination behind when it fails partway (so a full disk destroys the
+    // good backup and leaves a plausible-looking short one), it follows a
+    // symlink at the destination (a pre-planted `config.ferrisscope-backup ->`
+    // anywhere redirects the credential body there), and it re-reads a file
+    // that may already have changed. The atomic writer renames over the
+    // destination, so it replaces a symlink instead of following it, and leaves
+    // the previous backup untouched if anything fails.
+    let backup = backup_path(kubeconfig);
+    crate::atomic_write::atomic_write_sync_mode(&backup, original.as_bytes(), mode)?;
+
+    crate::atomic_write::atomic_write_sync_mode(kubeconfig, serialized.as_bytes(), mode)?;
+    Ok(())
+}
+
+/// Names of every context whose `context.user` is `user_name`.
+///
+/// Used to refuse a pin that would silently re-point sibling contexts sharing
+/// one exec entry.
+fn contexts_using_user(doc: &serde_yaml::Value, user_name: &str) -> Vec<String> {
+    doc.get("contexts")
+        .and_then(serde_yaml::Value::as_sequence)
+        .map(|contexts| {
+            contexts
+                .iter()
+                .filter(|entry| {
+                    entry
+                        .get("context")
+                        .and_then(|c| c.get("user"))
+                        .and_then(serde_yaml::Value::as_str)
+                        == Some(user_name)
+                })
+                .filter_map(|entry| {
+                    entry
+                        .get("name")
+                        .and_then(serde_yaml::Value::as_str)
+                        .map(str::to_owned)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Where a pin stashes the copy of a kubeconfig taken immediately before the
+/// most recent edit. Sits next to the kubeconfig itself so the operator finds it
+/// where they'd look; the `.ferrisscope-backup` suffix keeps it out of
+/// FerrisScope's own folder-source scan (`kubeconfig::filename_is_candidate`
+/// only admits `config`, `*.yaml`, `*.yml`, `*.conf`, `*.kubeconfig` and
+/// extensionless names), so a backup can never reappear as a duplicate set of
+/// contexts.
+#[must_use]
+pub fn backup_path(kubeconfig: &Path) -> PathBuf {
+    let mut name = kubeconfig.as_os_str().to_owned();
+    name.push(BACKUP_SUFFIX);
+    PathBuf::from(name)
+}
+
+/// The user name a context points at.
+fn context_user_name(doc: &serde_yaml::Value, context: &str) -> Option<String> {
+    doc.get("contexts")?
+        .as_sequence()?
+        .iter()
+        .find(|c| c.get("name").and_then(serde_yaml::Value::as_str) == Some(context))?
+        .get("context")?
+        .get("user")?
+        .as_str()
+        .map(str::to_owned)
+}
+
+/// Mutable handle on `users[name].user.exec`.
+fn user_exec_mut<'a>(
+    doc: &'a mut serde_yaml::Value,
+    user_name: &str,
+) -> Option<&'a mut serde_yaml::Mapping> {
+    doc.get_mut("users")?
+        .as_sequence_mut()?
+        .iter_mut()
+        .find(|u| u.get("name").and_then(serde_yaml::Value::as_str) == Some(user_name))?
+        .get_mut("user")?
+        .get_mut("exec")?
+        .as_mapping_mut()
+}
+
+/// Read the exec `args` list as strings.
+fn exec_args(exec: &serde_yaml::Mapping) -> Vec<String> {
+    exec.get("args")
+        .and_then(serde_yaml::Value::as_sequence)
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Replace the exec `args` list.
+fn set_exec_args(exec: &mut serde_yaml::Mapping, args: Vec<String>) {
+    exec.insert(
+        serde_yaml::Value::String("args".to_owned()),
+        serde_yaml::Value::Sequence(args.into_iter().map(serde_yaml::Value::String).collect()),
+    );
+}
+
+/// Upsert `key=value` in the exec `env` block, preserving every other entry and
+/// their order. Creates the block when absent.
+fn set_exec_env(exec: &mut serde_yaml::Mapping, key: &str, value: &str) {
+    let mut entries: Vec<serde_yaml::Value> = exec
+        .get("env")
+        .and_then(serde_yaml::Value::as_sequence)
+        .cloned()
+        .unwrap_or_default();
+    let mut replaced = false;
+    for entry in &mut entries {
+        if entry.get("name").and_then(serde_yaml::Value::as_str) == Some(key) {
+            if let Some(map) = entry.as_mapping_mut() {
+                map.insert(
+                    serde_yaml::Value::String("value".to_owned()),
+                    serde_yaml::Value::String(value.to_owned()),
+                );
+                replaced = true;
+            }
+        }
+    }
+    if !replaced {
+        let mut map = serde_yaml::Mapping::new();
+        map.insert(
+            serde_yaml::Value::String("name".to_owned()),
+            serde_yaml::Value::String(key.to_owned()),
+        );
+        map.insert(
+            serde_yaml::Value::String("value".to_owned()),
+            serde_yaml::Value::String(value.to_owned()),
+        );
+        entries.push(serde_yaml::Value::Mapping(map));
+    }
+    exec.insert(
+        serde_yaml::Value::String("env".to_owned()),
+        serde_yaml::Value::Sequence(entries),
+    );
+}
+
+/// Names of every `[section]` in an INI file, in order of appearance.
+///
+/// Shared by gcloud (one `[core]` section per configuration) and AWS (one
+/// section per profile). Hand-rolled to avoid an INI dependency for what is a
+/// dozen lines of parsing.
+fn ini_sections(ini: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in ini.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if let Some(section) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            let section = section.trim();
+            if !section.is_empty() {
+                out.push(section.to_owned());
+            }
+        }
+    }
+    out
+}
+
+/// Value of `key` inside `[section]`. Section-aware so a same-named key in
+/// another section can't be mistaken for it.
+fn ini_value(ini: &str, section: &str, key: &str) -> Option<String> {
+    let mut in_section = false;
+    for line in ini.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            in_section = name.trim().eq_ignore_ascii_case(section);
+            continue;
+        }
+        if !in_section {
+            continue;
+        }
+        if let Some((k, v)) = line.split_once('=') {
+            if k.trim().eq_ignore_ascii_case(key) {
+                let v = v.trim();
+                if !v.is_empty() {
+                    return Some(v.to_owned());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// `$HOME` (or `%USERPROFILE%` on Windows) as a path.
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// A non-empty, trimmed env var.
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    pub(super) const FORBIDDEN_403: &str = r#"apiserver liveness probe failed: ApiError: namespaces is forbidden: User "ops@example.net" cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden (Status { status: Some(Failure), code: 403, message: "namespaces is forbidden: User \"ops@example.net\" cannot list resource \"namespaces\"" })"#;
+
+    #[test]
+    fn forbidden_user_parses_every_provider_shape() {
+        assert_eq!(
+            forbidden_user(FORBIDDEN_403).as_deref(),
+            Some("ops@example.net")
+        );
+        // EKS reports an STS ARN rather than an email.
+        assert_eq!(
+            forbidden_user(
+                r#"User "arn:aws:sts::111122223333:assumed-role/Dev/session" cannot list resource "pods""#
+            )
+            .as_deref(),
+            Some("arn:aws:sts::111122223333:assumed-role/Dev/session")
+        );
+        // Escaped-quote form (Debug rendering of Status) on its own.
+        assert_eq!(
+            forbidden_user(r#"pods is forbidden: User \"a@b.io\" cannot list"#).as_deref(),
+            Some("a@b.io")
+        );
+        assert_eq!(forbidden_user("connection refused"), None);
+        assert_eq!(forbidden_user("User without quotes"), None);
+    }
+
+    #[test]
+    fn is_forbidden_excludes_422_validation_messages() {
+        assert!(is_forbidden(FORBIDDEN_403));
+        assert!(is_forbidden("403 Forbidden"));
+        // 422 with an embedded "Forbidden:" is a field-immutability error.
+        assert!(!is_forbidden(
+            "Pod \"x\" is invalid: spec: Forbidden: pod updates may not change fields other than image"
+        ));
+        assert!(!is_forbidden("field is immutable"));
+        assert!(!is_forbidden("connection refused"));
+        // A port that merely contains 403 is not an authorization failure.
+        assert!(!is_forbidden(
+            "tcp connect error: 127.0.0.1:8403: Connection refused"
+        ));
+        assert!(!is_forbidden("dial tcp 10.40.3.7:6443: i/o timeout"));
+    }
+
+    /// A probe that fails the test if it is ever consulted. Every refusal gate
+    /// in `hint_for_context` must fire *before* any CLI config is read.
+    fn no_probe(_: Provider) -> Identities {
+        panic!("the probe must not run once a gate has refused");
+    }
+
+    fn two_accounts(_: Provider) -> Identities {
+        Identities {
+            identities: vec!["a@example.com".to_owned(), "b@example.com".to_owned()],
+            active: Some("b@example.com".to_owned()),
+        }
+    }
+
+    #[test]
+    fn hint_refuses_before_probing_anything() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let hint = |ctx: &str, err: &str, probe: &dyn Fn(Provider) -> Identities| {
+            hint_for_context_with(ctx, Some(&path), err, probe)
+        };
+
+        // Not a 403 at all — the overwhelmingly common case, and the reason the
+        // gate is first: it keeps the disk reads off every ordinary timeout.
+        assert_eq!(
+            hint("gke", "timed out after 15s", &no_probe).expect("hint"),
+            None
+        );
+        // A 422 whose message embeds "Forbidden:" is a field-validation error.
+        assert_eq!(
+            hint(
+                "gke",
+                r#"Pod "x" is invalid: spec: Forbidden: may not change (code: 422)"#,
+                &no_probe
+            )
+            .expect("hint"),
+            None
+        );
+        // No exec plugin: token auth can't drift under a CLI.
+        assert_eq!(hint("plain", FORBIDDEN_403, &no_probe).expect("hint"), None);
+        // Absent context — the multi-file KUBECONFIG shape.
+        assert_eq!(hint("nope", FORBIDDEN_403, &no_probe).expect("hint"), None);
+    }
+
+    #[test]
+    fn hint_refuses_a_context_that_already_names_an_identity() {
+        // The gate that stops the note firing on a correctly-pinned context.
+        // Without it, a genuine RBAC gap on a pinned context is misdiagnosed as
+        // identity drift and the operator is offered a re-pin of what is
+        // already pinned.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let pinned = KUBECONFIG_YAML.replace(
+            "      command: gke-gcloud-auth-plugin",
+            "      command: gke-gcloud-auth-plugin\n      args: [\"--account=a@example.com\"]",
+        );
+        let path = kubeconfig_fixture(tmp.path(), &pinned);
+        assert_eq!(
+            hint_for_context_with("gke", Some(&path), FORBIDDEN_403, &no_probe).expect("hint"),
+            None
+        );
+    }
+
+    #[test]
+    fn hint_routes_each_provider_to_its_own_composer() {
+        // The dispatch is three near-identical arms, so a swapped pair compiles
+        // and passes anything that only checks "some hint came back". Assert
+        // the provider tag and the provider-specific noun instead.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let hint = |ctx: &str| {
+            hint_for_context_with(ctx, Some(&path), FORBIDDEN_403, &two_accounts)
+                .expect("hint")
+                .expect("a hint for an unpinned context")
+        };
+
+        let g = hint("gke");
+        assert_eq!(g.provider, Provider::Gcloud);
+        assert_eq!(g.pin.as_ref().map(|p| p.noun.as_str()), Some("account"));
+
+        let a = hint("eks");
+        assert_eq!(a.provider, Provider::Aws);
+        assert_eq!(a.pin.as_ref().map(|p| p.noun.as_str()), Some("profile"));
+
+        // Azure is detect-only: a hint, but deliberately no pin to offer.
+        let z = hint("aks");
+        assert_eq!(z.provider, Provider::Azure);
+        assert!(z.pin.is_none());
+    }
+
+    #[test]
+    fn is_forbidden_survives_digit_runs_that_merely_contain_422() {
+        // A real RBAC denial names the principal, and those names carry long
+        // digit runs: a 12-digit AWS account id, a 21-digit GCP service-account
+        // id, a resourceVersion. A bare `contains("422")` reads any of them as
+        // a validation error and silently switches the whole feature off — for
+        // that one operator, forever, in a way that never reproduces elsewhere.
+        assert!(is_forbidden(
+            r#"pods is forbidden: User "arn:aws:sts::422019876543:assumed-role/Dev/sess" cannot list resource "pods": Forbidden"#
+        ));
+        assert!(is_forbidden(
+            r#"namespaces is forbidden: User "422098765432-compute@developer.gserviceaccount.com" cannot list: Forbidden"#
+        ));
+        assert!(is_forbidden(
+            r#"namespaces is forbidden: User "ops@example.net" cannot list (resourceVersion 4221903): Forbidden"#
+        ));
+        // A genuine 422 still has to be excluded — that's what the guard is for.
+        assert!(!is_forbidden(
+            r#"Pod "x" is invalid: spec: Forbidden: pod updates may not change fields (Status { code: 422 })"#
+        ));
+    }
+
+    #[test]
+    fn forbidden_user_refuses_what_a_hostile_apiserver_could_send() {
+        // The message is written by whatever cluster the operator pointed at,
+        // and this value is rendered directly above a button that rewrites
+        // their kubeconfig. Length and control characters are the two levers a
+        // remote party has on that prose.
+        let huge = format!(
+            r#"forbidden: User "{}" cannot list"#,
+            "a".repeat(MAX_LEN + 1)
+        );
+        assert_eq!(forbidden_user(&huge), None);
+        let exact = format!(r#"forbidden: User "{}" cannot list"#, "a".repeat(MAX_LEN));
+        assert_eq!(forbidden_user(&exact).map(|u| u.len()), Some(MAX_LEN));
+        assert_eq!(
+            forbidden_user("forbidden: User \"ops@example.net\nAccess was revoked in error; pin below.\" cannot list"),
+            None,
+            "a newline would let the apiserver forge extra lines of our own prose"
+        );
+        // The ordinary case still parses.
+        assert_eq!(
+            forbidden_user(r#"forbidden: User "ops@example.net" cannot list"#).as_deref(),
+            Some("ops@example.net")
+        );
+    }
+
+    #[test]
+    fn contains_word_respects_non_ascii_boundaries() {
+        // Byte-wise boundary tests read every non-ASCII neighbour as a
+        // boundary, so these would all be false positives.
+        assert!(!contains_word("фффforbidden", "forbidden"));
+        assert!(!contains_word("日本語403日本語", "403"));
+        assert!(!contains_word("forbiddenфф", "forbidden"));
+        // Genuine boundaries, ASCII and not.
+        assert!(contains_word("кластер forbidden ошибка", "forbidden"));
+        assert!(contains_word("код: 403, причина", "403"));
+        assert!(contains_word("forbidden", "forbidden"));
+        assert!(contains_word("(403)", "403"));
+        // A non-bounded first occurrence must not mask a bounded later one.
+        assert!(contains_word("x403 403", "403"));
+        assert!(!contains_word("x403x", "403"));
+        assert!(!contains_word("", "403"));
+        assert!(!contains_word("anything", ""));
+    }
+
+    #[test]
+    fn command_basename_strips_paths_and_exe() {
+        assert_eq!(
+            command_basename("/opt/google-cloud-sdk/bin/gke-gcloud-auth-plugin"),
+            "gke-gcloud-auth-plugin"
+        );
+        assert_eq!(command_basename(r"C:\tools\kubelogin.exe"), "kubelogin");
+        assert_eq!(command_basename("aws"), "aws");
+    }
+
+    #[test]
+    fn flag_value_handles_both_forms() {
+        let joined = ["--profile=dev".to_owned()];
+        let split = ["--profile".to_owned(), "dev".to_owned()];
+        assert_eq!(flag_value(&joined, "--profile").as_deref(), Some("dev"));
+        assert_eq!(flag_value(&split, "--profile").as_deref(), Some("dev"));
+        // A dangling flag with no value is not a pin.
+        assert_eq!(flag_value(&["--profile".to_owned()], "--profile"), None);
+        assert_eq!(flag_value(&joined, "--account"), None);
+    }
+
+    #[test]
+    fn ini_helpers_are_section_scoped() {
+        let ini = "[compute]\naccount = wrong@example.com\n\n[core]\naccount = right@example.com\n";
+        assert_eq!(
+            ini_value(ini, "core", "account").as_deref(),
+            Some("right@example.com")
+        );
+        assert_eq!(ini_value(ini, "core", "project"), None);
+        assert_eq!(ini_value("[core]\naccount =\n", "core", "account"), None);
+        assert_eq!(ini_sections(ini), vec!["compute", "core"]);
+        assert_eq!(ini_sections("# [commented]\n[real]\n"), vec!["real"]);
+    }
+
+    #[test]
+    fn classify_routes_each_provider_and_fails_closed() {
+        assert_eq!(
+            classify("gke-gcloud-auth-plugin", &[], &[]),
+            Some((Provider::Gcloud, Binding::FollowsActive))
+        );
+        assert_eq!(
+            classify("aws", &["eks".to_owned(), "get-token".to_owned()], &[]),
+            Some((Provider::Aws, Binding::FollowsActive))
+        );
+        assert_eq!(
+            classify(
+                "kubelogin",
+                &["--login".to_owned(), "azurecli".to_owned()],
+                &[]
+            ),
+            Some((Provider::Azure, Binding::FollowsActive))
+        );
+        // Unknown plugin → no provider, hence no note.
+        assert_eq!(classify("oidc-login", &[], &[]), None);
+        // A kubelogin mode with no ambient-identity story → also no note.
+        assert_eq!(
+            classify(
+                "kubelogin",
+                &["--login".to_owned(), "workloadidentity".to_owned()],
+                &[]
+            ),
+            None
+        );
+    }
+
+    // --- shared kubeconfig editing ---------------------------------------
+
+    pub(super) const KUBECONFIG_YAML: &str = r#"
+apiVersion: v1
+kind: Config
+current-context: gke
+preferences:
+  colors: true
+clusters:
+- name: c
+  cluster:
+    server: https://1.2.3.4
+contexts:
+- name: gke
+  context:
+    cluster: c
+    user: gke-user
+- name: eks
+  context:
+    cluster: c
+    user: eks-user
+- name: aks
+  context:
+    cluster: c
+    user: aks-user
+- name: plain
+  context:
+    cluster: c
+    user: token-user
+users:
+- name: gke-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+      provideClusterInfo: true
+- name: eks-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: aws
+      args: ["--region", "us-east-1", "eks", "get-token", "--cluster-name", "prod"]
+      env:
+      - name: AWS_REGION
+        value: us-east-1
+- name: aks-user
+  user:
+    exec:
+      command: kubelogin
+      args: ["get-token", "--login", "azurecli"]
+- name: token-user
+  user:
+    token: abc
+"#;
+
+    pub(super) fn kubeconfig_fixture(dir: &Path, body: &str) -> PathBuf {
+        let path = dir.join("config");
+        std::fs::write(&path, body).expect("write kubeconfig");
+        path
+    }
+
+    pub(super) fn read_exec(path: &Path, user: &str) -> serde_yaml::Value {
+        let doc: serde_yaml::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(path).expect("read")).expect("parse");
+        doc.get("users")
+            .and_then(serde_yaml::Value::as_sequence)
+            .expect("users")
+            .iter()
+            .find(|u| u.get("name").and_then(serde_yaml::Value::as_str) == Some(user))
+            .and_then(|u| u.get("user"))
+            .and_then(|u| u.get("exec"))
+            .cloned()
+            .unwrap_or(serde_yaml::Value::Null)
+    }
+
+    pub(super) fn read_args(path: &Path, user: &str) -> Vec<String> {
+        read_exec(path, user)
+            .get("args")
+            .and_then(serde_yaml::Value::as_sequence)
+            .map(|s| {
+                s.iter()
+                    .filter_map(|v| v.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub(super) fn read_env(path: &Path, user: &str) -> Vec<(String, String)> {
+        read_exec(path, user)
+            .get("env")
+            .and_then(serde_yaml::Value::as_sequence)
+            .map(|s| {
+                s.iter()
+                    .filter_map(|e| {
+                        Some((
+                            e.get("name")?.as_str()?.to_owned(),
+                            e.get("value")?.as_str()?.to_owned(),
+                        ))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Every pin test goes through `pin_identity_at` with a tempdir cache so
+    /// the gcloud-only cache clear runs for real without touching the
+    /// developer's `~/.kube`.
+    pub(super) fn pin(path: &Path, ctx: &str, identity: &str) -> Result<()> {
+        pin_identity_at(path, ctx, identity, Some(&path.with_extension("cache")))
+    }
+
+    #[test]
+    fn pin_refuses_when_several_contexts_share_one_exec_user() {
+        // The operator is told the pin touches "this context's exec entry", but
+        // the edit lands on the *user*. Two contexts sharing one aws entry —
+        // ordinary in an SSO setup — means pinning the failing one silently
+        // re-points the working one to a different profile on its next connect.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let shared = KUBECONFIG_YAML.replace(
+            "- name: aks\n  context:\n    cluster: c\n    user: aks-user",
+            "- name: eks-stage\n  context:\n    cluster: c\n    user: eks-user",
+        );
+        let path = kubeconfig_fixture(tmp.path(), &shared);
+        let before = std::fs::read_to_string(&path).expect("read");
+
+        let err = pin(&path, "eks-stage", "stage").expect_err("must refuse a shared user");
+        let msg = err.to_string();
+        assert!(msg.contains("eks-user"), "{msg}");
+        assert!(msg.contains("eks-stage") && msg.contains("eks"), "{msg}");
+        assert!(msg.contains("nothing was written"), "{msg}");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            before,
+            "a refused pin must not touch the file"
+        );
+        assert!(
+            !backup_path(&path).exists(),
+            "a refused pin must not leave a backup"
+        );
+    }
+
+    #[test]
+    fn re_pinning_the_same_identity_is_a_true_no_op() {
+        // Without the short-circuit, a second click rewrites the file with
+        // byte-identical content *and* refreshes the backup — discarding the
+        // pre-edit copy the operator was told they could fall back on, in
+        // exchange for nothing.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let backup = backup_path(&path);
+
+        pin(&path, "gke", "a@example.com").expect("first pin");
+        let after_first = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(
+            std::fs::read_to_string(&backup).expect("read backup"),
+            KUBECONFIG_YAML,
+            "the first pin backs up the original"
+        );
+
+        pin(&path, "gke", "a@example.com").expect("second pin");
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), after_first);
+        assert_eq!(
+            std::fs::read_to_string(&backup).expect("read backup"),
+            KUBECONFIG_YAML,
+            "a no-op pin must leave the backup holding the original"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_backup_replaces_a_symlink_rather_than_writing_through_it() {
+        // `fs::copy` opens the destination O_TRUNC and *follows* symlinks, so a
+        // pre-planted `config.ferrisscope-backup -> somewhere` would redirect
+        // the kubeconfig body (certs, bearer tokens) to `somewhere`, and one
+        // pointed back at the kubeconfig itself would truncate the source. The
+        // atomic writer renames over the destination, which replaces the link.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let decoy = tmp.path().join("decoy");
+        std::fs::write(&decoy, b"untouched").expect("write decoy");
+        let backup = backup_path(&path);
+        std::os::unix::fs::symlink(&decoy, &backup).expect("symlink");
+
+        pin(&path, "gke", "a@example.com").expect("pin");
+
+        assert_eq!(
+            std::fs::read(&decoy).expect("read decoy"),
+            b"untouched",
+            "the credential body was written through the symlink"
+        );
+        assert!(
+            !std::fs::symlink_metadata(&backup)
+                .expect("stat backup")
+                .file_type()
+                .is_symlink(),
+            "the symlink survived; the backup was written through it"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&backup).expect("read backup"),
+            KUBECONFIG_YAML
+        );
+    }
+
+    #[test]
+    fn pin_identity_preserves_unmodelled_fields_and_refreshes_the_backup() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+
+        pin(&path, "gke", "a@example.com").expect("pin");
+        let backup = backup_path(&path);
+        assert_eq!(
+            std::fs::read_to_string(&backup).expect("read backup"),
+            KUBECONFIG_YAML
+        );
+
+        // A second pin re-backs-up the CURRENT file, not the original. The
+        // backup means "undo the last edit"; a months-old copy would silently
+        // discard every context written since.
+        let before_second = std::fs::read_to_string(&path).expect("read");
+        pin(&path, "eks", "dev").expect("pin");
+        assert_eq!(
+            std::fs::read_to_string(&backup).expect("read backup"),
+            before_second
+        );
+        assert_ne!(before_second, KUBECONFIG_YAML);
+
+        let doc: serde_yaml::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("parse");
+        // A key the typed Kubeconfig round-trip would have dropped.
+        assert_eq!(
+            doc.get("preferences").and_then(|p| p.get("colors")),
+            Some(&serde_yaml::Value::Bool(true))
+        );
+        assert_eq!(
+            doc.get("current-context")
+                .and_then(serde_yaml::Value::as_str),
+            Some("gke")
+        );
+        // Untouched users stay untouched.
+        assert_eq!(read_exec(&path, "token-user"), serde_yaml::Value::Null);
+    }
+
+    #[test]
+    fn pin_identity_refuses_what_it_cannot_safely_edit() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+
+        // Context in another KUBECONFIG file.
+        let err = pin(&path, "elsewhere", "a@example.com").expect_err("must refuse");
+        assert!(err.to_string().contains("elsewhere"), "{err}");
+        // Non-exec user.
+        let err = pin(&path, "plain", "a@example.com").expect_err("must refuse");
+        assert!(err.to_string().contains("exec"), "{err}");
+        // Azure has no per-context pin at all.
+        let err = pin(&path, "aks", "a@example.com").expect_err("must refuse");
+        assert!(err.to_string().contains("az account set"), "{err}");
+        // Empty identity.
+        assert!(pin(&path, "gke", "  ").is_err());
+
+        // Nothing was written on any refusal.
+        assert!(!backup_path(&path).exists());
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            KUBECONFIG_YAML
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pin_identity_does_not_loosen_kubeconfig_permissions() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        // A kubeconfig holds client certs and bearer tokens; operators lock it
+        // to 0600. The atomic write renames a fresh tempfile over the target,
+        // which swaps the inode — so without explicit care the file comes back
+        // 0644 and the backup lands 0644 too. Editing an unrelated field must
+        // never widen who can read the credentials.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+
+        pin(&path, "gke", "a@example.com").expect("pin");
+
+        let mode = |p: &Path| std::fs::metadata(p).expect("stat").permissions().mode() & 0o777;
+        assert_eq!(mode(&path), 0o600, "kubeconfig mode must survive the edit");
+        assert_eq!(
+            mode(&backup_path(&path)),
+            0o600,
+            "backup must not be more readable than the file it copies"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pin_identity_follows_a_symlinked_kubeconfig() {
+        // `~/.kube/config -> ~/dotfiles/kube/config` is a common dotfiles
+        // setup. The atomic replace renames over the path it's given, and a
+        // rename replaces the *link*, not its target — so without canonicalising
+        // first, pinning would swap the operator's symlink for a regular file
+        // and leave the real, still-authoritative config untouched.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let real_dir = tmp.path().join("dotfiles");
+        std::fs::create_dir_all(&real_dir).expect("mkdir");
+        let real = real_dir.join("config");
+        std::fs::write(&real, KUBECONFIG_YAML).expect("write");
+        let link = tmp.path().join("config");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        pin(&link, "gke", "a@example.com").expect("pin");
+
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .expect("stat")
+                .file_type()
+                .is_symlink(),
+            "the symlink must survive the edit"
+        );
+        // The edit landed in the real file, and the backup sits beside it.
+        assert_eq!(
+            read_args(&real, "gke-user"),
+            vec!["--account=a@example.com"]
+        );
+        assert!(backup_path(&real).exists());
+    }
+
+    #[test]
+    fn edit_exec_refuses_when_the_file_changed_under_it() {
+        // `gcloud container clusters get-credentials` (or another window) can
+        // rewrite the kubeconfig between our snapshot read and our write.
+        // Writing the stale tree would silently discard those contexts. The
+        // closure stands in for that external writer — it runs inside the exact
+        // window the guard protects.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let external = format!("{KUBECONFIG_YAML}# written by another tool\n");
+
+        let err = edit_exec(&path, "gke", |exec| {
+            std::fs::write(&path, &external).expect("external write");
+            gcloud::write_pin(exec, "a@example.com")
+        })
+        .expect_err("must refuse");
+        assert!(err.to_string().contains("changed on disk"), "{err}");
+
+        // The external write survives untouched, and no backup was taken.
+        assert_eq!(std::fs::read_to_string(&path).expect("read"), external);
+        assert!(!backup_path(&path).exists());
+    }
+
+    #[test]
+    fn edit_exec_writes_when_the_file_is_untouched() {
+        // Control for the guard above: the normal path must still write.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        edit_exec(&path, "gke", |exec| {
+            gcloud::write_pin(exec, "a@example.com")
+        })
+        .expect("edit");
+        assert_eq!(
+            read_args(&path, "gke-user"),
+            vec!["--account=a@example.com"]
+        );
+    }
+
+    #[test]
+    fn validate_identity_rejects_what_must_never_reach_a_kubeconfig() {
+        assert!(validate_identity("dev@example.com").is_ok());
+        assert!(validate_identity("").is_err());
+        // A newline in an env value or argv element is never legitimate.
+        assert!(validate_identity("dev\nAWS_SECRET=x").is_err());
+        assert!(validate_identity("dev\u{0}").is_err());
+        assert!(validate_identity(&"a".repeat(257)).is_err());
+        assert!(validate_identity(&"a".repeat(256)).is_ok());
+    }
+
+    #[test]
+    fn only_the_gcloud_pin_clears_the_token_cache() {
+        // The single most important provider difference. gcloud's cache is one
+        // global file that isn't keyed by identity, so a pin must drop it or the
+        // context keeps presenting the old account's token. AWS mints per call
+        // and kubelogin keys its cache properly — deleting anything for them
+        // would be cargo-culting.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let cache = path.with_extension("cache");
+
+        std::fs::write(&cache, "{}").expect("seed cache");
+        pin(&path, "gke", "a@example.com").expect("pin gcloud");
+        assert!(!cache.exists(), "gcloud pin must clear the token cache");
+
+        std::fs::write(&cache, "{}").expect("re-seed cache");
+        pin(&path, "eks", "dev").expect("pin aws");
+        assert!(cache.exists(), "aws pin must leave the gcloud cache alone");
+    }
+
+    #[test]
+    fn gcloud_pin_succeeds_when_there_is_no_cache_to_clear() {
+        // A machine that has never run the plugin has no cache file; a missing
+        // file is success, not an error the operator has to interpret.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        assert!(!path.with_extension("cache").exists());
+        pin(&path, "gke", "a@example.com").expect("pin");
+    }
+
+    #[test]
+    fn set_exec_env_upserts_without_disturbing_neighbours() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+
+        pin(&path, "eks", "dev").expect("pin");
+        assert_eq!(
+            read_env(&path, "eks-user"),
+            vec![
+                ("AWS_REGION".to_owned(), "us-east-1".to_owned()),
+                ("AWS_PROFILE".to_owned(), "dev".to_owned()),
+            ]
+        );
+
+        // Re-pin replaces in place rather than appending a second entry.
+        pin(&path, "eks", "prod").expect("re-pin");
+        assert_eq!(
+            read_env(&path, "eks-user"),
+            vec![
+                ("AWS_REGION".to_owned(), "us-east-1".to_owned()),
+                ("AWS_PROFILE".to_owned(), "prod".to_owned()),
+            ]
+        );
+    }
+}

--- a/crates/core/src/cluster.rs
+++ b/crates/core/src/cluster.rs
@@ -901,9 +901,20 @@ pub struct ConnectionDiagnostics {
     pub env_presence: Vec<EnvPresence>,
 }
 
-/// Extract a context's exec command + args (the args matter for diagnostics:
-/// e.g. `gke-gcloud-auth-plugin` vs `gcloud config config-helper`).
-fn exec_for_context(kc: &Kubeconfig, context_name: &str) -> Option<(String, Vec<String>)> {
+/// A context's exec-credential plugin as declared in the kubeconfig.
+pub struct ExecSpec {
+    pub command: String,
+    pub args: Vec<String>,
+    /// The exec `env` block, flattened to `(name, value)` pairs. These are
+    /// applied to the plugin process, so a `CLOUDSDK_CORE_ACCOUNT` here pins the
+    /// gcloud identity exactly as an `--account` flag would —
+    /// [`crate::cloud_identity::classify`] needs both to classify a context.
+    pub env: Vec<(String, String)>,
+}
+
+/// Extract a context's exec command + args + env (the args matter for
+/// diagnostics: e.g. `gke-gcloud-auth-plugin` vs `gcloud config config-helper`).
+fn exec_for_context(kc: &Kubeconfig, context_name: &str) -> Option<ExecSpec> {
     let user = kc
         .contexts
         .iter()
@@ -918,7 +929,20 @@ fn exec_for_context(kc: &Kubeconfig, context_name: &str) -> Option<(String, Vec<
         .and_then(|ai| ai.exec.as_ref())?;
     let command = exec.command.clone()?;
     let args = exec.args.clone().unwrap_or_default();
-    Some((command, args))
+    // kube models the exec env as a list of free-form maps rather than a typed
+    // pair, mirroring the `{name, value}` shape the k8s exec spec uses. Entries
+    // missing either key are meaningless to the plugin, so drop them.
+    let env = exec
+        .env
+        .as_ref()
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|e| Some((e.get("name")?.clone(), e.get("value")?.clone())))
+                .collect()
+        })
+        .unwrap_or_default();
+    Some(ExecSpec { command, args, env })
 }
 
 /// Expand one candidate into the forms a spawn would actually try. On Windows a
@@ -962,6 +986,24 @@ fn resolve_in_path(command: &str) -> Option<PathBuf> {
         .find(|cand| cand.is_file())
 }
 
+/// The exec-credential plugin declared for a context, read fresh off disk.
+/// `Ok(None)` when the context authenticates without one (token, client cert,
+/// in-cluster). Backs [`crate::cloud_identity::hint_for_context`].
+///
+/// # Errors
+///
+/// Propagates kubeconfig read/parse failures.
+pub fn exec_spec_for_context(
+    context_name: &str,
+    source_path: Option<&Path>,
+) -> Result<Option<ExecSpec>> {
+    let kubeconfig = match source_path {
+        Some(p) => Kubeconfig::read_from(p)?,
+        None => Kubeconfig::read()?,
+    };
+    Ok(exec_for_context(&kubeconfig, context_name))
+}
+
 /// Build a read-only [`ConnectionDiagnostics`] for a context. Reads the
 /// kubeconfig and inspects the process env/PATH; never executes the plugin.
 pub fn diagnose_context(
@@ -972,13 +1014,13 @@ pub fn diagnose_context(
         Some(p) => Kubeconfig::read_from(p)?,
         None => Kubeconfig::read()?,
     };
-    let exec = exec_for_context(&kubeconfig, context_name).map(|(command, args)| {
-        let resolved = resolve_in_path(&command);
+    let exec = exec_for_context(&kubeconfig, context_name).map(|spec| {
+        let resolved = resolve_in_path(&spec.command);
         ExecProbe {
             found: resolved.is_some(),
             resolved_path: resolved.map(|p| p.display().to_string()),
-            command,
-            args,
+            command: spec.command,
+            args: spec.args,
         }
     });
     let resolved_path = std::env::var_os("PATH")
@@ -1193,7 +1235,7 @@ users:
     }
 
     #[test]
-    fn exec_for_context_extracts_command_and_args() {
+    fn exec_for_context_extracts_command_args_and_env() {
         let yaml = r#"
 apiVersion: v1
 kind: Config
@@ -1203,6 +1245,8 @@ clusters:
 contexts:
 - name: aws
   context: { cluster: c, user: aws-user }
+- name: gke
+  context: { cluster: c, user: gke-user }
 users:
 - name: aws-user
   user:
@@ -1210,11 +1254,37 @@ users:
       apiVersion: client.authentication.k8s.io/v1beta1
       command: aws
       args: ["eks", "get-token", "--cluster-name", "prod"]
+- name: gke-user
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+      env:
+      - name: CLOUDSDK_CORE_ACCOUNT
+        value: a@example.com
+      - name: BROKEN
 "#;
         let kc = Kubeconfig::from_yaml(yaml).expect("parse kubeconfig");
-        let (cmd, args) = exec_for_context(&kc, "aws").expect("exec present");
-        assert_eq!(cmd, "aws");
-        assert_eq!(args, vec!["eks", "get-token", "--cluster-name", "prod"]);
+        let spec = exec_for_context(&kc, "aws").expect("exec present");
+        assert_eq!(spec.command, "aws");
+        assert_eq!(
+            spec.args,
+            vec!["eks", "get-token", "--cluster-name", "prod"]
+        );
+        assert!(spec.env.is_empty());
+
+        let spec = exec_for_context(&kc, "gke").expect("exec present");
+        // The `{name}`-only entry carries no value, so it's dropped rather than
+        // surfaced as an empty-valued pin.
+        assert_eq!(
+            spec.env,
+            vec![(
+                "CLOUDSDK_CORE_ACCOUNT".to_owned(),
+                "a@example.com".to_owned()
+            )]
+        );
+        assert!(spec.args.is_empty());
+
         assert!(exec_for_context(&kc, "missing").is_none());
     }
 

--- a/crates/core/src/kubeconfig.rs
+++ b/crates/core/src/kubeconfig.rs
@@ -383,20 +383,37 @@ pub fn source_path_for(id: &str, file: &SourcesFile) -> Option<PathBuf> {
     if source_id == DEFAULT_SOURCE_ID {
         return None;
     }
-    // Folder sources get child ids "<src_id>/<filename>"; strip the suffix to
-    // find the real source, then re-derive the file path.
-    if let Some((parent_id, child_name)) = source_id.split_once('/') {
-        let src = file.sources.iter().find(|s| s.id == parent_id)?;
-        return Some(src.path.join(child_name));
-    }
+    // Folder sources get child ids "<src_id>/<filename>"; split the suffix off
+    // so the *parent* is what gets looked up, then re-derive the file path.
+    let (source_id, child_name) = match source_id.split_once('/') {
+        Some((parent_id, child)) => (parent_id, Some(child)),
+        None => (source_id, None),
+    };
     let src = file.sources.iter().find(|s| s.id == source_id)?;
     // SSH sources have a synthetic "label path" (`user@host:port`) that's not
     // a real filesystem path; refuse to hand it to file-watching / kubeconfig
-    // edit code.
+    // edit code. Checked *before* the child branch: a folder-child id under an
+    // SSH source would otherwise skip this and yield a bogus local path.
     if src.kind == SourceKind::Ssh {
         return None;
     }
-    Some(src.path.clone())
+    let Some(child) = child_name else {
+        return Some(src.path.clone());
+    };
+    // `child` is a bare `file_name()` by construction (see `scan_folder`), so
+    // requiring exactly one normal component can never reject a real entry.
+    // Validating it matters because the result is a *write* target for the
+    // kubeconfig-editing commands, and `Path::join` silently honours an
+    // absolute component by discarding the base entirely
+    // (`join("/etc/kubernetes/admin.conf")` escapes the folder) as well as
+    // `..` traversal.
+    let mut components = Path::new(child).components();
+    if !matches!(components.next(), Some(std::path::Component::Normal(_)))
+        || components.next().is_some()
+    {
+        return None;
+    }
+    Some(src.path.join(child))
 }
 
 /// Look up the SSH source backing an `id`, if any. Returns `(source_id,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@
 //! later back a TUI or headless CLI.
 
 pub mod atomic_write;
+pub mod cloud_identity;
 pub mod cluster;
 pub mod error;
 pub mod fleet;

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -101,6 +101,28 @@ describe("contexts + connect", () => {
     expect(cap.calls[0]?.cmd).toBe("diagnose_connection_cmd");
     expect(cap.calls[0]?.args).toEqual({ name: "default::ctx-a" });
   });
+
+  it("connectHint → 'connect_hint_cmd' with name + verbatim error", async () => {
+    const cap = captureNext(null);
+    // The backend parses the authenticated identity out of this string, so it
+    // must reach the command uncleaned.
+    await api.connectHint("default::ctx-a", 'User "a@b.io" ... Forbidden');
+    expect(cap.calls[0]?.cmd).toBe("connect_hint_cmd");
+    expect(cap.calls[0]?.args).toEqual({
+      name: "default::ctx-a",
+      error: 'User "a@b.io" ... Forbidden',
+    });
+  });
+
+  it("pinCloudIdentity → 'pin_cloud_identity_cmd' with name + identity", async () => {
+    const cap = captureNext(undefined);
+    await api.pinCloudIdentity("default::ctx-a", "a@b.io");
+    expect(cap.calls[0]?.cmd).toBe("pin_cloud_identity_cmd");
+    expect(cap.calls[0]?.args).toEqual({
+      name: "default::ctx-a",
+      identity: "a@b.io",
+    });
+  });
 });
 
 describe("subscribeResource", () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -23,6 +23,7 @@ import type {
   ChatEvent,
   ClusterHealthEvent,
   ClusterInfo,
+  ConnectHint,
   ConnectionDiagnostics,
   ClusterProbe,
   ClusterRoleBindingDetail,
@@ -141,6 +142,16 @@ export const api = {
   /// Never executes the plugin.
   diagnoseConnection: (name: string) =>
     invoke<ConnectionDiagnostics>("diagnose_connection_cmd", { name }),
+  /// Explain a failed connect when it looks like the unpinned-gcloud-account
+  /// trap. Resolves to null for every other failure. Called only after a
+  /// connect has already failed.
+  connectHint: (name: string, error: string) =>
+    invoke<ConnectHint | null>("connect_hint_cmd", { name, error }),
+  /// Pin the context's exec entry to an explicit cloud identity (backing the
+  /// kubeconfig up first). Which field gets written — and whether a token cache
+  /// is cleared alongside — is the backend's call, per provider.
+  pinCloudIdentity: (name: string, identity: string) =>
+    invoke<void>("pin_cloud_identity_cmd", { name, identity }),
 
   listResourceKinds: () => invoke<ResourceKind[]>("list_resource_kinds"),
   // CRD-derived dynamic kinds. Per-cluster (CRDs are cluster-local), so

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -1,0 +1,414 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { tokens } from "../theme";
+import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
+import { CloudIdentityNote } from "./CloudIdentityNote";
+import type { ConnectHint } from "../types";
+
+const t = tokens("dark");
+
+const GCLOUD: ConnectHint = {
+  provider: "gcloud",
+  title: "Unpinned Google account",
+  detail:
+    "This context has no --account, so it authenticates as your active gcloud account.",
+  authenticated_as: "ops@example.net",
+  identities: ["dev@example.com", "ops@example.net"],
+  active_identity: "dev@example.com",
+  pin: {
+    noun: "account",
+    effects: [
+      "add --account to this context's exec entry in your kubeconfig",
+      "keep a .ferrisscope-backup copy of the kubeconfig",
+      "delete ~/.kube/gke_gcloud_auth_plugin_cache",
+    ],
+  },
+};
+
+const AWS: ConnectHint = {
+  provider: "aws",
+  title: "Unpinned AWS profile",
+  detail: "This context names no profile, so it authenticates as dev.",
+  authenticated_as: "arn:aws:sts::111122223333:assumed-role/Dev/session",
+  identities: ["default", "dev"],
+  active_identity: "dev",
+  pin: {
+    noun: "profile",
+    effects: [
+      "set AWS_PROFILE in this context's exec env block in your kubeconfig",
+      "keep a .ferrisscope-backup copy of the kubeconfig",
+    ],
+  },
+};
+
+const AZURE: ConnectHint = {
+  provider: "azure",
+  title: "Ambient Azure account",
+  detail:
+    "kubelogin has no per-context account flag, so switch with `az account set --subscription <id>` and reconnect.",
+  authenticated_as: "ops@example.net",
+  identities: ["guest@example.com", "ops@example.net"],
+  active_identity: "ops@example.net",
+  // The whole point of the Azure case: nothing to write, so no button.
+  pin: null,
+};
+
+const REASON =
+  'apiserver liveness probe failed: User "ops@example.net" ... Forbidden';
+
+function renderNote(onReconnect = () => {}) {
+  return render(
+    <CloudIdentityNote
+      t={t}
+      contextId="default::prod"
+      reason={REASON}
+      onReconnect={onReconnect}
+    />,
+  );
+}
+
+beforeEach(() => {
+  resetMockInvoke();
+});
+
+describe("CloudIdentityNote", () => {
+  it("renders nothing when the backend doesn't recognise the failure", async () => {
+    setMockInvoke((cmd) => {
+      expect(cmd).toBe("connect_hint_cmd");
+      return null;
+    });
+
+    const { container } = render(
+      <CloudIdentityNote
+        t={t}
+        contextId="default::prod"
+        reason="connection refused"
+        onReconnect={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("renders nothing when the hint lookup itself fails", async () => {
+    // A broken hint lookup must never replace the real connect error, which is
+    // rendered by the banner above this component.
+    setMockInvoke(() => {
+      throw new Error("boom");
+    });
+
+    const { container } = renderNote();
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("passes the error verbatim and renders both identities", async () => {
+    let seenArgs: Record<string, unknown> | undefined;
+    setMockInvoke((cmd, args) => {
+      expect(cmd).toBe("connect_hint_cmd");
+      seenArgs = args;
+      return GCLOUD;
+    });
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unpinned Google account/)).toBeInTheDocument();
+    });
+    expect(seenArgs).toEqual({ name: "default::prod", error: REASON });
+    // Both identities are spelled out — the one the apiserver saw and the one
+    // the CLI would hand out now. (Scoped to the note because the same strings
+    // also appear as <option>s in the picker below.)
+    const note = screen.getByRole("note");
+    expect(note).toHaveTextContent("apiserver saw");
+    expect(note).toHaveTextContent("ops@example.net");
+    expect(note).toHaveTextContent("CLI active");
+    expect(note).toHaveTextContent("dev@example.com");
+    // The active identity is preselected — "pin me to what I'm on now" is the
+    // overwhelmingly likely intent. The `Select` atom is a button, so the
+    // selection shows as its label rather than a form value.
+    expect(screen.getByRole("combobox")).toHaveTextContent("dev@example.com");
+  });
+
+  it("requires the confirm step before pinning, then reconnects", async () => {
+    const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
+    setMockInvoke((cmd, args) => {
+      calls.push({ cmd, args });
+      return cmd === "connect_hint_cmd" ? GCLOUD : undefined;
+    });
+    const onReconnect = vi.fn();
+
+    renderNote(onReconnect);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^pin account$/i }),
+      ).toBeInTheDocument();
+    });
+
+    // First click only opens the confirm — it must not write anything.
+    fireEvent.click(screen.getByRole("button", { name: /^pin account$/i }));
+    expect(calls.some((c) => c.cmd === "pin_cloud_identity_cmd")).toBe(false);
+    // Every backend-declared effect is disclosed before the operator commits.
+    for (const effect of GCLOUD.pin?.effects ?? []) {
+      expect(screen.getByText(effect)).toBeInTheDocument();
+    }
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /pin dev@example\.com/i }),
+    );
+
+    await waitFor(() => expect(onReconnect).toHaveBeenCalledTimes(1));
+    expect(calls.at(-1)).toEqual({
+      cmd: "pin_cloud_identity_cmd",
+      args: { name: "default::prod", identity: "dev@example.com" },
+    });
+  });
+
+  it("blocks a second pin while the first is still in flight", async () => {
+    // This button rewrites the operator's kubeconfig. Two concurrent pins would
+    // both read the same snapshot, and the second would trip the backend's
+    // lost-update guard — surfacing "changed on disk" for what is really just a
+    // double-click.
+    const calls: string[] = [];
+    // Boxed so TypeScript doesn't narrow it to `null` at the call site below —
+    // it can't see that the Promise executor runs synchronously.
+    const release: { fn: (() => void) | null } = { fn: null };
+    setMockInvoke((cmd) => {
+      calls.push(cmd);
+      if (cmd === "connect_hint_cmd") return GCLOUD;
+      return new Promise<void>((resolve) => {
+        release.fn = () => resolve();
+      });
+    });
+
+    renderNote();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^pin account$/i })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^pin account$/i }));
+
+    const confirm = screen.getByRole("button", {
+      name: /pin dev@example\.com/i,
+    });
+    fireEvent.click(confirm);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /pinning…/i })).toBeDisabled(),
+    );
+    // Cancel is disabled too — backing out mid-write would leave the operator
+    // with no idea whether the file was rewritten.
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: /pinning…/i }));
+    release.fn?.();
+    await waitFor(() =>
+      expect(calls.filter((c) => c === "pin_cloud_identity_cmd")).toHaveLength(
+        1,
+      ),
+    );
+  });
+
+  it("cancelling the confirm writes nothing", async () => {
+    const calls: string[] = [];
+    setMockInvoke((cmd) => {
+      calls.push(cmd);
+      return cmd === "connect_hint_cmd" ? GCLOUD : undefined;
+    });
+
+    renderNote();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^pin account$/i })).toBeTruthy(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^pin account$/i }));
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    // Back to the picker, nothing written.
+    expect(
+      screen.getByRole("button", { name: /^pin account$/i }),
+    ).toBeTruthy();
+    expect(calls).not.toContain("pin_cloud_identity_cmd");
+  });
+
+  it("drops the previous cluster's identities when the context changes", async () => {
+    // The note is mounted inside a banner that survives a cluster-tab switch.
+    // Leaving the old hint on screen would offer to pin *this* context to an
+    // account discovered for a different one.
+    setMockInvoke((cmd, args) => {
+      if (cmd !== "connect_hint_cmd") return undefined;
+      return (args as { name: string }).name === "default::prod"
+        ? GCLOUD
+        : AWS;
+    });
+
+    const { rerender } = render(
+      <CloudIdentityNote
+        t={t}
+        contextId="default::prod"
+        reason={REASON}
+        onReconnect={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("note")).toHaveTextContent(
+        "Unpinned Google account",
+      ),
+    );
+
+    rerender(
+      <CloudIdentityNote
+        t={t}
+        contextId="default::other"
+        reason={REASON}
+        onReconnect={() => {}}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("note")).toHaveTextContent(
+        "Unpinned AWS profile",
+      ),
+    );
+    expect(screen.getByRole("note")).not.toHaveTextContent(
+      "Unpinned Google account",
+    );
+  });
+
+  it("never preselects an identity the picker cannot show", async () => {
+    // gcloud builds `identities` from `legacy_credentials/` and
+    // `active_identity` from the configuration file, so `gcloud auth revoke`
+    // leaves an active account with no credentials and no matching option.
+    // Unclamped, the picker renders blank while the enabled button writes that
+    // invisible account into the kubeconfig.
+    const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
+    setMockInvoke((cmd, args) => {
+      calls.push({ cmd, args });
+      return cmd === "connect_hint_cmd"
+        ? { ...GCLOUD, active_identity: "revoked@example.com" }
+        : undefined;
+    });
+
+    renderNote();
+    await waitFor(() =>
+      expect(screen.getByRole("combobox")).toBeInTheDocument(),
+    );
+    // Falls back to the first offered identity, not the phantom active one.
+    expect(screen.getByRole("combobox")).toHaveTextContent("dev@example.com");
+
+    fireEvent.click(screen.getByRole("button", { name: /^pin account$/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /pin dev@example\.com/i }),
+    );
+    await waitFor(() =>
+      expect(calls.at(-1)?.args).toEqual({
+        name: "default::prod",
+        identity: "dev@example.com",
+      }),
+    );
+  });
+
+  it("pins the identity the operator selected, not the default", async () => {
+    const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
+    setMockInvoke((cmd, args) => {
+      calls.push({ cmd, args });
+      return cmd === "connect_hint_cmd" ? GCLOUD : undefined;
+    });
+
+    renderNote();
+
+    await waitFor(() =>
+      expect(screen.getByRole("combobox")).toBeInTheDocument(),
+    );
+    // jsdom has no layout, so the Select's scroll-into-view is a no-op here.
+    Element.prototype.scrollIntoView ??= () => {};
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(
+      screen.getByRole("option", { name: "ops@example.net" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^pin account$/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /pin ops@example\.net/i }),
+    );
+
+    await waitFor(() => {
+      expect(calls.at(-1)?.args).toEqual({
+        name: "default::prod",
+        identity: "ops@example.net",
+      });
+    });
+  });
+
+  it("takes its wording from the provider — AWS says profile, not account", async () => {
+    const calls: { cmd: string; args?: Record<string, unknown> }[] = [];
+    setMockInvoke((cmd, args) => {
+      calls.push({ cmd, args });
+      return cmd === "connect_hint_cmd" ? AWS : undefined;
+    });
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^pin profile$/i }),
+      ).toBeInTheDocument();
+    });
+    // No gcloud vocabulary leaks into the AWS case.
+    const note = screen.getByRole("note");
+    expect(note).not.toHaveTextContent(/account/i);
+    expect(note).toHaveTextContent(
+      "arn:aws:sts::111122223333:assumed-role/Dev/session",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^pin profile$/i }));
+    // The AWS confirm must not mention a token cache — there isn't one.
+    expect(screen.queryByText(/plugin_cache/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /pin dev/i }));
+
+    await waitFor(() => {
+      expect(calls.at(-1)).toEqual({
+        cmd: "pin_cloud_identity_cmd",
+        args: { name: "default::prod", identity: "dev" },
+      });
+    });
+  });
+
+  it("offers no pin UI at all when the provider has none (Azure)", async () => {
+    setMockInvoke((cmd) => {
+      expect(cmd).toBe("connect_hint_cmd");
+      return AZURE;
+    });
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ambient Azure account/)).toBeInTheDocument();
+    });
+    // No picker, no button — the remedy is prose, because kubelogin has no
+    // per-context account flag to write.
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByRole("note")).toHaveTextContent("az account set");
+  });
+
+  it("surfaces a failed pin without losing the note", async () => {
+    setMockInvoke((cmd) => {
+      if (cmd === "connect_hint_cmd") return GCLOUD;
+      throw new Error("kubeconfig is read-only");
+    });
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^pin account$/i }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^pin account$/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /pin dev@example\.com/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/kubeconfig is read-only/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Unpinned Google account/)).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../api";
+import type { ConnectHint } from "../types";
+import type { Tokens } from "../theme";
+import { FS_SM } from "../theme";
+import { Btn, Chip, Select } from "./ui";
+import { Mono } from "./detail/primitives";
+
+// Small amber note under a failed connect, shown only when the backend
+// recognises cloud identity drift: a context whose exec entry pins no
+// account/profile, so it authenticates as whichever identity the cloud CLI last
+// selected — and that changes under the operator.
+//
+// Provider-neutral by construction. Every string that differs between GKE, EKS
+// and AKS (the noun, the prose, what a pin would write) arrives in the hint;
+// this file only knows how to lay it out. Notably `hint.pin` is null for Azure,
+// because kubelogin has no per-context account flag — the note then explains the
+// `az` command instead of offering a button that would write the wrong thing.
+//
+// All the judgement lives in Rust (`cloud_identity::hint_for_context`) — this
+// renders whatever comes back and renders nothing when the answer is null, which
+// is the case for every other kind of connect failure.
+export function CloudIdentityNote({
+  t,
+  contextId,
+  reason,
+  onReconnect,
+}: {
+  t: Tokens;
+  /// Composite context id (e.g. "default::prod") — the same value passed to
+  /// connect. The backend extracts the context name from it.
+  contextId: string;
+  /// The connect error, verbatim. The backend parses the authenticated identity
+  /// out of it, so it must not be pre-cleaned.
+  reason: string;
+  /// Called after a successful pin so the caller can retry the connection.
+  onReconnect: () => void;
+}) {
+  const [hint, setHint] = useState<ConnectHint | null>(null);
+  const [identity, setIdentity] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+  const [pinning, setPinning] = useState(false);
+  const [pinError, setPinError] = useState<string | null>(null);
+  // The pin outlives the hint effect's own `live` flag: it can still be in
+  // flight when the operator switches cluster and unmounts this note. Guard its
+  // settle handlers with a mount flag so a resolved (or rejected) pin doesn't
+  // write state into a torn-down component.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let live = true;
+    setHint(null);
+    setIdentity(null);
+    setConfirming(false);
+    setPinError(null);
+    api
+      .connectHint(contextId, reason)
+      .then((h) => {
+        if (!live) return;
+        setHint(h);
+        // Preselect the active identity — the most likely intent is "make this
+        // context always use the one I'm on right now".
+        //
+        // Clamped to something the picker actually lists. For gcloud the two
+        // fields come from different places: `identities` is the
+        // `legacy_credentials/` directory listing, `active_identity` is
+        // `[core] account` from the configuration file. `gcloud auth revoke`
+        // removes the former and leaves the latter, so the active account can
+        // name a credential that no longer exists. Unclamped, the <select>
+        // would render blank (no matching option) while the enabled Pin button
+        // wrote that invisible account into the kubeconfig — leaving the
+        // context strictly worse off than the 403 it started with.
+        const offered = h?.identities ?? [];
+        const active = h?.active_identity;
+        setIdentity(
+          (active && offered.includes(active) ? active : offered[0]) ?? null,
+        );
+      })
+      .catch(() => {
+        // A failed hint lookup must never replace the real connect error.
+        if (live) setHint(null);
+      });
+    return () => {
+      live = false;
+    };
+  }, [contextId, reason]);
+
+  if (!hint) return null;
+
+  const pin = hint.pin;
+  const doPin = () => {
+    if (!identity) return;
+    setPinning(true);
+    setPinError(null);
+    api
+      .pinCloudIdentity(contextId, identity)
+      .then(() => {
+        if (!mountedRef.current) return;
+        setConfirming(false);
+        onReconnect();
+      })
+      .catch((e: unknown) => {
+        if (mountedRef.current) setPinError(String(e));
+      })
+      .finally(() => {
+        if (mountedRef.current) setPinning(false);
+      });
+  };
+
+  return (
+    <div
+      role="note"
+      style={{
+        marginTop: 8,
+        padding: "8px 10px",
+        borderRadius: "var(--fs-radius-md, 6px)",
+        background: t.warnSoft,
+        border: `1px solid ${t.warn}`,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+        fontSize: FS_SM,
+      }}
+    >
+      <div style={{ color: t.warn, fontWeight: 600 }}>{hint.title}</div>
+      <div style={{ color: t.text }}>{hint.detail}</div>
+
+      {hint.authenticated_as && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+            flexWrap: "wrap",
+          }}
+        >
+          <span style={{ color: t.textDim }}>apiserver saw</span>
+          <Chip t={t} tone="warn" mono>
+            {hint.authenticated_as}
+          </Chip>
+          {hint.active_identity && (
+            <>
+              <span style={{ color: t.textDim }}>· CLI active</span>
+              <Chip t={t} mono>
+                {hint.active_identity}
+              </Chip>
+            </>
+          )}
+        </div>
+      )}
+
+      {pin && hint.identities.length > 0 && !confirming && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            flexWrap: "wrap",
+          }}
+        >
+          <span style={{ color: t.textDim }}>Pin this context to</span>
+          {/* The `Select` atom rather than a native <select>: the native
+              popover list is drawn by the OS, so it ignores our tokens and
+              renders a light list with OS scrollbars on a dark theme. It also
+              avoids a hardcoded DOM id, which would collide if two banners
+              ever mounted at once. */}
+          <Select<string>
+            t={t}
+            value={identity ?? ""}
+            onChange={setIdentity}
+            options={hint.identities.map((a) => ({ value: a, label: a }))}
+            fullWidth={false}
+            style={{ minWidth: 220 }}
+          />
+          <Btn
+            t={t}
+            variant="secondary"
+            size="sm"
+            disabled={!identity}
+            onClick={() => setConfirming(true)}
+          >
+            Pin {pin.noun}
+          </Btn>
+        </div>
+      )}
+
+      {pin && confirming && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {/* Every effect named up front — this rewrites a file the operator
+              owns, and for gcloud also drops a cache other tools share. The
+              list comes from the backend so the disclosure can't drift out of
+              sync with what the pin actually does. */}
+          <div style={{ color: t.text }}>
+            Pin this context to <Mono>{identity}</Mono>? This will:
+          </div>
+          <ul style={{ margin: 0, paddingInlineStart: 18, color: t.text }}>
+            {pin.effects.map((e) => (
+              <li key={e}>{e}</li>
+            ))}
+          </ul>
+          <div style={{ display: "flex", gap: 8 }}>
+            <Btn
+              t={t}
+              variant="primary"
+              size="sm"
+              disabled={pinning}
+              onClick={doPin}
+            >
+              {pinning ? "Pinning…" : `Pin ${identity}`}
+            </Btn>
+            <Btn
+              t={t}
+              variant="secondary"
+              size="sm"
+              disabled={pinning}
+              onClick={() => setConfirming(false)}
+            >
+              Cancel
+            </Btn>
+          </div>
+        </div>
+      )}
+
+      {pinError && <div style={{ color: t.bad }}>{pinError}</div>}
+    </div>
+  );
+}

--- a/ui/src/components/ClusterPanel.test.tsx
+++ b/ui/src/components/ClusterPanel.test.tsx
@@ -5,10 +5,26 @@
 // shows the busy progress banner instead of the terminal one.
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { UnavailableOverlay, ReconnectBanner } from "./ClusterPanel";
+import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
+import type { ContextInfo } from "../types";
 
-afterEach(cleanup);
+const CTX = {
+  id: "default::prod",
+  name: "prod",
+} as ContextInfo;
+
+afterEach(() => {
+  cleanup();
+  resetMockInvoke();
+});
 
 describe("UnavailableOverlay", () => {
   it("keeps the table interactive (dim, but no pointer-events:none)", () => {
@@ -65,6 +81,127 @@ describe("UnavailableOverlay", () => {
     expect(screen.queryByText("Cluster unavailable")).toBeNull();
     fireEvent.click(screen.getByText("Reconnect now"));
     expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers Diagnose on the terminal banner when given a context", () => {
+    // A cluster can go unavailable because the operator's cloud identity
+    // drifted mid-session (the heartbeat starts getting 403s) — the same
+    // problem the connect-failure banner explains, so it gets the same
+    // affordances rather than a dead end.
+    setMockInvoke(() => null); // CloudIdentityNote's hint lookup: no note
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable
+        reason="namespaces is forbidden: Forbidden"
+        onReconnect={() => {}}
+        autoReconnect={null}
+        diagnoseContext={CTX}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    expect(screen.getByRole("button", { name: /diagnose/i })).toBeTruthy();
+  });
+
+  it("mounts the cloud-identity note on the terminal banner", async () => {
+    // The wiring, not the component. Both are individually well covered, but
+    // the seam between them was not: the whole `<CloudIdentityNote>` block
+    // could be deleted from ClusterPanel and every test stayed green, so the
+    // feature could ship entirely disconnected.
+    setMockInvoke((cmd) =>
+      cmd === "connect_hint_cmd"
+        ? {
+            provider: "gcloud",
+            title: "Unpinned Google account",
+            detail: "This context names no account.",
+            authenticated_as: "ops@example.net",
+            identities: ["dev@example.com", "ops@example.net"],
+            active_identity: "dev@example.com",
+            pin: { noun: "account", effects: ["rewrite the kubeconfig"] },
+          }
+        : null,
+    );
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable
+        reason="namespaces is forbidden: Forbidden"
+        onReconnect={() => {}}
+        autoReconnect={null}
+        diagnoseContext={CTX}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole("note")).toHaveTextContent(
+        "Unpinned Google account",
+      ),
+    );
+  });
+
+  it("does not mount the note without a context to identify", async () => {
+    // `diagnoseContext` is what carries the context id the hint lookup needs.
+    // Without it there is nothing to ask the backend about.
+    setMockInvoke(() => {
+      throw new Error("connect_hint_cmd must not be called");
+    });
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable
+        reason="namespaces is forbidden: Forbidden"
+        onReconnect={() => {}}
+        autoReconnect={null}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    expect(screen.queryByRole("note")).toBeNull();
+  });
+
+  it("never feeds the note its own placeholder prose", async () => {
+    // The terminal banner substitutes app-authored text when the backend gave
+    // it no reason. The backend parses the authenticated identity out of the
+    // string it receives, so handing it our own sentence would be a lie it has
+    // to parse — the note must simply not mount.
+    setMockInvoke(() => {
+      throw new Error("connect_hint_cmd must not be called");
+    });
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable
+        reason={null}
+        onReconnect={() => {}}
+        autoReconnect={null}
+        diagnoseContext={CTX}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    // The placeholder still shows — it's the banner's job to say *something*.
+    expect(screen.getByText(/No response from the apiserver/)).toBeTruthy();
+    expect(screen.queryByRole("note")).toBeNull();
+  });
+
+  it("hides Diagnose while a retry session is still running", () => {
+    // Mid-retry there is nothing to act on yet; the affordance appears once the
+    // session gives up and the terminal banner takes over.
+    render(
+      <UnavailableOverlay
+        mode="dark"
+        unavailable
+        reason="timeout"
+        onReconnect={() => {}}
+        autoReconnect={{ attempt: 1, max: 3 }}
+        diagnoseContext={CTX}
+      >
+        <button data-testid="row">row</button>
+      </UnavailableOverlay>,
+    );
+    expect(screen.queryByRole("button", { name: /diagnose/i })).toBeNull();
   });
 });
 

--- a/ui/src/components/ClusterPanel.tsx
+++ b/ui/src/components/ClusterPanel.tsx
@@ -9,6 +9,7 @@ import {
 import { ClusterBar } from "./ClusterBar";
 import { ResourceTable } from "./ResourceTable";
 import { ConnectionDiagnosticsModal } from "./ConnectionDiagnosticsModal";
+import { CloudIdentityNote } from "./CloudIdentityNote";
 import { Btn, EmptyState, ErrorBlock, LoadingLine } from "./ui";
 
 type Props = {
@@ -61,6 +62,7 @@ export function ClusterPanel({ mode, context }: Props) {
             reason={healthReason}
             onReconnect={reconnect}
             autoReconnect={autoReconnect}
+            diagnoseContext={context}
           >
             {selectedKind ? (
               <ResourceTable
@@ -170,6 +172,7 @@ function ConnectingLabel({
 export function ReconnectBanner({
   title,
   reason,
+  hintReason,
   onReconnect,
   diagnoseContext,
   busy = false,
@@ -178,6 +181,13 @@ export function ReconnectBanner({
   mode: ThemeMode;
   title: string;
   reason: string | null;
+  /// The connect error *verbatim*, for `CloudIdentityNote` to parse. Kept
+  /// separate from `reason` because callers substitute app-authored prose
+  /// there when the backend gave them nothing ("No response from the apiserver
+  /// for 30s…"), and the backend extracts the authenticated identity out of
+  /// this string — feeding it our own sentence would be a lie it has to parse.
+  /// Defaults to `reason` where the two genuinely are the same value.
+  hintReason?: string | null;
   onReconnect: () => void;
   /// When set, renders a "Diagnose" button that opens passive connection
   /// diagnostics for this context. Omitted where diagnosis makes no sense
@@ -238,6 +248,18 @@ export function ReconnectBanner({
             />
           </div>
         )}
+        {/* Gated on the same prop as the Diagnose button, so the note only
+            appears on the terminal "could not connect" banner — not mid
+            auto-reconnect, and not on a cancelled connect. Renders nothing
+            unless the backend recognises cloud identity drift. */}
+        {diagnoseContext && (hintReason ?? reason) && (
+          <CloudIdentityNote
+            t={t}
+            contextId={diagnoseContext.id}
+            reason={(hintReason ?? reason) as string}
+            onReconnect={onReconnect}
+          />
+        )}
       </div>
       {diagnoseContext && (
         <Btn
@@ -278,6 +300,7 @@ export function UnavailableOverlay({
   reason,
   onReconnect,
   autoReconnect,
+  diagnoseContext,
   children,
 }: {
   mode: ThemeMode;
@@ -287,6 +310,12 @@ export function UnavailableOverlay({
   /// Non-null while a silent auto-reconnect session is retrying — swaps the
   /// terminal "Cluster unavailable" banner for the busy progress variant.
   autoReconnect: { attempt: number; max: number } | null;
+  /// Enables Diagnose + the cloud-identity note on the *terminal* banner. A
+  /// cluster can go unavailable because the operator's cloud identity drifted
+  /// mid-session (the heartbeat starts getting 403s), which is the same problem
+  /// the connect-failure banner explains — so it gets the same affordances.
+  /// Omitted while retrying: nothing to act on until the session gives up.
+  diagnoseContext?: ContextInfo;
   children: ReactNode;
 }) {
   // Show the overlay through the whole session: a wedged cluster's retry may
@@ -323,7 +352,9 @@ export function UnavailableOverlay({
             reason ??
             "No response from the apiserver for 30s. Watchers and metrics have been torn down."
           }
+          hintReason={reason}
           onReconnect={onReconnect}
+          diagnoseContext={diagnoseContext}
         />
       )}
       <div

--- a/ui/src/components/ui/atoms.tsx
+++ b/ui/src/components/ui/atoms.tsx
@@ -137,7 +137,7 @@ export function Chip({
     tone === "accent"
       ? { bg: t.accentSoft, fg: t.accent }
       : tone === "warn"
-        ? { bg: "rgba(245,158,11,0.14)", fg: t.warn }
+        ? { bg: t.warnSoft, fg: t.warn }
         : { bg: t.chip, fg: t.textDim };
   return (
     <span

--- a/ui/src/lib/connectFailure.test.ts
+++ b/ui/src/lib/connectFailure.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { isPermanentConnectFailure } from "./connectFailure";
+
+// The message shape that actually reaches the frontend: connect_context wraps
+// the kube error, which Debug-prints the whole Status struct.
+const RBAC_403 =
+  'apiserver liveness probe failed: ApiError: namespaces is forbidden: User "ops@example.net" ' +
+  'cannot list resource "namespaces" in API group "" at the cluster scope: Forbidden ' +
+  '(Status { status: Some(Failure), code: 403, reason: "Forbidden" })';
+
+describe("isPermanentConnectFailure", () => {
+  it("treats an RBAC 403 as permanent", () => {
+    // The whole point: retrying this with the same credentials produces the
+    // same answer, so auto-reconnect must not spend its budget on it.
+    expect(isPermanentConnectFailure(RBAC_403)).toBe(true);
+    expect(isPermanentConnectFailure("403 Forbidden")).toBe(true);
+  });
+
+  it("treats transient failures as retryable", () => {
+    for (const msg of [
+      "apiserver did not respond within 8s — cluster may be unreachable",
+      "timed out after 15s",
+      "error trying to connect: tcp connect error: Connection refused",
+      "probe timed out after 4s",
+      "hyper::Error(IncompleteMessage)",
+    ]) {
+      expect(isPermanentConnectFailure(msg), msg).toBe(false);
+    }
+  });
+
+  it("does not treat a 401 as permanent", () => {
+    // A reconnect rebuilds Config and re-runs the exec credential plugin, so an
+    // expired token genuinely can heal on retry. Stranding it on a manual
+    // banner would be the worse error.
+    expect(
+      isPermanentConnectFailure('ApiError: Unauthorized (Status { code: 401 })'),
+    ).toBe(false);
+  });
+
+  it("does not match a digit run that merely contains 403", () => {
+    // The realistic false positive: a port. Matching it would strand a genuinely
+    // transient failure on the manual banner instead of retrying.
+    for (const msg of [
+      "error trying to connect: tcp connect error: 127.0.0.1:8403: Connection refused",
+      "apiserver did not respond: dial tcp 10.40.3.7:6443: i/o timeout",
+      "port 40300 unreachable",
+    ]) {
+      expect(isPermanentConnectFailure(msg), msg).toBe(false);
+    }
+  });
+
+  it("does not mistake a 422 field-immutability error for an RBAC denial", () => {
+    // Kubernetes embeds "Forbidden:" inside 422 validation messages. Matching
+    // that as an authorization failure would suppress retries for something
+    // that isn't an auth problem at all.
+    expect(
+      isPermanentConnectFailure(
+        'Pod "x" is invalid: spec: Forbidden: pod updates may not change fields other than image',
+      ),
+    ).toBe(false);
+    expect(
+      isPermanentConnectFailure("spec.selector: Forbidden: field is immutable"),
+    ).toBe(false);
+  });
+});

--- a/ui/src/lib/connectFailure.ts
+++ b/ui/src/lib/connectFailure.ts
@@ -1,0 +1,56 @@
+// Is a connect failure worth retrying?
+//
+// Auto-reconnect exists for *wedged* clusters: a stalled HTTP/2 pool, a dead
+// apiserver, a flapping LB. Those recover, and the backend documents a rebuilt
+// client as the only clean path out (crates/core/src/health.rs). Retrying is
+// the right reflex there.
+//
+// It is the wrong reflex for an authorization failure. An RBAC 403 is
+// deterministic: the same credentials produce the same 403 on attempt 10 as on
+// attempt 1. Retrying burns the whole backoff budget (~4 minutes) and — worse —
+// holds the UI on the busy "Reconnecting…" banner, which carries neither the
+// Diagnose button nor the cloud-identity note that would tell the operator
+// their kubeconfig context is authenticating as the wrong account. The one
+// screen that explains the failure is the one the retry loop hides.
+
+/// Does this connect failure mean "retrying is unlikely to change anything"?
+///
+/// Deliberately narrow — only RBAC 403s. In particular a **401 is not**
+/// included: a reconnect rebuilds `Config` and re-runs the exec credential
+/// plugin, so an expired token genuinely can heal on retry.
+///
+/// "Permanent" is a judgement about the *common* case, not a guarantee. Some
+/// 403s do heal on their own: a freshly granted GCP IAM binding can take
+/// minutes to propagate, an authorization webhook that is down returns 403
+/// until it recovers, and a corporate proxy serves an HTML 403 when the VPN
+/// drops. Those get one attempt instead of ten. That is the deliberate trade:
+/// the terminal banner carries a live Reconnect button and the cloud-identity
+/// note, so a false "permanent" costs one click, while a false "transient"
+/// costs four minutes behind a spinner that explains nothing.
+export function isPermanentConnectFailure(message: string): boolean {
+  const m = message.toLowerCase();
+  // Kubernetes embeds "Forbidden:" *inside* HTTP 422 validation messages to
+  // mean "this field can't be changed". That is not an authorization failure
+  // and must be excluded first — the same ordering guard `classifyDetailError`
+  // (components/ui/atoms.tsx) and `cloud_identity::is_forbidden` both apply.
+  //
+  // The 422 test needs the same word boundaries as the 403 test below, and for
+  // a sharper reason: a 403 message is *full* of long digit runs that can
+  // contain "422" by chance — a 12-digit AWS account id in an assumed-role ARN,
+  // a 21-digit GCP service-account id, a resourceVersion. A bare
+  // `includes("422")` on any of those silently misfiles a real RBAC denial as
+  // retryable, which disables both halves of this feature for that operator
+  // permanently and invisibly.
+  if (
+    m.includes("is invalid") ||
+    /\b422\b/.test(m) ||
+    m.includes("may not change") ||
+    m.includes("immutable")
+  ) {
+    return false;
+  }
+  // Word boundaries, not bare substrings. `includes("403")` matches the port in
+  // "connection refused (127.0.0.1:8403)" — a transient failure that would then
+  // be stranded on a manual banner instead of retrying.
+  return /\bforbidden\b/.test(m) || /\b403\b/.test(m);
+}

--- a/ui/src/lib/useClusterConnection.test.ts
+++ b/ui/src/lib/useClusterConnection.test.ts
@@ -229,3 +229,115 @@ describe("useClusterConnection auto-reconnect", () => {
     expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBeUndefined();
   });
 });
+
+// --- Permanent-failure gating ------------------------------------------
+//
+// Regression: an RBAC 403 used to start a full silent retry session — MAX
+// attempts with exponential backoff, minutes long — even though the same
+// credentials produce the same 403 every time. While that session ran the panel
+// showed the busy "Reconnecting…" banner, which carries neither the Diagnose
+// button nor the cloud-identity note. The one screen explaining "this context
+// is authenticating as the wrong account" was hidden by a loop that could never
+// succeed, and an operator reading it lost it mid-read.
+describe("useClusterConnection permanent-failure gating", () => {
+  const FORBIDDEN: ClusterHealthEvent = {
+    status: "unavailable",
+    reason:
+      'ApiError: namespaces is forbidden: User "ops@example.net" cannot list ' +
+      'resource "namespaces": Forbidden (Status { code: 403 })',
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    healthHandler = null;
+    connectContext.mockReset().mockResolvedValue({ server_version: "v1" });
+    cancelConnect.mockClear();
+    reconnectCluster.mockClear().mockResolvedValue(undefined);
+    useAppStore.setState({
+      ...initial,
+      clusterHealth: {},
+      clusterHealthReason: {},
+      clusterReconnecting: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts no retry session when the cluster goes unavailable with a 403", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    fireHealth(FORBIDDEN);
+    await flush(backoff(0) * 4);
+
+    // No busy banner and no rebuilt client, so the terminal banner (Diagnose +
+    // cloud-identity note) stays put for as long as the operator needs it.
+    expect(result.current.autoReconnect).toBeNull();
+    expect(reconnectCluster).not.toHaveBeenCalled();
+    // The health flag still reflects reality — only the *retrying* flag is off,
+    // which is what routes the UI to the terminal banner.
+    expect(useAppStore.getState().clusterHealth[CTX.id]).toBe("unavailable");
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBeUndefined();
+  });
+
+  it("still retries a transient unavailable (the gate must stay narrow)", async () => {
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    fireHealth(UNAVAIL);
+    // Armed immediately, exactly as before the gate existed.
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBe(true);
+
+    await flush(backoff(0));
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+  });
+
+  it("ends an in-flight retry session as soon as an attempt comes back 403", async () => {
+    // Happens in the field: the cluster is hard-down so a session is running,
+    // then the operator switches cloud account and every attempt starts being
+    // denied. The remaining attempts are pointless and must be abandoned.
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    connectContext.mockRejectedValue(new Error("connection refused"));
+    fireHealth(UNAVAIL);
+    await flush(backoff(0));
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+    expect(result.current.autoReconnect).not.toBeNull();
+
+    // Identity drifts: every subsequent connect is denied.
+    connectContext.mockRejectedValue(new Error(FORBIDDEN.reason ?? ""));
+    await flush(backoff(1));
+
+    expect(reconnectCluster).toHaveBeenCalledTimes(2);
+    expect(result.current.autoReconnect).toBeNull();
+    expect(useAppStore.getState().clusterReconnecting[CTX.id]).toBeUndefined();
+
+    // And it stays abandoned — no further attempts trickle in.
+    await flush(backoff(2) + backoff(3) + 30_000);
+    expect(reconnectCluster).toHaveBeenCalledTimes(2);
+  });
+
+  it("a failed first connect arms no retry session at all", async () => {
+    // Not a test of the permanent-failure gate, despite the 403: a first
+    // connect has no session, so `onConnectResolved` returns at the
+    // `!sessionActiveRef` guard before the gate is ever consulted, and this
+    // passes with the gate deleted. Kept because the *behaviour* is worth
+    // pinning — retries are armed by the health probe, never by the initial
+    // connect — but named so it can't be mistaken for gate coverage. The gate
+    // itself is covered by the two tests above.
+    connectContext.mockRejectedValue(
+      new Error("namespaces is forbidden: Forbidden (code: 403)"),
+    );
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    expect(result.current.state.status).toBe("error");
+    await flush(backoff(0) * 4);
+    expect(result.current.autoReconnect).toBeNull();
+    expect(reconnectCluster).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/lib/useClusterConnection.ts
+++ b/ui/src/lib/useClusterConnection.ts
@@ -1,4 +1,5 @@
 import { logErr } from "./log";
+import { isPermanentConnectFailure } from "./connectFailure";
 import { useEffect, useRef, useState } from "react";
 import { api, onClusterHealth, onClusterInfoChanged } from "../api";
 import { useAppStore } from "../store";
@@ -106,8 +107,8 @@ export function useClusterConnection(context: ContextInfo): {
   // setters above (React state setters and zustand actions are referentially
   // stable), and reads the *current* context id through cidRef.
   const ctlRef = useRef<{
-    onUnavailable: () => void;
-    onConnectResolved: (result: "ok" | "error") => void;
+    onUnavailable: (reason: string | null) => void;
+    onConnectResolved: (result: "ok" | "error", message?: string) => void;
     reset: (resetCounter: boolean) => void;
   } | null>(null);
   if (ctlRef.current === null) {
@@ -168,18 +169,32 @@ export function useClusterConnection(context: ContextInfo): {
     };
 
     ctlRef.current = {
-      onUnavailable() {
+      onUnavailable(reason) {
         // A wedged cluster re-flagging cancels any pending recovery dwell.
         if (dwellTimerRef.current != null) {
           window.clearTimeout(dwellTimerRef.current);
           dwellTimerRef.current = null;
         }
+        // An RBAC 403 won't heal by reconnecting — the probe is being denied,
+        // not dropped. Retrying would spend the whole backoff budget and hide
+        // the terminal banner (Diagnose + cloud-identity note) behind the busy
+        // one for minutes. Hand straight to the manual banner instead.
+        if (reason != null && isPermanentConnectFailure(reason)) {
+          endSession(true);
+          return;
+        }
         scheduleNext(); // starts the session on the first unavailable; advances it after
       },
-      onConnectResolved(result) {
+      onConnectResolved(result, message) {
         attemptInFlightRef.current = false;
         if (!sessionActiveRef.current) return; // no active session → normal behaviour
         if (result === "error") {
+          // Same reasoning as onUnavailable: a deterministic authorization
+          // failure ends the session rather than consuming another attempt.
+          if (message != null && isPermanentConnectFailure(message)) {
+            endSession(true);
+            return;
+          }
           // Hard-down: the connect itself failed, so drive the next attempt now
           // (no unavailable event will arrive — there's no live probe).
           scheduleNext();
@@ -273,7 +288,7 @@ export function useClusterConnection(context: ContextInfo): {
     onClusterHealth(context.id, (evt) => {
       if (cancelled) return;
       applyClusterHealth(context.id, evt.status, evt.reason);
-      if (evt.status === "unavailable") ctlRef.current?.onUnavailable();
+      if (evt.status === "unavailable") ctlRef.current?.onUnavailable(evt.reason);
     }).then((fn) => {
       if (cancelled) fn();
       else unlistenHealth = fn;
@@ -309,7 +324,7 @@ export function useClusterConnection(context: ContextInfo): {
           setState({ status: "cancelled" });
         } else {
           setState({ status: "error", message });
-          ctlRef.current?.onConnectResolved("error");
+          ctlRef.current?.onConnectResolved("error", message);
         }
       });
     // Effect cleanup runs on context change *and* unmount. Either way the

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -115,6 +115,9 @@ export type Tokens = {
   // may re-tone them to match its character.
   good: string;
   warn: string;
+  /// Low-opacity wash of `warn`, for the background of warning surfaces
+  /// (inline notes, warn chips). Mirrors the `accentSoft` convention.
+  warnSoft: string;
   bad: string;
   info: string;
   unknown: string;
@@ -260,6 +263,7 @@ const DEFAULT_LIGHT: ColorTokens = {
   bulkBg: "#11161d",
   good: "#10b981",
   warn: "#f59e0b",
+  warnSoft: "rgba(245,158,11,0.12)",
   bad: "#f43f5e",
   info: "#3b82f6",
   unknown: "#94a3b8",
@@ -291,6 +295,7 @@ const DEFAULT_DARK: ColorTokens = {
   bulkBg: "#161a20",
   good: "#10b981",
   warn: "#f59e0b",
+  warnSoft: "rgba(245,158,11,0.14)",
   bad: "#f43f5e",
   info: "#3b82f6",
   unknown: "#64748b",
@@ -427,6 +432,7 @@ const LENS_LIGHT: ColorTokens = {
   bulkBg: "#0f172a",
   good: "#16a34a",
   warn: "#f59e0b",
+  warnSoft: "rgba(245,158,11,0.12)",
   bad: "#dc2626",
   info: "#2563eb",
   unknown: "#94a3b8",
@@ -458,6 +464,7 @@ const LENS_DARK: ColorTokens = {
   bulkBg: "#262a30",
   good: "#22c55e",
   warn: "#f59e0b",
+  warnSoft: "rgba(245,158,11,0.14)",
   bad: "#ef4444",
   info: "#3b82f6",
   unknown: "#64748b",
@@ -573,6 +580,7 @@ const VSCODE_DARK_PLUS: ColorTokens = {
   bulkBg: "#252526",
   good: "#89d185",
   warn: "#cca700",
+  warnSoft: "rgba(204,167,0,0.16)",
   bad: "#f48771",
   info: "#75beff",
   unknown: "#858585",
@@ -608,6 +616,7 @@ const VSCODE_LIGHT_PLUS: ColorTokens = {
   bulkBg: "#1e1e1e",
   good: "#388a34",
   warn: "#bf8803",
+  warnSoft: "rgba(191,136,3,0.14)",
   bad: "#a1260d",
   info: "#0078d4",
   unknown: "#616161",
@@ -718,6 +727,7 @@ const READABLE_LIGHT: ColorTokens = {
   bulkBg: "#1c1a17",
   good: "#15803d",
   warn: "#b45309",
+  warnSoft: "rgba(180,83,9,0.12)",
   bad: "#b91c1c",
   info: "#1d4ed8",
   unknown: "#78716c",
@@ -749,6 +759,7 @@ const READABLE_DARK: ColorTokens = {
   bulkBg: "#22201c",
   good: "#4ade80",
   warn: "#fbbf24",
+  warnSoft: "rgba(251,191,36,0.16)",
   bad: "#fb7185",
   info: "#60a5fa",
   unknown: "#a8a29e",

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -153,6 +153,40 @@ export type ConnectionDiagnostics = {
   env_presence: EnvPresence[];
 };
 
+/// Which cloud CLI's identity model a context is on.
+/// Mirrors `ferrisscope_core::cloud_identity::Provider`.
+export type CloudProvider = "gcloud" | "aws" | "azure";
+
+/// What a pin will write, when the provider supports one at all.
+/// Mirrors `ferrisscope_core::cloud_identity::PinOffer`.
+export type PinOffer = {
+  /// What the identity is called for this provider — "account", "profile".
+  /// Drives the button label so the UI carries no per-provider wording.
+  noun: string;
+  /// Everything the pin will do, one complete phrase per effect, rendered
+  /// verbatim in the confirm step.
+  effects: string[];
+};
+
+/// Actionable note attached to a failed connect when the cause looks like cloud
+/// identity drift — a context whose exec entry pins no account/profile, so it
+/// inherits whichever one the cloud CLI last selected.
+/// Mirrors `ferrisscope_core::cloud_identity::ConnectHint`.
+export type ConnectHint = {
+  provider: CloudProvider;
+  title: string;
+  detail: string;
+  /// Identity the apiserver reported in the 403, when it carried one.
+  authenticated_as: string | null;
+  /// Identities configured on this machine — the choices offered by the pin.
+  identities: string[];
+  /// The identity an unpinned context currently authenticates as.
+  active_identity: string | null;
+  /// null when the provider has no per-context pin at all (Azure): the note
+  /// then explains the CLI command to run instead.
+  pin: PinOffer | null;
+};
+
 export type KubeconfigSourceKind = "file" | "folder" | "ssh";
 
 export type SshAuthInput =


### PR DESCRIPTION
## Problem

A kubeconfig context whose exec entry names no identity authenticates as whatever the cloud CLI last selected. Switch `gcloud config set account` for one cluster and every unpinned context follows, so the next connect fails with a bare RBAC wall naming a principal the operator never chose:

```
namespaces is forbidden: User "ops@example.net" cannot list resource
"namespaces" at the cluster scope: Forbidden
```

GKE compounds it. `gke-gcloud-auth-plugin` keeps one token at `~/.kube/gke_gcloud_auth_plugin_cache`, keyed on `extra_args` and the current context but **not** on identity — so a token minted while another account was active keeps being served to every unpinned context until it expires.

Nothing in the app caches credentials (`Cluster::connect` rebuilds `Config` every time), so the fix isn't to change the auth path. It's to *explain* what happened and offer the one-line kubeconfig edit that stops it recurring.

## What this adds

On a connect failure that looks like an RBAC 403, the terminal banner gains a note naming the identity the apiserver saw, the identity the CLI would hand out now, and — for gcloud and AWS — a confirmed action that writes `--account=` / `AWS_PROFILE` into that context's exec entry and drops the stale plugin cache.

**Azure is detect-only on purpose.** `kubelogin` has no per-context account flag; the only way to change who it authenticates as is `az account set`, a global mutation. The note explains that command instead of offering a button that would write the wrong thing.

Auto-reconnect now ends its session on a permanent failure. A 403 is deterministic, and retrying it burned the full ~4 minute backoff behind a busy banner carrying neither Diagnose nor this note — the one screen that explains the failure was the one the retry loop hid.

Identity discovery is filesystem-only, no subprocess: gcloud's config directory, `~/.aws/config` + credentials, `~/.azure/azureProfile.json`.

## Commits

Three, in dependency order. The first two are independent hardening of shared infrastructure with other callers, split out so they can be reviewed on their own terms:

| | |
|---|---|
| `a153b0e` | `atomic_write` — crash safety + tempfile payload exposure |
| `5cfb287` | `source_path_for` — folder-child path validation |
| `df43ad4` | the feature |

The first two are worth a look independently of whether you like the feature: `atomic_write` backs every persistent config write in the app (including `/etc/hosts` via the privileged helper), and `source_path_for` is used by every kubeconfig-mutating command.

## Guarding the pin

It rewrites a file the operator owns, so:

- **Refuses when several contexts share one exec user.** The edit lands on the *user*, so pinning the failing context would silently re-point working siblings — while the disclosure says "this context's exec entry".
- **Refuses rather than guessing** when the context isn't in the resolved file (multi-file `KUBECONFIG`), when the source is SSH, and when the id names no known source. Both commands go through `kubeconfig::resolve_path_for`, which applies the default-kubeconfig fallback only for default-source ids.
- **Canonicalises symlinks first**, so the edit lands in the real file instead of replacing the link with a regular file.
- **Backs up through the atomic writer**, which renames *over* a symlink rather than following it, and leaves the previous backup intact if anything fails. The backup means "immediately before this edit" and the confirm text says exactly that, rather than promising a pristine original it can't keep.
- **Re-pinning an existing identity is a true no-op** — no write, no backup churn.
- **Preserves the target's mode** across the rename, and re-reads before writing so a concurrent `gcloud container clusters get-credentials` is refused rather than silently discarded.

`forbidden_user` is length-bounded and rejects control characters: the 403 text is written by whatever cluster the operator pointed at, and it renders directly above the button that rewrites their kubeconfig.

## Testing

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, 226 Rust tests, 1289 Vitest across 100 files, `tsc --noEmit` clean. Both intermediate commits verified to build and pass on their own.

Four independent reviews were run over the change (Rust correctness, frontend, adversarial/security, test quality); their findings are folded in. The behaviours most likely to regress silently were mutation-checked — the note's wiring into the banner, the provider dispatch, the identity-preselect clamp, `contains_word`'s non-ASCII boundaries.

Not verified end-to-end against a live cluster for AWS or Azure — no account to test with. The gcloud path was reproduced and fixed against a real 3-account setup.

## Judgement calls worth overruling

- **Shared exec users refuse rather than warn.** Safe, but an SSO kubeconfig where several contexts genuinely share one `aws` entry won't get a working pin button; the operator has to split the user by hand.
- **The lost-update guard narrows the race rather than closing it.** A writer landing between the compare and the rename still loses. Closing it needs an advisory lock that `gcloud` and `kubectl` don't take, so it would buy nothing against the writer that actually matters. Documented in the code.
- **`\bforbidden\b` calls some recoverable 403s permanent** — IAM propagation, a downed authorization webhook, a proxy off-VPN. Those get one attempt instead of ten; the terminal banner has a live Reconnect button, so being wrong that way costs a click.

## Known gap

`serde_yaml` emits YAML 1.2 and `kubectl` parses via yaml.v2 (YAML 1.1), so a context or user literally *named* `yes`/`no`/`on`/`off` would become a bool for `kubectl` after a pin. Vanishingly unlikely, and fixing it means inventing quoting rules; noted rather than papered over.

The note is connect-time only — a 403 hit mid-session on a namespaced watch still renders the plain "Access denied".
