### PR TITLE
feat(ui): short cluster names, project grouping, adaptive multi-cluster bar

### DIFF
--- a/crates/core/src/prefs.rs
+++ b/crates/core/src/prefs.rs
@@ -157,6 +157,13 @@ fn default_dark_console() -> bool {
     true
 }
 
+/// Shared `#[serde(default)]` source for the boolean prefs that ship enabled.
+/// Used by `shorten_cluster_names` / `group_fleet_by_project` so prefs.json
+/// files written before those fields existed opt in on next launch.
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
     pub refresh_sec: u32,
@@ -177,6 +184,18 @@ pub struct Settings {
     /// What scope the app opens with after a restart. Settings → General.
     #[serde(default)]
     pub startup_scope: StartupScope,
+    /// Render machine-generated kubeconfig context names (GKE's
+    /// `gke_<project>_<location>_<cluster>`, EKS cluster ARNs, eksctl's
+    /// `<identity>@<cluster>.<region>.eksctl.io`, OpenShift's
+    /// `<ns>/<host>/<user>`) as just the cluster segment. Names the app
+    /// doesn't recognise are left untouched. Settings → Appearance.
+    #[serde(default = "default_true")]
+    pub shorten_cluster_names: bool,
+    /// Bucket the fleet landing's cards by the project / account / region the
+    /// shortened names were stripped of, so the shared qualifier appears once
+    /// on a sub-header instead of on every row. Settings → Appearance.
+    #[serde(default = "default_true")]
+    pub group_fleet_by_project: bool,
 }
 
 /// Restore-on-launch behaviour. `LatestView` reopens exactly what was on
@@ -206,6 +225,8 @@ impl Default for Settings {
             fleet_view: FleetView::default(),
             dark_console: default_dark_console(),
             startup_scope: StartupScope::default(),
+            shorten_cluster_names: default_true(),
+            group_fleet_by_project: default_true(),
         }
     }
 }
@@ -427,6 +448,48 @@ mod tests {
             prefs.update.auto_check_enabled,
             "auto_check_enabled must default to true so legacy installs opt in"
         );
+    }
+
+    #[test]
+    fn legacy_prefs_without_cluster_name_settings_default_on() {
+        // A prefs.json written before the cluster-name-shortening settings
+        // existed must deserialise cleanly with both flags on, so existing
+        // installs get the shorter names (and the project grouping) without
+        // having to visit Settings.
+        let legacy = r#"{
+            "theme": "dark",
+            "settings": {
+                "refresh_sec": 15,
+                "confirm_destructive": true,
+                "show_system_ns": false,
+                "density": "comfortable",
+                "mono_tables": true,
+                "refresh_on_launch": true
+            },
+            "ui": {}
+        }"#;
+        let prefs = parse(legacy);
+        assert!(
+            prefs.settings.shorten_cluster_names,
+            "shorten_cluster_names must default to true for legacy prefs"
+        );
+        assert!(
+            prefs.settings.group_fleet_by_project,
+            "group_fleet_by_project must default to true for legacy prefs"
+        );
+    }
+
+    #[test]
+    fn cluster_name_settings_round_trip_when_disabled() {
+        // Opting out must survive a save/load cycle — a `false` written to
+        // disk must not be re-defaulted back to `true` by serde.
+        let mut prefs = Prefs::default();
+        prefs.settings.shorten_cluster_names = false;
+        prefs.settings.group_fleet_by_project = false;
+        let json = serde_json::to_string(&prefs).expect("serialize");
+        let back = parse(&json);
+        assert!(!back.settings.shorten_cluster_names);
+        assert!(!back.settings.group_fleet_by_project);
     }
 
     #[test]

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -17,6 +17,7 @@ import {
   selectClusterDegraded,
   useActiveClusterIds,
   useAppStore,
+  useClusterLabels,
   useResolvedTheme,
   type ClusterTab,
   type SelectionMeta,
@@ -127,6 +128,9 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeClusterKey, contexts],
   );
+  // Short display names for every cluster, shared by the Dock's tab titles,
+  // the header crumb's multi-cluster summary and the bulk-failure prefixes.
+  const clusterLabels = useClusterLabels();
   // Primary (first) cluster of a tab's scope — feeds the Dock's "new terminal"
   // default and chat target. Only meaningful for the visible (active) tab;
   // inactive Dock pairs are hidden, so a best-effort fallback is fine.
@@ -141,9 +145,12 @@ export default function App() {
       });
       const first = ids[0] ?? "";
       const c = contexts.find((cc) => cc.id === first);
-      return { id: first, name: c?.name ?? first };
+      return {
+        id: first,
+        name: clusterLabels[first]?.short ?? c?.name ?? first,
+      };
     },
-    [contexts, allVirtualContexts],
+    [contexts, allVirtualContexts, clusterLabels],
   );
   const multiClusterActive =
     activeVirtualContext !== null || activeClusterIds.length > 1;
@@ -155,7 +162,10 @@ export default function App() {
     if (activeContexts.length < 2) return undefined;
     const tags = namespaceClusterTags(
       nsClusters,
-      activeContexts.map((c) => ({ id: c.id, name: c.name })),
+      activeContexts.map((c) => ({
+        id: c.id,
+        name: clusterLabels[c.id]?.short ?? c.name,
+      })),
     );
     const colorIdx = clusterColorIndexMap(activeContexts.map((c) => c.id));
     const out: Record<string, { label: string; color: string }[]> = {};
@@ -213,7 +223,9 @@ export default function App() {
   // Display name for a cluster id in bulk-failure prefixes. Imperative read —
   // resolved inside click handlers, so no store subscription is needed.
   const clusterLabelFor = (cid: string) =>
-    useAppStore.getState().contexts.find((c) => c.id === cid)?.name ?? cid;
+    clusterLabels[cid]?.short ??
+    useAppStore.getState().contexts.find((c) => c.id === cid)?.name ??
+    cid;
 
   // YAML compare drawer — armed from the bulk bar when exactly two rows of
   // one kind are selected (any kind; the killer use is the same object on
@@ -822,7 +834,7 @@ export default function App() {
                 ...activeContexts[0]!,
                 name:
                   activeVirtualContext?.name ??
-                  `${activeContexts[0]!.name} +${activeContexts.length - 1}`,
+                  `${clusterLabels[activeContexts[0]!.id]?.short ?? activeContexts[0]!.name} +${activeContexts.length - 1}`,
                 namespace: null,
               }
             : null)
@@ -867,7 +879,7 @@ export default function App() {
                 title={
                   activeVirtualContext
                     ? activeVirtualContext.name
-                    : `${selectedContext?.name ?? "Ad-hoc"} +${activeContexts.length - 1}`
+                    : `${(selectedContext && clusterLabels[selectedContext.id]?.short) ?? selectedContext?.name ?? "Ad-hoc"} +${activeContexts.length - 1}`
                 }
                 viewScopeId={
                   activeVirtualContext

--- a/ui/src/components/AppHeader.test.tsx
+++ b/ui/src/components/AppHeader.test.tsx
@@ -205,3 +205,86 @@ describe("AppHeader cluster switcher", () => {
     expect(useAppStore.getState().selectedContext).toBe("default::beta");
   });
 });
+
+describe("AppHeader short cluster names", () => {
+  const GKE_OPEN = "gke_development-d83ab4a8_europe-west4_truenv-03";
+  const GKE_OTHER = "gke_production-4f83b34d_us-central1_prod-6";
+  const mkCtx = (name: string) => ({
+    id: `default::${name}`,
+    name,
+    cluster: name,
+    user: null,
+    namespace: null,
+    is_current: false,
+    group: "Default",
+    source_id: "default",
+    source_path: null,
+  });
+  const open = mkCtx(GKE_OPEN);
+  const other = mkCtx(GKE_OTHER);
+
+  const renderWithFleet = () => {
+    act(() => {
+      useAppStore.setState({
+        contexts: [open, other],
+        virtualContexts: [],
+        openTabs: [],
+        activeTabId: null,
+      });
+      useAppStore
+        .getState()
+        .openTab({ kind: "context", contextId: open.id });
+    });
+    return render(
+      <AppHeader
+        mode="dark"
+        context={open}
+        selectedKindLabel="Pod"
+        unreadNotifications={0}
+        activeForwards={0}
+        onHome={noop}
+        onPalette={noop}
+        onToggleTheme={noop}
+        onOpenNotifications={noop}
+        onOpenSettings={noop}
+        onOpenForwards={noop}
+      />,
+    );
+  };
+
+  it("renders the breadcrumb as the short name with the full one on hover", () => {
+    const utils = renderWithFleet();
+    expect(utils.getByText("truenv-03")).toBeTruthy();
+    expect(utils.queryByText(GKE_OPEN)).toBeNull();
+    expect(
+      utils.getByTitle(`${GKE_OPEN} — switch or open a cluster`),
+    ).toBeTruthy();
+  });
+
+  it("shortens the 'Open another' list and keeps the coordinate beside it", () => {
+    const utils = renderWithFleet();
+    fireEvent.click(utils.getByText("truenv-03"));
+    // The unopened context is listed short, not as a 42-character string.
+    expect(utils.getByText("prod-6")).toBeTruthy();
+    expect(utils.queryByText(GKE_OTHER)).toBeNull();
+    // …with the stripped coordinate dim next to it, so two clusters from
+    // different projects stay distinguishable.
+    expect(
+      utils.getByText("production-4f83b34d · us-central1"),
+    ).toBeTruthy();
+    // Full name still recoverable on hover.
+    expect(utils.getByTitle(GKE_OTHER)).toBeTruthy();
+  });
+
+  it("falls back to full names when shortening is off", () => {
+    act(() => {
+      useAppStore.getState().patchSettings({ shortenClusterNames: false });
+    });
+    const utils = renderWithFleet();
+    expect(utils.getByText(GKE_OPEN)).toBeTruthy();
+    expect(utils.queryByText("truenv-03")).toBeNull();
+    act(() => {
+      useAppStore.getState().patchSettings({ shortenClusterNames: true });
+    });
+  });
+});

--- a/ui/src/components/AppHeader.tsx
+++ b/ui/src/components/AppHeader.tsx
@@ -26,7 +26,12 @@ import { MOD_KEY, IS_MAC } from "../lib/keyboard";
 import { headerPaddingLeft, dragRegionProps } from "../lib/macChrome";
 import { HeaderToast } from "./HeaderToast";
 import { parseTableFilter } from "../lib/tableFilter";
-import { useAppStore, useResolvedTheme, type ClusterTab } from "../store";
+import {
+  useAppStore,
+  useClusterLabels,
+  useResolvedTheme,
+  type ClusterTab,
+} from "../store";
 import { api } from "../api";
 import {
   closeClusterTab,
@@ -72,6 +77,12 @@ export function AppHeader({
   onOpenForwards,
 }: Props) {
   const t = useResolvedTheme().tokens;
+  // Breadcrumb shows the short cluster name; `title` on the surrounding
+  // button keeps the full context name one hover away.
+  const clusterLabels = useClusterLabels();
+  const contextLabel = context
+    ? clusterLabels[context.id]?.short ?? context.name
+    : "";
   // Open cluster tabs for the breadcrumb switcher dropdown.
   const openTabs = useAppStore((s) => s.openTabs);
   const activeTabId = useAppStore((s) => s.activeTabId);
@@ -189,7 +200,11 @@ export function AppHeader({
               onClick={() => setClusterMenuOpen((v) => !v)}
               aria-haspopup="menu"
               aria-expanded={clusterMenuOpen}
-              title="Switch or open a cluster"
+              title={
+                context && contextLabel !== context.name
+                  ? `${context.name} — switch or open a cluster`
+                  : "Switch or open a cluster"
+              }
               style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -205,7 +220,7 @@ export function AppHeader({
                 font: "inherit",
               }}
             >
-              {context.name}
+              {contextLabel}
               <span
                 aria-hidden
                 style={{
@@ -825,6 +840,7 @@ function ClusterSwitcherMenu({
   onOpenVirtual: (id: string) => void;
   onClose: () => void;
 }) {
+  const labels = useClusterLabels();
   // Anchor the menu to the trigger's viewport rect. It is portaled to <body>
   // (below) so it escapes the header's stacking context (zIndex 5) — otherwise
   // it would paint behind the dock (zIndex 25) and detail panel. Fixed
@@ -902,7 +918,7 @@ function ClusterSwitcherMenu({
         <MenuCaption t={t}>Open</MenuCaption>
         {openTabs.map((tab) => {
           const isActive = tab.id === activeTabId;
-          const label = clusterTabLabel(tab, contexts, virtualContexts);
+          const label = clusterTabLabel(tab, contexts, virtualContexts, labels);
           const primaryId = clusterTabPrimaryId(tab, contexts, virtualContexts);
           return (
             <div
@@ -979,7 +995,9 @@ function ClusterSwitcherMenu({
               <MenuOpenRow
                 key={`c:${c.id}`}
                 t={t}
-                label={c.name}
+                label={labels[c.id]?.short ?? c.name}
+                sub={labels[c.id]?.qualifier ?? null}
+                title={c.name}
                 onClick={() => onOpenContext(c.id)}
               />
             ))}
@@ -1011,15 +1029,22 @@ function MenuCaption({ t, children }: { t: Tokens; children: ReactNode }) {
 function MenuOpenRow({
   t,
   label,
+  sub,
+  title,
   onClick,
 }: {
   t: Tokens;
   label: string;
+  /// Dim coordinate rendered after the label — what shortening stripped.
+  sub?: string | null;
+  /// Full context name, for the hover tooltip.
+  title?: string;
   onClick: () => void;
 }) {
   return (
     <div
       role="menuitem"
+      title={title}
       onClick={onClick}
       style={{
         display: "flex",
@@ -1049,6 +1074,18 @@ function MenuOpenRow({
         }}
       >
         {label}
+        {sub && (
+          <span
+            style={{
+              marginLeft: 6,
+              color: t.textMuted,
+              fontFamily: FF_MONO,
+              fontSize: FS_XS,
+            }}
+          >
+            {sub}
+          </span>
+        )}
       </span>
     </div>
   );

--- a/ui/src/components/ClusterBar.tsx
+++ b/ui/src/components/ClusterBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from
 import { Mono } from "./detail";
 import type { ContextInfo, ClusterInfo } from "../types";
 import { tokens, FF_MONO, type ThemeMode, R_LG, R_MD, FS_MD, FS_XS } from "../theme";
-import { useAppStore, useResolvedTheme } from "../store";
+import { useAppStore, useClusterLabels, useResolvedTheme } from "../store";
 import { Stat, StatusPill, Gauge, Icons, Kbd, Tooltip } from "./ui";
 import { makeChatTab, makeTerminalTab, makeYamlTab } from "./Dock";
 import { MOD_KEY, SHIFT_KEY } from "../lib/keyboard";
@@ -25,6 +25,15 @@ type Props = {
 // Hosts the namespace filter button and the "+" menu (terminal / YAML).
 export function ClusterBar({ mode, context, state, style }: Props) {
   const t = useResolvedTheme().tokens;
+  // Short names for the "Add cluster…" list and for dock-tab titles — a
+  // terminal tab labelled with a 50-character GKE context is unreadable.
+  const clusterLabels = useClusterLabels();
+  const shortName = (c: ContextInfo) => clusterLabels[c.id]?.short ?? c.name;
+  // The Cluster stat renders the kubeconfig cluster entry, which for every
+  // managed provider is the same machine-generated string as the context
+  // name. Split it the same way the rest of the app does.
+  const clusterShort = clusterLabels[context.id]?.short ?? context.cluster;
+  const clusterQualifier = clusterLabels[context.id]?.qualifier ?? null;
 
   const addMenuOpen = useAppStore((s) => s.addMenuOpen);
   const setAddMenuOpen = useAppStore((s) => s.setAddMenuOpen);
@@ -133,9 +142,30 @@ export function ClusterBar({ mode, context, state, style }: Props) {
         t={t}
         label="Cluster"
         value={
-          <Mono>
-            {context.cluster}
-          </Mono>
+          // Two lines instead of one 50-character string that wraps
+          // mid-token: the cluster segment on top, the coordinate it was
+          // stripped of (project · region) dim underneath. Falls back to the
+          // single kubeconfig cluster name when nothing was shortened.
+          clusterQualifier ? (
+            <span
+              title={context.cluster}
+              style={{ display: "flex", flexDirection: "column", lineHeight: 1.25 }}
+            >
+              <Mono>{clusterShort}</Mono>
+              <span
+                style={{
+                  fontFamily: FF_MONO,
+                  fontSize: FS_XS,
+                  fontWeight: 500,
+                  color: t.textMuted,
+                }}
+              >
+                {clusterQualifier}
+              </span>
+            </span>
+          ) : (
+            <Mono>{context.cluster}</Mono>
+          )
         }
       />
       {showUser && context.user && (
@@ -215,8 +245,8 @@ export function ClusterBar({ mode, context, state, style }: Props) {
                     key={c.id}
                     t={t}
                     icon={Icons.cluster}
-                    title={c.name}
-                    subtitle={c.cluster}
+                    title={shortName(c)}
+                    subtitle={clusterLabels[c.id]?.qualifier ?? c.cluster}
                     onClick={() => {
                       addScopeExtra(c.id);
                       setAddMenuOpen(false);
@@ -240,7 +270,7 @@ export function ClusterBar({ mode, context, state, style }: Props) {
                       clusterId: context.id,
                       namespace: null,
                     },
-                    context.name,
+                    shortName(context),
                   ),
                 );
               }}
@@ -275,7 +305,7 @@ export function ClusterBar({ mode, context, state, style }: Props) {
                   s.setDockActiveId(existing.id);
                   s.setDockMin("right", false);
                 } else {
-                  addDockTab(makeChatTab(context.id, context.name));
+                  addDockTab(makeChatTab(context.id, shortName(context)));
                 }
               }}
             />

--- a/ui/src/components/ClusterPanel.tsx
+++ b/ui/src/components/ClusterPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { useAppStore, useResolvedTheme } from "../store";
+import { useAppStore, useClusterLabels, useResolvedTheme } from "../store";
 import type { ClusterInfo, ContextInfo } from "../types";
 import { type ThemeMode, FS_MD } from "../theme";
 import {
@@ -151,14 +151,15 @@ function ConnectingLabel({
   startedAt: number;
 }) {
   const [now, setNow] = useState(Date.now());
+  const shortName = useClusterLabels()[context.id]?.short ?? context.name;
   useEffect(() => {
     const i = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(i);
   }, []);
   const secs = Math.max(0, Math.floor((now - startedAt) / 1000));
   return (
-    <span>
-      Connecting to {context.name}… <span style={{ opacity: 0.6 }}>({secs}s)</span>
+    <span title={context.name}>
+      Connecting to {shortName}… <span style={{ opacity: 0.6 }}>({secs}s)</span>
     </span>
   );
 }

--- a/ui/src/components/CommandPalette.test.tsx
+++ b/ui/src/components/CommandPalette.test.tsx
@@ -183,3 +183,52 @@ describe("CommandPalette search", () => {
     expect(onClose).toHaveBeenCalled();
   });
 });
+
+describe("CommandPalette short cluster names", () => {
+  const GKE = "gke_production-4f83b34d_us-central1_prod-6";
+  const gkeCtx: ContextInfo = {
+    ...ctxEu,
+    id: `kc::${GKE}`,
+    name: GKE,
+    cluster: GKE,
+    group: "Default",
+  };
+
+  const withGkeFleet = () =>
+    act(() => {
+      useAppStore.setState({
+        contexts: [gkeCtx],
+        selectedContext: null,
+        scopeExtras: [],
+      });
+    });
+
+  it("lists the switch-context row under its short name", async () => {
+    withGkeFleet();
+    setMockInvoke(() => undefined);
+    const utils = render(<CommandPalette mode="dark" onClose={() => {}} />);
+    await typeQuery(utils.getByPlaceholderText(/Search/), "prod-6");
+    expect(utils.getByText("prod-6")).toBeInTheDocument();
+    expect(utils.queryByText(GKE)).toBeNull();
+  });
+
+  it("still matches when the operator types the full context name", async () => {
+    withGkeFleet();
+    setMockInvoke(() => undefined);
+    const utils = render(<CommandPalette mode="dark" onClose={() => {}} />);
+    // Muscle memory: the full name is still in the keyword index even though
+    // the row renders short.
+    await typeQuery(utils.getByPlaceholderText(/Search/), "gke_production-4f8");
+    expect(utils.getByText("prod-6")).toBeInTheDocument();
+  });
+
+  it("shows the stripped coordinate on the row's sub line", async () => {
+    withGkeFleet();
+    setMockInvoke(() => undefined);
+    const utils = render(<CommandPalette mode="dark" onClose={() => {}} />);
+    await typeQuery(utils.getByPlaceholderText(/Search/), "prod-6");
+    expect(
+      utils.getByText(/Default · production-4f83b34d · us-central1/),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/CommandPalette.tsx
+++ b/ui/src/components/CommandPalette.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { useActiveClusterIds, useAppStore, useResolvedTheme } from "../store";
+import {
+  useActiveClusterIds,
+  useAppStore,
+  useClusterLabels,
+  useResolvedTheme,
+} from "../store";
 import { FF_MONO, type ThemeMode, R_LG, FS_LG, FS_MD, FS_SM, FS_XS } from "../theme";
 import { Icons, Kbd, resolveKindIcon } from "./ui";
 import { MOD_KEY } from "../lib/keyboard";
@@ -42,6 +47,9 @@ export function CommandPalette({ mode, onClose }: Props) {
   const activeItemRef = useRef<HTMLButtonElement | null>(null);
 
   const contexts = useAppStore((s) => s.contexts);
+  // Rows show the short name; `keywords` below still carries the full
+  // context name, so typing `gke_production-…` keeps matching.
+  const clusterLabels = useClusterLabels();
   const kinds = useAppStore((s) => s.kinds);
   const selectedContext = useAppStore((s) => s.selectedContext);
   const selectContext = useAppStore((s) => s.selectContext);
@@ -152,8 +160,8 @@ export function CommandPalette({ mode, onClose }: Props) {
             }}
           />
         ),
-        label: c.name,
-        sub: `${c.group} · ${c.cluster}${c.namespace ? ` · ns:${c.namespace}` : ""}`,
+        label: clusterLabels[c.id]?.short ?? c.name,
+        sub: `${c.group} · ${clusterLabels[c.id]?.qualifier ?? c.cluster}${c.namespace ? ` · ns:${c.namespace}` : ""}`,
         keywords: `${c.name} ${c.group} ${c.cluster} ${c.namespace ?? ""} ${c.user ?? ""}`.toLowerCase(),
         mono: true,
         action: () => selectContext(c.id),
@@ -274,6 +282,7 @@ export function CommandPalette({ mode, onClose }: Props) {
     return list;
   }, [
     contexts,
+    clusterLabels,
     virtualContexts,
     kinds,
     scopeActive,
@@ -295,7 +304,9 @@ export function CommandPalette({ mode, onClose }: Props) {
     const kindByIdAttempt = new Map(kinds.map((k) => [k.id, k]));
     const multi = activeClusterIds.length > 1;
     const clusterName = (cid: string) =>
-      contexts.find((c) => c.id === cid)?.name ?? cid;
+      clusterLabels[cid]?.short ??
+      contexts.find((c) => c.id === cid)?.name ??
+      cid;
     // Index rows can outlive their kind id — e.g. a CRD upgraded to a new
     // version leaves `crd:`/`wkcrd:` ids no rail entry matches until GC
     // sweeps them. Navigating to a dead kind id is a guaranteed no-op, so
@@ -338,7 +349,15 @@ export function CommandPalette({ mode, onClose }: Props) {
           navigateToDetail(h.kind_id, h.namespace, h.name, clusterId),
       };
     });
-  }, [hits, kinds, t, navigateToDetail, activeClusterIds, contexts]);
+  }, [
+    hits,
+    kinds,
+    t,
+    navigateToDetail,
+    activeClusterIds,
+    contexts,
+    clusterLabels,
+  ]);
 
   const filtered = useMemo(() => {
     const needle = q.trim().toLowerCase();
@@ -576,7 +595,12 @@ export function CommandPalette({ mode, onClose }: Props) {
             >
               search unavailable on{" "}
               {searchFailures
-                .map((cid) => contexts.find((c) => c.id === cid)?.name ?? cid)
+                .map(
+                  (cid) =>
+                    clusterLabels[cid]?.short ??
+                    contexts.find((c) => c.id === cid)?.name ??
+                    cid,
+                )
                 .join(", ")}
             </div>
           )}

--- a/ui/src/components/FleetLanding.test.tsx
+++ b/ui/src/components/FleetLanding.test.tsx
@@ -11,7 +11,8 @@ import { render, cleanup, act } from "@testing-library/react";
 import { Profiler, type ProfilerOnRenderCallback } from "react";
 import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
 import { useAppStore } from "../store";
-import { FleetLanding } from "./FleetLanding";
+import { FleetLanding, bucketByProject } from "./FleetLanding";
+import { clusterLabels } from "../lib/clusterName";
 
 afterEach(() => {
   cleanup();
@@ -410,5 +411,280 @@ describe("FleetLanding generated names + temporary open", () => {
     expect(s.virtualContexts).toHaveLength(0);
     expect(s.selectedVirtualContextId).toBeNull();
     expect(screen.queryByText("Open")).toBeNull();
+  });
+});
+
+// ─── Short cluster names + project grouping ─────────────────────────────────
+
+const gkeCtx = (cluster: string, project: string, location = "us-central1") => {
+  const name = `gke_${project}_${location}_${cluster}`;
+  return { ...fleetCtx(`default::${name}`, name), cluster: name };
+};
+
+const namedFleet = (contexts: ReturnType<typeof fleetCtx>[]) =>
+  setMockInvoke((cmd) => {
+    switch (cmd) {
+      case "list_contexts":
+        return contexts;
+      case "get_fleet_cache":
+        return {};
+      case "refresh_fleet":
+        return undefined;
+      default:
+        return undefined;
+    }
+  });
+
+const renderFleet = async (view: "tiles" | "rows" | "mini" = "rows") => {
+  act(() => {
+    useAppStore.setState((s) => ({
+      settings: { ...s.settings, fleetView: view },
+    }));
+  });
+  await act(async () => {
+    render(<FleetLanding mode="dark" onSelect={() => {}} />);
+  });
+  await act(async () => {});
+};
+
+const setNameSettings = (
+  shortenClusterNames: boolean,
+  groupFleetByProject: boolean,
+) =>
+  act(() => {
+    useAppStore
+      .getState()
+      .patchSettings({ shortenClusterNames, groupFleetByProject });
+  });
+
+describe("FleetLanding short cluster names", () => {
+  afterEach(() => setNameSettings(true, true));
+
+  it("renders GKE contexts as their cluster segment", async () => {
+    resetVctxState();
+    setNameSettings(true, false);
+    namedFleet([
+      gkeCtx("prod-6", "production-4f83b34d"),
+      gkeCtx("truenv-03", "development-d83ab4a8", "europe-west4"),
+    ]);
+    await renderFleet();
+
+    expect(screen.getAllByText("prod-6").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("truenv-03").length).toBeGreaterThan(0);
+    expect(
+      screen.queryByText("gke_production-4f83b34d_us-central1_prod-6"),
+    ).toBeNull();
+  });
+
+  it("shows the stripped project as a dim qualifier when ungrouped", async () => {
+    resetVctxState();
+    setNameSettings(true, false);
+    namedFleet([gkeCtx("prod-6", "production-4f83b34d")]);
+    await renderFleet();
+
+    expect(
+      screen.getAllByText("· production-4f83b34d · us-central1").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("leaves unrecognised context names untouched", async () => {
+    resetVctxState();
+    setNameSettings(true, true);
+    namedFleet([fleetCtx("default::kind-ruw-e2e", "kind-ruw-e2e")]);
+    await renderFleet();
+
+    expect(screen.getAllByText("kind-ruw-e2e").length).toBeGreaterThan(0);
+    expect(screen.queryByTestId("fleet-project-header")).toBeNull();
+  });
+
+  it("restores full names when the setting is off", async () => {
+    resetVctxState();
+    setNameSettings(false, false);
+    namedFleet([gkeCtx("prod-6", "production-4f83b34d")]);
+    await renderFleet();
+
+    expect(
+      screen.getAllByText("gke_production-4f83b34d_us-central1_prod-6").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("prod-6")).toBeNull();
+  });
+});
+
+describe("FleetLanding project grouping", () => {
+  afterEach(() => setNameSettings(true, true));
+
+  const twoProjects = () => [
+    gkeCtx("prod-6", "production-4f83b34d"),
+    gkeCtx("prod-7", "production-4f83b34d"),
+    gkeCtx("truenv-03", "development-d83ab4a8", "europe-west4"),
+  ];
+
+  it.each(["rows", "tiles", "mini"] as const)(
+    "renders a project sub-header in the %s view",
+    async (view) => {
+      resetVctxState();
+      setNameSettings(true, true);
+      namedFleet(twoProjects());
+      await renderFleet(view);
+
+      const headers = screen.getAllByTestId("fleet-project-header");
+      expect(headers).toHaveLength(1);
+      expect(headers[0]!.textContent).toContain(
+        "production-4f83b34d · us-central1",
+      );
+    },
+  );
+
+  it("suppresses the per-row qualifier inside a bucket", async () => {
+    resetVctxState();
+    setNameSettings(true, true);
+    namedFleet(twoProjects());
+    await renderFleet();
+
+    // The coordinate appears once, on the header — not beside each row.
+    expect(
+      screen.queryByText("· production-4f83b34d · us-central1"),
+    ).toBeNull();
+    expect(screen.getAllByText("prod-6").length).toBeGreaterThan(0);
+  });
+
+  it("does not give a lone cluster its own header", async () => {
+    resetVctxState();
+    setNameSettings(true, true);
+    namedFleet(twoProjects());
+    await renderFleet();
+
+    // development-d83ab4a8 has a single member, so it stays in the
+    // ungrouped remainder and keeps its inline qualifier instead.
+    const headers = screen.getAllByTestId("fleet-project-header");
+    expect(headers.map((h) => h.textContent).join("")).not.toContain(
+      "development-d83ab4a8",
+    );
+    expect(
+      screen.getAllByText("· development-d83ab4a8 · europe-west4").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("groups by project even when shortening is off", async () => {
+    // The two settings are independent — grouping is derived from the parsed
+    // coordinate, not from the display decision.
+    resetVctxState();
+    setNameSettings(false, true);
+    namedFleet(twoProjects());
+    await renderFleet();
+
+    const headers = screen.getAllByTestId("fleet-project-header");
+    expect(headers).toHaveLength(1);
+    expect(headers[0]!.textContent).toContain(
+      "production-4f83b34d · us-central1",
+    );
+    // Rows still show their full names.
+    expect(
+      screen.getAllByText("gke_production-4f83b34d_us-central1_prod-6").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("renders one flat list when grouping is off", async () => {
+    resetVctxState();
+    setNameSettings(true, false);
+    namedFleet(twoProjects());
+    await renderFleet();
+
+    expect(screen.queryByTestId("fleet-project-header")).toBeNull();
+    expect(
+      screen.getAllByText("· production-4f83b34d · us-central1").length,
+    ).toBe(2);
+  });
+});
+
+describe("bucketByProject", () => {
+  const c = (name: string) => ({
+    ...fleetCtx(`default::${name}`, name),
+    cluster: name,
+  });
+  const gke = (cluster: string, project: string, loc = "us-central1") =>
+    c(`gke_${project}_${loc}_${cluster}`);
+
+  const bucket = (list: ReturnType<typeof c>[], enabled = true) =>
+    bucketByProject(list, clusterLabels(list, true), enabled);
+
+  it("returns one unlabelled bucket when grouping is off", () => {
+    const list = [gke("prod-6", "p1"), gke("prod-7", "p1")];
+    const out = bucket(list, false);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.label).toBeNull();
+    expect(out[0]!.list).toEqual(list);
+  });
+
+  it("groups contexts that share a coordinate", () => {
+    const list = [gke("prod-6", "p1"), gke("prod-7", "p1")];
+    const out = bucket(list);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.label).toBe("p1 · us-central1");
+    expect(out[0]!.list.map((x) => x.name)).toEqual(list.map((x) => x.name));
+  });
+
+  it("folds singletons into the ungrouped remainder instead of giving them a header", () => {
+    const list = [gke("prod-6", "p1"), gke("prod-7", "p1"), gke("solo", "p2")];
+    const out = bucket(list);
+    expect(out).toHaveLength(2);
+    expect(out[0]!.label).toBeNull();
+    expect(out[0]!.list.map((x) => x.name)).toEqual([list[2]!.name]);
+    expect(out[1]!.label).toBe("p1 · us-central1");
+  });
+
+  it("keeps unrecognised names ungrouped", () => {
+    const list = [c("kind-a"), c("minikube")];
+    const out = bucket(list);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.label).toBeNull();
+    expect(out[0]!.list).toHaveLength(2);
+  });
+
+  it("puts the remainder first, then buckets alphabetically by header", () => {
+    const list = [
+      gke("z1", "zeta"),
+      gke("z2", "zeta"),
+      c("kind-a"),
+      gke("a1", "alpha"),
+      gke("a2", "alpha"),
+    ];
+    const out = bucket(list);
+    expect(out.map((b) => b.label)).toEqual([
+      null,
+      "alpha · us-central1",
+      "zeta · us-central1",
+    ]);
+  });
+
+  it("preserves the incoming order inside each bucket", () => {
+    const list = [gke("b", "p1"), gke("a", "p1"), gke("c", "p1")];
+    const out = bucket(list);
+    expect(out[0]!.list.map((x) => x.name.split("_")[3])).toEqual([
+      "b",
+      "a",
+      "c",
+    ]);
+  });
+});
+
+describe("FleetLanding virtual-context member chips", () => {
+  it("shortens member names and keeps the full one in the chip title", async () => {
+    resetVctxState();
+    setNameSettings(true, true);
+    const a = gkeCtx("prod-6", "production-4f83b34d");
+    const b = gkeCtx("prod-7", "production-4f83b34d");
+    namedFleet([a, b]);
+    act(() => {
+      useAppStore.setState({
+        virtualContexts: [
+          { id: "v0", name: "prod pair", members: [a.id, b.id] },
+        ],
+      });
+    });
+    await renderFleet("tiles");
+
+    const chip = screen.getAllByTitle(a.name).at(-1)!;
+    expect(chip.textContent).toBe("prod-6");
   });
 });

--- a/ui/src/components/FleetLanding.tsx
+++ b/ui/src/components/FleetLanding.tsx
@@ -1,7 +1,7 @@
 import { logErr } from "../lib/log";
 import { useEffect, useMemo, useState } from "react";
 import { api, onFleetProbe, onKubeconfigChanged } from "../api";
-import { useAppStore, useResolvedTheme } from "../store";
+import { useAppStore, useClusterLabels, useResolvedTheme } from "../store";
 import type { ClusterProbe, ContextInfo, VirtualContext } from "../types";
 import {
   FF_MONO,
@@ -18,6 +18,7 @@ import {
   FS_XS,
 } from "../theme";
 import { MOD_KEY } from "../lib/keyboard";
+import { labelFor, type ClusterLabel } from "../lib/clusterName";
 import {
   aggregateVirtualContext,
   clusterColorIndexMap,
@@ -65,6 +66,12 @@ export function FleetLanding({ mode, onSelect }: Props) {
   const setContexts = useAppStore((s) => s.setContexts);
   const setContextsLoading = useAppStore((s) => s.setContextsLoading);
   const setContextsError = useAppStore((s) => s.setContextsError);
+
+  // Display labels for the whole fleet, resolved once here and threaded down
+  // rather than re-subscribed per card. The uniqueness pass inside is
+  // list-aware, so it must see every context — never a bucket.
+  const labels = useClusterLabels();
+  const groupByProject = useAppStore((s) => s.settings.groupFleetByProject);
 
   const [probes, setProbes] = useState<Record<string, ClusterProbe>>({});
   const [menu, setMenu] = useState<{ pos: MenuPosition; ctx: ContextInfo } | null>(null);
@@ -124,6 +131,15 @@ export function FleetLanding({ mode, onSelect }: Props) {
   // Empty input is fine — we fall back to a pregenerated "a + b" / "a +N"
   // name (already deduped against existing virtual contexts), shown as the
   // input placeholder so the operator sees exactly what Save will use.
+  //
+  // Deliberately the FULL context names, not the shortened display labels.
+  // This name is persisted as the virtual context's identity, and
+  // `defaultVirtualContextName` runs its own sibling-elision pass over
+  // whatever it's given. Fed the short names it double-compresses: two
+  // clusters from different projects that both shorten to `prod-1` come out
+  // as "prod-1 + prod-1", and `prod-1` + `prod-2` come out as "1 + 2" with
+  // the project gone. Fed the full names it produces "alpha + beta" — the
+  // segment that actually distinguishes them.
   const generatedName = useMemo(() => {
     const pickedNames = Array.from(picked).map(
       (id) => contexts.find((c) => c.id === id)?.name ?? id,
@@ -348,6 +364,8 @@ export function FleetLanding({ mode, onSelect }: Props) {
           mode={mode}
           label={g}
           list={groups.get(g) ?? []}
+          labels={labels}
+          groupByProject={groupByProject}
           probes={probes}
           view={fleetView}
           picked={picked}
@@ -362,7 +380,7 @@ export function FleetLanding({ mode, onSelect }: Props) {
           mode={mode}
           position={menu.pos}
           onClose={() => setMenu(null)}
-          rowName={primaryLabel(menu.ctx)}
+          rowName={primaryLabel(menu.ctx, labels)}
           items={fleetMenuItems(menu.ctx, onSelect, togglePick)}
         />
       )}
@@ -698,6 +716,10 @@ function vctxDotColor(t: Tokens, agg: VirtualContextAggregate): string {
 
 // One colored dot + name per member; missing members render struck-through
 // in the bad color. `dotsOnly` drops the names for the Mini layout.
+//
+// Names go through the fleet's shortening pass — a virtual context over four
+// GKE clusters is exactly where 50-character chips hurt most. The full
+// context name stays in the chip's `title`.
 function VctxMemberChips({
   resolved,
   colorIdx,
@@ -708,6 +730,7 @@ function VctxMemberChips({
   dotsOnly?: boolean;
 }) {
   const t = useResolvedTheme().tokens;
+  const labels = useClusterLabels();
   return (
     <span
       style={{
@@ -744,7 +767,7 @@ function VctxMemberChips({
               outline: m.ctx ? undefined : `1px solid ${t.bad}`,
             }}
           />
-          {!dotsOnly && (m.ctx?.name ?? m.id)}
+          {!dotsOnly && labelFor(labels, m.id, m.ctx?.name ?? m.id).short}
         </span>
       ))}
     </span>
@@ -1065,10 +1088,64 @@ function VirtualContextRow({
   );
 }
 
+// One bucket of a kubeconfig group, split out by the cloud coordinate the
+// short names were stripped of (GKE project + location, EKS account +
+// region, AKS resource group, DO region). `key === null` is the remainder:
+// contexts with no coordinate to group by, plus buckets of one — a header
+// over a single row is noise, not structure.
+type ProjectBucket = {
+  key: string | null;
+  label: string | null;
+  list: ContextInfo[];
+};
+
+// Pure: bucket a kubeconfig group's contexts by `ClusterLabel.groupKey`.
+// Preserves the incoming order inside each bucket, puts the ungrouped
+// remainder first, then buckets alphabetically by header so the layout
+// doesn't reshuffle when a probe lands.
+export function bucketByProject(
+  list: ContextInfo[],
+  labels: Record<string, ClusterLabel>,
+  enabled: boolean,
+): ProjectBucket[] {
+  if (!enabled) return [{ key: null, label: null, list }];
+
+  const counts = new Map<string, number>();
+  for (const c of list) {
+    const key = labels[c.id]?.groupKey;
+    if (key) counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const loose: ContextInfo[] = [];
+  const buckets = new Map<string, { label: string; list: ContextInfo[] }>();
+  for (const c of list) {
+    const l = labels[c.id];
+    const key = l?.groupKey;
+    if (!key || !l?.groupLabel || (counts.get(key) ?? 0) < 2) {
+      loose.push(c);
+      continue;
+    }
+    const bucket = buckets.get(key) ?? { label: l.groupLabel, list: [] };
+    bucket.list.push(c);
+    buckets.set(key, bucket);
+  }
+
+  const out: ProjectBucket[] = [];
+  if (loose.length > 0) out.push({ key: null, label: null, list: loose });
+  for (const [key, bucket] of [...buckets].sort((a, b) =>
+    a[1].label.localeCompare(b[1].label),
+  )) {
+    out.push({ key, label: bucket.label, list: bucket.list });
+  }
+  return out;
+}
+
 function FleetGroup({
   mode,
   label,
   list,
+  labels,
+  groupByProject,
   probes,
   view,
   picked,
@@ -1079,6 +1156,8 @@ function FleetGroup({
   mode: ThemeMode;
   label: string;
   list: ContextInfo[];
+  labels: Record<string, ClusterLabel>;
+  groupByProject: boolean;
   probes: Record<string, ClusterProbe>;
   view: FleetView;
   picked: Set<string>;
@@ -1117,6 +1196,59 @@ function FleetGroup({
     </div>
   );
 
+  const buckets = bucketByProject(list, labels, groupByProject);
+  // A bucket's header already carries the coordinate, so repeating it on
+  // every row inside would be pure noise.
+  const showQualifier = (b: ProjectBucket) => b.label === null;
+
+  // Sub-header for one project bucket. `inset` is the Rows variant, which
+  // lives inside the bordered container and so needs its own padding and a
+  // separating rule rather than card-grid margins.
+  const subHeader = (b: ProjectBucket, inset: boolean) =>
+    b.label && (
+      <div
+        data-testid="fleet-project-header"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: inset ? "6px 14px" : undefined,
+          marginBottom: inset ? undefined : 8,
+          marginTop: inset ? undefined : 4,
+          background: inset ? t.chip : undefined,
+          borderBottom: inset ? `1px solid ${t.border}` : undefined,
+        }}
+      >
+        <span
+          style={{
+            fontSize: FS_XS,
+            fontFamily: FF_MONO,
+            fontWeight: 600,
+            color: t.textMuted,
+            letterSpacing: 0.2,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            minWidth: 0,
+          }}
+        >
+          {b.label}
+        </span>
+        <div style={{ flex: 1, height: 1, background: t.borderSoft }} />
+        <span
+          style={{
+            fontSize: FS_XS,
+            color: t.textMuted,
+            fontVariantNumeric: "tabular-nums",
+            fontFamily: FF_MONO,
+            flexShrink: 0,
+          }}
+        >
+          {b.list.length}
+        </span>
+      </div>
+    );
+
   if (view === "rows") {
     return (
       <div style={{ marginBottom: 28 }}>
@@ -1129,19 +1261,28 @@ function FleetGroup({
             overflow: "hidden",
           }}
         >
-          {list.map((c, i) => (
-            <FleetRow
-              key={c.id}
-              mode={mode}
-              context={c}
-              probe={probes[c.id] ?? null}
-              isLast={i === list.length - 1}
-              picked={picked.has(c.id)}
-              showPick={anyPicked}
-              onTogglePick={() => onTogglePick(c.id)}
-              onSelect={cardClick(c)}
-              onMenu={(pos) => onMenu(pos, c)}
-            />
+          {buckets.map((b, bi) => (
+            <div key={b.key ?? "__ungrouped"}>
+              {subHeader(b, true)}
+              {b.list.map((c, i) => (
+                <FleetRow
+                  key={c.id}
+                  mode={mode}
+                  context={c}
+                  labels={labels}
+                  showQualifier={showQualifier(b)}
+                  probe={probes[c.id] ?? null}
+                  isLast={
+                    bi === buckets.length - 1 && i === b.list.length - 1
+                  }
+                  picked={picked.has(c.id)}
+                  showPick={anyPicked}
+                  onTogglePick={() => onTogglePick(c.id)}
+                  onSelect={cardClick(c)}
+                  onMenu={(pos) => onMenu(pos, c)}
+                />
+              ))}
+            </div>
           ))}
         </div>
       </div>
@@ -1155,55 +1296,65 @@ function FleetGroup({
   return (
     <div style={{ marginBottom: 28 }}>
       {header}
-      <div
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          gap: view === "mini" ? 8 : 12,
-          alignItems: "stretch",
-        }}
-      >
-        {list.map((c) => {
-          const title = primaryLabel(c);
-          const sub = secondaryLabel(c);
-          const visibleLen = title.length + (sub ? sub.length + 3 : 0);
-          return (
-            <div
-              key={c.id}
-              style={{
-                flex: `1 0 ${basisFn(title, sub)}px`,
-                minWidth: 0,
-                maxWidth: "100%",
-              }}
-            >
-              {view === "mini" ? (
-                <MiniCard
-                  mode={mode}
-                  context={c}
-                  probe={probes[c.id] ?? null}
-                  picked={picked.has(c.id)}
-                  showPick={anyPicked}
-                  onTogglePick={() => onTogglePick(c.id)}
-                  onSelect={cardClick(c)}
-                  onMenu={(pos) => onMenu(pos, c)}
-                />
-              ) : (
-                <FleetCard
-                  mode={mode}
-                  context={c}
-                  probe={probes[c.id] ?? null}
-                  wide={visibleLen > 36}
-                  picked={picked.has(c.id)}
-                  showPick={anyPicked}
-                  onTogglePick={() => onTogglePick(c.id)}
-                  onSelect={cardClick(c)}
-                  onMenu={(pos) => onMenu(pos, c)}
-                />
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {buckets.map((b) => (
+        <div key={b.key ?? "__ungrouped"}>
+          {subHeader(b, false)}
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: view === "mini" ? 8 : 12,
+              alignItems: "stretch",
+              marginBottom: b.label ? 14 : 0,
+            }}
+          >
+            {b.list.map((c) => {
+              const title = primaryLabel(c, labels);
+              const sub = showQualifier(b) ? secondaryLabel(c, labels) : null;
+              const visibleLen = title.length + (sub ? sub.length + 3 : 0);
+              return (
+                <div
+                  key={c.id}
+                  style={{
+                    flex: `1 0 ${basisFn(title, sub)}px`,
+                    minWidth: 0,
+                    maxWidth: "100%",
+                  }}
+                >
+                  {view === "mini" ? (
+                    <MiniCard
+                      mode={mode}
+                      context={c}
+                      labels={labels}
+                      showQualifier={showQualifier(b)}
+                      probe={probes[c.id] ?? null}
+                      picked={picked.has(c.id)}
+                      showPick={anyPicked}
+                      onTogglePick={() => onTogglePick(c.id)}
+                      onSelect={cardClick(c)}
+                      onMenu={(pos) => onMenu(pos, c)}
+                    />
+                  ) : (
+                    <FleetCard
+                      mode={mode}
+                      context={c}
+                      labels={labels}
+                      showQualifier={showQualifier(b)}
+                      probe={probes[c.id] ?? null}
+                      wide={visibleLen > 36}
+                      picked={picked.has(c.id)}
+                      showPick={anyPicked}
+                      onTogglePick={() => onTogglePick(c.id)}
+                      onSelect={cardClick(c)}
+                      onMenu={(pos) => onMenu(pos, c)}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
@@ -1211,6 +1362,8 @@ function FleetGroup({
 function FleetCard({
   mode,
   context,
+  labels,
+  showQualifier,
   probe,
   wide,
   picked,
@@ -1221,6 +1374,10 @@ function FleetCard({
 }: {
   mode: ThemeMode;
   context: ContextInfo;
+  labels: Record<string, ClusterLabel>;
+  /// False when the card sits under a project sub-header that already shows
+  /// the coordinate; repeating it on the card would be noise.
+  showQualifier: boolean;
   probe: ClusterProbe | null;
   wide: boolean;
   picked: boolean;
@@ -1230,6 +1387,7 @@ function FleetCard({
   onMenu: (pos: MenuPosition) => void;
 }) {
   const t = useResolvedTheme().tokens;
+  const sub = showQualifier ? secondaryLabel(context, labels) : null;
   const density = useAppStore((s) => s.settings.density);
   const cardPad =
     density === "compact" ? 9 : density === "spacious" ? 18 : 14;
@@ -1343,8 +1501,8 @@ function FleetCard({
               maxWidth: "100%",
             }}
           >
-            {primaryLabel(context)}
-            {secondaryLabel(context) && (
+            {primaryLabel(context, labels)}
+            {sub && (
               <span
                 style={{
                   marginLeft: 6,
@@ -1355,7 +1513,7 @@ function FleetCard({
                   letterSpacing: 0,
                 }}
               >
-                · {secondaryLabel(context)}
+                · {sub}
               </span>
             )}
           </div>
@@ -1425,7 +1583,7 @@ function FleetCard({
             whiteSpace: "nowrap",
           }}
         >
-          {summaryLine(probe, context)}
+          {summaryLine(probe, context, labels)}
         </div>
       </div>
     </button>
@@ -1469,19 +1627,31 @@ function miniBasisPx(primary: string, secondary: string | null): number {
 }
 
 // Title for the card. We prefer the context name (k8s convention — what
-// `kubectl use-context` switches between, unique within a kubeconfig). If
-// the cluster name carries extra information (different from the context
-// name), `secondaryLabel` surfaces it next to the title.
-function primaryLabel(c: ContextInfo): string {
-  return c.name || c.cluster;
+// `kubectl use-context` switches between, unique within a kubeconfig),
+// shortened to the cluster segment when the name is one of the
+// machine-generated shapes `lib/clusterName` recognises.
+function primaryLabel(
+  c: ContextInfo,
+  labels: Record<string, ClusterLabel>,
+): string {
+  return labelFor(labels, c.id, c.name || c.cluster).short;
 }
 
-// Returns the cluster name when it adds information beyond the context
-// name. We only dedup on a literal case-insensitive match — the `user@`
-// prefix variant (`admin@prod-cluster` vs `prod-cluster`) still surfaces
-// the cluster, since the operator wants both the identity and the
-// underlying cluster visible on the card.
-function secondaryLabel(c: ContextInfo): string | null {
+// The dim text next to the title. When shortening stripped a cloud
+// coordinate (GKE project + location, EKS account + region, …) that's what
+// we surface, so the card still says which project a `prod-6` lives in.
+//
+// Otherwise we fall back to the kubeconfig cluster name when it adds
+// information beyond the context name. We only dedup on a literal
+// case-insensitive match — the `user@` prefix variant (`admin@prod-cluster`
+// vs `prod-cluster`) still surfaces the cluster, since the operator wants
+// both the identity and the underlying cluster visible on the card.
+function secondaryLabel(
+  c: ContextInfo,
+  labels: Record<string, ClusterLabel>,
+): string | null {
+  const qualifier = labels[c.id]?.qualifier;
+  if (qualifier) return qualifier;
   const cluster = c.cluster?.trim();
   if (!cluster) return null;
   const ctx = c.name.trim();
@@ -1492,9 +1662,10 @@ function secondaryLabel(c: ContextInfo): string | null {
 function summaryLine(
   probe: ClusterProbe | null,
   context: ContextInfo,
+  labels: Record<string, ClusterLabel>,
 ): string {
   if (!probe) {
-    return secondaryLabel(context) ? "" : context.cluster;
+    return secondaryLabel(context, labels) ? "" : context.cluster;
   }
   const bits: string[] = [];
   if (probe.nodes != null) bits.push(`${probe.nodes} nodes`);
@@ -1581,6 +1752,8 @@ function GaugeWithLabel({
 function MiniCard({
 
   context,
+  labels,
+  showQualifier,
   probe,
   picked,
   showPick,
@@ -1590,6 +1763,8 @@ function MiniCard({
 }: {
   mode: ThemeMode;
   context: ContextInfo;
+  labels: Record<string, ClusterLabel>;
+  showQualifier: boolean;
   probe: ClusterProbe | null;
   picked: boolean;
   showPick: boolean;
@@ -1604,7 +1779,7 @@ function MiniCard({
       : probe?.healthy === false
         ? t.bad
         : t.unknown;
-  const sub = secondaryLabel(context);
+  const sub = showQualifier ? secondaryLabel(context, labels) : null;
 
   const card = (
     <button
@@ -1684,7 +1859,7 @@ function MiniCard({
           whiteSpace: "nowrap",
         }}
       >
-        {primaryLabel(context)}
+        {primaryLabel(context, labels)}
         {sub && (
           <span
             style={{
@@ -1745,6 +1920,8 @@ function MiniCard({
 function FleetRow({
 
   context,
+  labels,
+  showQualifier,
   probe,
   isLast,
   picked,
@@ -1755,6 +1932,8 @@ function FleetRow({
 }: {
   mode: ThemeMode;
   context: ContextInfo;
+  labels: Record<string, ClusterLabel>;
+  showQualifier: boolean;
   probe: ClusterProbe | null;
   isLast: boolean;
   picked: boolean;
@@ -1770,7 +1949,7 @@ function FleetRow({
       : probe?.healthy === false
         ? t.bad
         : t.unknown;
-  const sub = secondaryLabel(context);
+  const sub = showQualifier ? secondaryLabel(context, labels) : null;
 
   const stats: string[] = [];
   if (probe?.nodes != null) stats.push(`${probe.nodes} nodes`);
@@ -1862,7 +2041,7 @@ function FleetRow({
             flexShrink: 1,
           }}
         >
-          {primaryLabel(context)}
+          {primaryLabel(context, labels)}
         </span>
         {sub && (
           <span

--- a/ui/src/components/LogPanel.tsx
+++ b/ui/src/components/LogPanel.tsx
@@ -6,7 +6,12 @@ import {
   useRef,
   useState,
 } from "react";
-import { useAppStore, useConsoleTokens, useResolvedTheme } from "../store";
+import {
+  useAppStore,
+  useClusterLabels,
+  useConsoleTokens,
+  useResolvedTheme,
+} from "../store";
 import { tokens, FF_MONO, type ThemeMode, FS_LG, FS_SM, FS_XS } from "../theme";
 import {
   EmptyState,
@@ -126,8 +131,13 @@ export function useObservedPods(targets: ObserveTarget[]): {
     .map((t) => [t.clusterId, t.kindId, t.namespace, t.name].join("\u0000"))
     .join("\u0001");
   const targetsRef = useRef(targets);
+  const clusterLabels = useClusterLabels();
+  // Read through a ref, like `targets`: a display-name change must not
+  // restart every resolve (and every log stream hanging off it).
+  const clusterLabelsRef = useRef(clusterLabels);
   useLayoutEffect(() => {
     targetsRef.current = targets;
+    clusterLabelsRef.current = clusterLabels;
   });
   useEffect(() => {
     const all = targetsRef.current;
@@ -207,7 +217,9 @@ export function useObservedPods(targets: ObserveTarget[]): {
       );
       if (cancelled) return;
       const clusterName = (cid: string) =>
-        useAppStore.getState().contexts.find((c) => c.id === cid)?.name ?? cid;
+        clusterLabelsRef.current[cid]?.short ??
+        useAppStore.getState().contexts.find((c) => c.id === cid)?.name ??
+        cid;
       results.forEach((res, i) => {
         const cid = entries[i]![0];
         if (res.status === "fulfilled") {
@@ -334,6 +346,7 @@ export function LogPanel({
   // + footer render as a console (dark by default).
   const consoleT = useConsoleTokens();
   const contexts = useAppStore((s) => s.contexts);
+  const clusterLabels = useClusterLabels();
   const [tab, setTab] = useState<ObserveTab>(initialTab ?? "logs");
   const { state, retry } = useObservedPods(targets);
   const [container, setContainer] = useState<string | null>(
@@ -373,8 +386,11 @@ export function LogPanel({
   }, [onClose]);
 
   const clusterNameFor = useCallback(
-    (cid: string) => contexts.find((c) => c.id === cid)?.name ?? cid,
-    [contexts],
+    (cid: string) =>
+      clusterLabels[cid]?.short ??
+      contexts.find((c) => c.id === cid)?.name ??
+      cid,
+    [contexts, clusterLabels],
   );
 
   const singlePod =

--- a/ui/src/components/OpenClustersStrip.test.tsx
+++ b/ui/src/components/OpenClustersStrip.test.tsx
@@ -65,3 +65,54 @@ describe("OpenClustersStrip", () => {
     ).toBe(false);
   });
 });
+
+describe("OpenClustersStrip short cluster names", () => {
+  const GKE_A = "gke_production-4f83b34d_us-central1_prod-6";
+  const GKE_B = "gke_development-d83ab4a8_europe-west4_truenv-03";
+
+  const openGkePair = () => {
+    act(() => {
+      useAppStore.setState({
+        contexts: [
+          { id: `default::${GKE_A}`, name: GKE_A, user: null } as never,
+          { id: `default::${GKE_B}`, name: GKE_B, user: null } as never,
+        ],
+      });
+      useAppStore
+        .getState()
+        .openTab({ kind: "context", contextId: `default::${GKE_A}` });
+      useAppStore
+        .getState()
+        .openTab({ kind: "context", contextId: `default::${GKE_B}` });
+    });
+  };
+
+  it("renders the short name but keeps the full one in the tooltip", () => {
+    openGkePair();
+    render(<OpenClustersStrip t={t} open />);
+    const row = screen.getByText("prod-6");
+    expect(row).toBeTruthy();
+    // The rail is narrow: no qualifier inline, full name on hover instead.
+    expect(row.getAttribute("title")).toBe(GKE_A);
+    expect(screen.queryByText(GKE_A)).toBeNull();
+  });
+
+  it("labels the close button with the full context name", () => {
+    openGkePair();
+    render(<OpenClustersStrip t={t} open />);
+    expect(screen.getByLabelText(`Close ${GKE_A}`)).toBeTruthy();
+  });
+
+  it("falls back to full names when shortening is off", () => {
+    act(() => {
+      useAppStore.getState().patchSettings({ shortenClusterNames: false });
+    });
+    openGkePair();
+    render(<OpenClustersStrip t={t} open />);
+    expect(screen.getByText(GKE_A)).toBeTruthy();
+    expect(screen.queryByText("prod-6")).toBeNull();
+    act(() => {
+      useAppStore.getState().patchSettings({ shortenClusterNames: true });
+    });
+  });
+});

--- a/ui/src/components/OpenClustersStrip.tsx
+++ b/ui/src/components/OpenClustersStrip.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
-import { useAppStore } from "../store";
+import { useAppStore, useClusterLabels } from "../store";
 import { clusterAccent, FS_SM, FS_XS, R_SM, type Tokens } from "../theme";
 import { clusterColorIndexMap } from "../lib/multiCluster";
 import { Icons, Tooltip } from "./ui";
 import {
   closeClusterTab,
+  clusterTabFullLabel,
   clusterTabLabel,
   clusterTabPrimaryId,
 } from "../lib/clusterTabs";
@@ -26,6 +27,7 @@ export function OpenClustersStrip({ t, open }: Props) {
   const switchTab = useAppStore((s) => s.switchTab);
   const contexts = useAppStore((s) => s.contexts);
   const virtualContexts = useAppStore((s) => s.virtualContexts);
+  const labels = useClusterLabels();
   const [hoverId, setHoverId] = useState<string | null>(null);
 
   if (openTabs.length < 2) return null;
@@ -64,7 +66,10 @@ export function OpenClustersStrip({ t, open }: Props) {
       )}
       {openTabs.map((tab) => {
         const isActive = tab.id === activeTabId;
-        const label = clusterTabLabel(tab, contexts, virtualContexts);
+        const label = clusterTabLabel(tab, contexts, virtualContexts, labels);
+        // The rail is narrow, so the row shows only the short name; the full
+        // context name stays reachable via the tooltip / aria-label.
+        const fullLabel = clusterTabFullLabel(tab, contexts, virtualContexts);
         const primaryId = clusterTabPrimaryId(tab, contexts, virtualContexts);
         const dot = clusterAccent(colorIdx[primaryId] ?? 0);
         const row = (
@@ -101,6 +106,7 @@ export function OpenClustersStrip({ t, open }: Props) {
             {open && (
               <>
                 <span
+                  title={fullLabel}
                   style={{
                     flex: 1,
                     minWidth: 0,
@@ -115,7 +121,7 @@ export function OpenClustersStrip({ t, open }: Props) {
                 </span>
                 <button
                   type="button"
-                  aria-label={`Close ${label}`}
+                  aria-label={`Close ${fullLabel}`}
                   title="Close cluster tab"
                   onClick={(e) => {
                     e.stopPropagation();
@@ -141,7 +147,7 @@ export function OpenClustersStrip({ t, open }: Props) {
           </div>
         );
         // Collapsed rail: dots only, name in a tooltip.
-        return open ? row : <Tooltip key={tab.id} label={label}>{row}</Tooltip>;
+        return open ? row : <Tooltip key={tab.id} label={fullLabel}>{row}</Tooltip>;
       })}
     </div>
   );

--- a/ui/src/components/PortForwardsPanel.test.tsx
+++ b/ui/src/components/PortForwardsPanel.test.tsx
@@ -127,3 +127,70 @@ describe("PortForwardsPanel — global section", () => {
     expect(screen.getByTestId("new-forward-form")).toBeTruthy();
   });
 });
+
+// The panel hydrates the helper lifecycle on mount; an undefined response
+// would be stored verbatim and crash the header.
+const mockPfIdle = (cmd: string) => {
+  if (cmd === "gf_list") return [];
+  if (cmd === "gf_helper_status") return { state: "not_started" };
+  return undefined;
+};
+
+describe("PortForwardsPanel short cluster names", () => {
+  const GKE = "gke_development-d83ab4a8_europe-west4_truenv-03";
+  const CID = `default::${GKE}`;
+  const entry = {
+    spec: {
+      id: `${CID}::Service/default/api:80`,
+      cluster_id: CID,
+      target: { kind: "Service", namespace: "default", name: "api" },
+      remote_port: 80,
+      requested_local_port: null,
+      autostart: false,
+      mode: "simple",
+    },
+    actual_local_port: 8080,
+    status: { kind: "listening" },
+  } as never;
+
+  const seed = () =>
+    useAppStore.setState({
+      forwards: { [`${CID}::Service/default/api:80`]: entry },
+      forwardsOpen: true,
+      globalForwards: {},
+      helperStatus: { state: "not_started" },
+      contexts: [
+        {
+          id: CID,
+          name: GKE,
+          cluster: GKE,
+          user: null,
+          namespace: null,
+          is_current: false,
+          group: "Default",
+          source_id: "default",
+          source_path: null,
+        },
+      ],
+    });
+
+  it("heads each group with the short name, full name on hover", () => {
+    seed();
+    setMockInvoke(mockPfIdle);
+    render(<PortForwardsPanel mode="dark" />);
+    const heading = screen.getByText("truenv-03");
+    expect(heading).toBeTruthy();
+    expect(heading.getAttribute("title")).toBe(GKE);
+    expect(screen.queryByText(GKE)).toBeNull();
+  });
+
+  it("falls back to the full name when shortening is off", () => {
+    useAppStore.getState().patchSettings({ shortenClusterNames: false });
+    seed();
+    setMockInvoke(mockPfIdle);
+    render(<PortForwardsPanel mode="dark" />);
+    expect(screen.getByText(GKE)).toBeTruthy();
+    expect(screen.queryByText("truenv-03")).toBeNull();
+    useAppStore.getState().patchSettings({ shortenClusterNames: true });
+  });
+});

--- a/ui/src/components/PortForwardsPanel.tsx
+++ b/ui/src/components/PortForwardsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../api";
-import { useAppStore, useResolvedTheme } from "../store";
+import { useAppStore, useClusterLabels, useResolvedTheme } from "../store";
 import { FF_MONO, FONT_SANS, type ThemeMode, type Tokens, FS_MD, FS_SM, FS_XS } from "../theme";
 import type {
   ForwardEntry,
@@ -33,6 +33,7 @@ export function PortForwardsPanel({ mode }: Props) {
   const removeForward = useAppStore((s) => s.removeForward);
   const upsertForward = useAppStore((s) => s.upsertForward);
   const contexts = useAppStore((s) => s.contexts);
+  const clusterLabels = useClusterLabels();
   const globalForwards = useAppStore((s) => s.globalForwards);
   const helperStatus = useAppStore((s) => s.helperStatus);
   const hydrateGlobalForwards = useAppStore((s) => s.hydrateGlobalForwards);
@@ -83,6 +84,14 @@ export function PortForwardsPanel({ mode }: Props) {
   // handled by backend cleanup, but we still want to show the in-memory
   // entry until the status event arrives).
   const clusterLabel = useMemo(() => {
+    const map = new Map(
+      contexts.map((c) => [c.id, clusterLabels[c.id]?.short ?? c.name]),
+    );
+    return (id: string) => map.get(id) ?? id;
+  }, [contexts, clusterLabels]);
+  // Full context name for the row tooltip, so the short label above is
+  // always recoverable.
+  const clusterFullName = useMemo(() => {
     const map = new Map(contexts.map((c) => [c.id, c.name]));
     return (id: string) => map.get(id) ?? id;
   }, [contexts]);
@@ -284,6 +293,7 @@ export function PortForwardsPanel({ mode }: Props) {
                   key={clusterId}
                   t={t}
                   title={clusterLabel(clusterId)}
+                  fullTitle={clusterFullName(clusterId)}
                   entries={items}
                   onStop={onStop}
                   onPinToggle={onPinToggle}
@@ -313,6 +323,7 @@ export function PortForwardsPanel({ mode }: Props) {
 function ClusterGroup({
   t,
   title,
+  fullTitle,
   entries,
   onStop,
   onPinToggle,
@@ -320,7 +331,11 @@ function ClusterGroup({
   onOpen,
 }: {
   t: Tokens;
+  /// Short cluster name — the group heading.
   title: string;
+  /// Full context name, kept on the heading's `title` attribute so the
+  /// shortened heading is always recoverable.
+  fullTitle?: string;
   entries: ForwardEntry[];
   onStop: (id: string) => void;
   onPinToggle: (e: ForwardEntry) => void;
@@ -330,6 +345,7 @@ function ClusterGroup({
   return (
     <div>
       <div
+        title={fullTitle}
         style={{
           padding: "10px 18px 6px",
           background: t.surfaceAlt,

--- a/ui/src/components/ResourceTable.multi.test.tsx
+++ b/ui/src/components/ResourceTable.multi.test.tsx
@@ -325,3 +325,94 @@ describe("ResourceTable — pendingDetail resolution", () => {
     }
   });
 });
+
+describe("cluster focus", () => {
+  const mockThree = () =>
+    mockSubscribe({
+      [CID_A]: [{ uid: "u1", name: "cm-a", namespace: "default" }],
+      [CID_B]: [
+        { uid: "u2", name: "cm-b", namespace: "default" },
+        { uid: "u3", name: "cm-c", namespace: "default" },
+      ],
+    });
+
+  const renderMulti = async (clusters = TWO) => {
+    await act(async () => {
+      render(
+        <ResourceTable
+          mode="dark"
+          clusters={clusters}
+          viewScopeId="vctx:focus"
+          kind={configMapsKind}
+        />,
+      );
+    });
+    await act(async () => {});
+  };
+
+  it("narrows the merged rows to the focused member", async () => {
+    mockThree();
+    await renderMulti();
+    expect(useAppStore.getState().tableCount).toEqual({
+      filtered: 3,
+      total: 3,
+    });
+
+    await act(async () => {
+      useAppStore.getState().toggleFocusedCluster(CID_B);
+    });
+    expect(useAppStore.getState().tableCount).toEqual({
+      filtered: 2,
+      total: 3,
+    });
+  });
+
+  it("restores every row when the focus is cleared", async () => {
+    mockThree();
+    await renderMulti();
+    await act(async () => {
+      useAppStore.getState().toggleFocusedCluster(CID_A);
+    });
+    expect(useAppStore.getState().tableCount?.filtered).toBe(1);
+    await act(async () => {
+      useAppStore.getState().clearFocusedCluster();
+    });
+    expect(useAppStore.getState().tableCount?.filtered).toBe(3);
+  });
+
+  it("ignores a focus on a cluster that is not in the current scope", async () => {
+    // A stale id from a previous scope must not blank the table.
+    mockThree();
+    await renderMulti();
+    await act(async () => {
+      useAppStore.getState().toggleFocusedCluster("default::gone");
+    });
+    expect(useAppStore.getState().tableCount?.filtered).toBe(3);
+  });
+
+  it("ignores a focus in a single-cluster view", async () => {
+    mockSubscribe({
+      [CID_A]: [{ uid: "u1", name: "cm-a", namespace: "default" }],
+    });
+    await renderMulti(ONE);
+    await act(async () => {
+      useAppStore.getState().toggleFocusedCluster(CID_A);
+    });
+    expect(useAppStore.getState().tableCount?.filtered).toBe(1);
+  });
+
+  it("names the focused cluster in the empty state when nothing matches", async () => {
+    mockSubscribe({
+      [CID_A]: [{ uid: "u1", name: "cm-a", namespace: "default" }],
+      [CID_B]: [],
+    });
+    await renderMulti();
+    await act(async () => {
+      useAppStore.getState().toggleFocusedCluster(CID_B);
+    });
+    expect(
+      screen.getByText("No configmaps match the current filters"),
+    ).toBeTruthy();
+    expect(screen.getByText(/cluster prod-us/)).toBeTruthy();
+  });
+});

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -24,7 +24,12 @@ import {
 } from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { api, onResourceDelta } from "../api";
-import { selectClusterDegraded, useAppStore, useResolvedTheme } from "../store";
+import {
+  selectClusterDegraded,
+  useAppStore,
+  useClusterLabels,
+  useResolvedTheme,
+} from "../store";
 import { formatQuantity } from "./detail";
 import { execContainers, rowLogContainers } from "../lib/podContainers";
 import type {
@@ -66,7 +71,7 @@ import {
   applyScopedDelta,
   mergeScopedSnapshots,
   scopedUid,
-  shortClusterNames,
+  clusterDisplayMeta,
   type ScopedRow,
 } from "../lib/multiCluster";
 import {
@@ -266,6 +271,7 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
   // Lifted to the store so the AppHeader can render the active-filter chip
   // and so the palette in filter mode can edit it live without prop drilling.
   const tableFilter = useAppStore((s) => s.tableFilter);
+  const focusedClusterId = useAppStore((s) => s.focusedClusterId);
   const setTableCount = useAppStore((s) => s.setTableCount);
   const [logTarget, setLogTarget] = useState<ScopedRow | null>(null);
   const [logDefaultContainer, setLogDefaultContainer] = useState<string | null>(
@@ -332,6 +338,7 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
         : clusters,
     [clusters, kindClusterIds],
   );
+  const clusterLabels = useClusterLabels();
   const clusterIds = useMemo(
     () => effectiveClusters.map((c) => c.id),
     [effectiveClusters],
@@ -343,20 +350,10 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
   // `short` is the compressed sibling-distinguishing name (common prefix /
   // suffix tokens stripped across the member set) the cell displays; the
   // full name stays in the tooltip and the failure strips.
-  const clusterMeta = useMemo(() => {
-    const shorts = shortClusterNames(clusters.map((c) => c.name));
-    const out: Record<
-      string,
-      { name: string; short: string; colorIdx: number }
-    > = {};
-    for (const c of clusters)
-      out[c.id] = {
-        name: c.name,
-        short: shorts[c.name] ?? c.name,
-        colorIdx: c.colorIdx,
-      };
-    return out;
-  }, [clusters]);
+  const clusterMeta = useMemo(
+    () => clusterDisplayMeta(clusters, clusterLabels),
+    [clusters, clusterLabels],
+  );
   const clusterMetaRef = useRef(clusterMeta);
   clusterMetaRef.current = clusterMeta;
 
@@ -615,10 +612,19 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
     return () => window.clearTimeout(handle);
   }, [pendingDetail, kind.id, load.kind, consumePendingDetail]);
 
+  // A cluster focus set from the multi-cluster bar only applies while the
+  // view actually spans several members — a single-cluster tab can't be
+  // focused, and a stale id from a previous scope must not blank the table.
+  const focusActive =
+    clusters.length > 1 &&
+    focusedClusterId !== null &&
+    clusters.some((c) => c.id === focusedClusterId);
+
   const filtered = useMemo(() => {
     const parsed = parseTableFilter(tableFilter);
     const nsFilterActive = kind.namespaced && selectedNamespaces.size > 0;
     return rows
+      .filter((r) => !focusActive || r.__clusterId === focusedClusterId)
       .filter((r) => {
         if (!nsFilterActive) return true;
         const ns = r.namespace;
@@ -630,7 +636,14 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
         // `r.__labels` (watcher-injected).
         return parsed.test(r);
       });
-  }, [rows, selectedNamespaces, tableFilter, kind.namespaced]);
+  }, [
+    rows,
+    selectedNamespaces,
+    tableFilter,
+    kind.namespaced,
+    focusActive,
+    focusedClusterId,
+  ]);
 
   // Push the row count to the store so the header breadcrumb can render it
   // (`Pods · 232` / `Pods · 12/232`). Reset to null on unmount so a stale
@@ -1466,9 +1479,22 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
               const nsFilterApplied =
                 kind.namespaced && selectedNamespaces.size > 0;
               const filtersApplied =
-                tableFilter.trim().length > 0 || nsFilterApplied;
+                tableFilter.trim().length > 0 || nsFilterApplied || focusActive;
               if (filtersApplied) {
                 const bits: string[] = [];
+                if (focusActive) {
+                  // The provider-short name, NOT `clusterMeta.short` — that
+                  // one is further compressed against its siblings for the
+                  // narrow Cluster column ("us"), which reads as nonsense in
+                  // a sentence.
+                  bits.push(
+                    `cluster ${
+                      clusterLabels[focusedClusterId!]?.short ??
+                      clusterMeta[focusedClusterId!]?.name ??
+                      focusedClusterId
+                    }`,
+                  );
+                }
                 if (nsFilterApplied) {
                   bits.push(
                     selectedNamespaces.size === 1

--- a/ui/src/components/SettingsPanel.tsx
+++ b/ui/src/components/SettingsPanel.tsx
@@ -639,6 +639,30 @@ function AppearanceSection({}: { mode: ThemeMode }) {
       </Field>
       <Field
         t={t}
+        label="Short cluster names"
+        hint="Show GKE / EKS / eksctl / OpenShift contexts as just the cluster name, with the project or account beside it. Names we don't recognise are left as-is; the full name stays in the tooltip and in search."
+      >
+        <Toggle
+          t={t}
+          checked={settings.shortenClusterNames}
+          onChange={(v) => patchSettings({ shortenClusterNames: v })}
+          label={settings.shortenClusterNames ? "On" : "Off"}
+        />
+      </Field>
+      <Field
+        t={t}
+        label="Group fleet by project"
+        hint="On the fleet landing, bucket clusters under the project, account or region they share."
+      >
+        <Toggle
+          t={t}
+          checked={settings.groupFleetByProject}
+          onChange={(v) => patchSettings({ groupFleetByProject: v })}
+          label={settings.groupFleetByProject ? "On" : "Off"}
+        />
+      </Field>
+      <Field
+        t={t}
         label="Interface scale"
         hint={`Zoom the whole UI. ${MOD_KEY}+− / ${MOD_KEY}+= to nudge, ${MOD_KEY}+0 to reset.`}
       >

--- a/ui/src/components/VirtualClusterPanel.test.tsx
+++ b/ui/src/components/VirtualClusterPanel.test.tsx
@@ -2,7 +2,14 @@
 // per-member failure banners with their own Reconnect.
 
 import { describe, it, expect, afterEach } from "vitest";
-import { render, cleanup, act, screen, fireEvent } from "@testing-library/react";
+import {
+  render,
+  cleanup,
+  act,
+  screen,
+  fireEvent,
+  within,
+} from "@testing-library/react";
 import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
 import { resetEventMock, emitMock } from "../test/tauri-event-mock";
 import { useAppStore } from "../store";
@@ -496,5 +503,175 @@ describe("VirtualClusterBar save mode with an active virtual context", () => {
     // single-cluster menu (subtitles present).
     expect(screen.getByText("Talk to the cluster-aware assistant")).toBeTruthy();
     expect(screen.getByText("Merge another cluster into this view")).toBeTruthy();
+  });
+});
+
+describe("VirtualClusterPanel short member names", () => {
+  const GKE_6 = "gke_production-4f83b34d_us-central1_prod-6";
+  const GKE_7 = "gke_production-4f83b34d_us-central1_prod-7";
+  const GKE_MEMBERS = [
+    ctx(`default::${GKE_6}`, GKE_6),
+    ctx(`default::${GKE_7}`, GKE_7),
+  ];
+
+  const renderGke = async () => {
+    setMockInvoke((cmd) => {
+      switch (cmd) {
+        case "connect_context":
+          return { server_version: "1.30", node_count: 1 };
+        case "subscribe_resource":
+          return { rows: [], init_done: true };
+        default:
+          return undefined;
+      }
+    });
+    // Labels resolve against the STORE's fleet (the uniqueness pass is
+    // list-aware), not against the panel's member prop — seed both.
+    act(() => {
+      useAppStore.setState({ contexts: GKE_MEMBERS });
+    });
+    await act(async () => {
+      render(
+        <VirtualClusterPanel
+          mode="dark"
+          title="prod pair"
+          viewScopeId="vctx:t2"
+          contexts={GKE_MEMBERS}
+        />,
+      );
+    });
+    await act(async () => {});
+  };
+
+  it("renders member chips with the short name", async () => {
+    await renderGke();
+    expect(screen.getByText("prod-6")).toBeTruthy();
+    expect(screen.getByText("prod-7")).toBeTruthy();
+    expect(screen.queryByText(GKE_6)).toBeNull();
+  });
+
+  it("falls back to full names when shortening is off", async () => {
+    act(() => {
+      useAppStore.getState().patchSettings({ shortenClusterNames: false });
+    });
+    await renderGke();
+    expect(screen.getByText(GKE_6)).toBeTruthy();
+    expect(screen.queryByText("prod-6")).toBeNull();
+    act(() => {
+      useAppStore.getState().patchSettings({ shortenClusterNames: true });
+    });
+  });
+});
+
+describe("VirtualClusterPanel member strip", () => {
+  const many = (n: number) =>
+    Array.from({ length: n }, (_, i) =>
+      ctx(`default::c${i}`, `cluster-${String(i).padStart(2, "0")}`),
+    );
+
+  const renderMembers = async (members: ContextInfo[]) => {
+    setMockInvoke((cmd) => {
+      switch (cmd) {
+        case "connect_context":
+          return { server_version: "1.30", node_count: 1 };
+        case "subscribe_resource":
+          return { rows: [], init_done: true };
+        default:
+          return undefined;
+      }
+    });
+    act(() => {
+      useAppStore.setState({ contexts: members, focusedClusterId: null });
+    });
+    await act(async () => {
+      render(
+        <VirtualClusterPanel
+          mode="dark"
+          title="fleet"
+          viewScopeId="vctx:strip"
+          contexts={members}
+        />,
+      );
+    });
+    await act(async () => {});
+  };
+
+  it("shows every chip and no overflow control for a small view", async () => {
+    await renderMembers(many(2));
+    expect(screen.getByText("cluster-00")).toBeTruthy();
+    expect(screen.getByText("cluster-01")).toBeTruthy();
+    expect(screen.queryByTestId("member-overflow")).toBeNull();
+    // Two healthy clusters need no rollup — the chips already say it.
+    expect(screen.queryByTestId("member-rollup")).toBeNull();
+  });
+
+  it("collapses the tail into a +N control with a rollup at scale", async () => {
+    await renderMembers(many(24));
+    const overflow = screen.getByTestId("member-overflow");
+    expect(overflow.textContent).toMatch(/^\+\d+$/);
+    expect(overflow.getAttribute("aria-label")).toContain("24 clusters");
+    expect(screen.getByTestId("member-rollup")).toBeTruthy();
+  });
+
+  it("opens a searchable list of every member from +N", async () => {
+    await renderMembers(many(24));
+    fireEvent.click(screen.getByTestId("member-overflow"));
+    const dialog = screen.getByRole("dialog", {
+      name: "All clusters in this view",
+    });
+    expect(dialog).toBeTruthy();
+    // The list carries every member, not only the hidden ones, so the
+    // popover is a complete answer to "what is in this view".
+    expect(screen.getByLabelText("Search clusters in this view")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Search clusters in this view"), {
+      target: { value: "cluster-17" },
+    });
+    // Scope the assertions to the popover: the search filters the list, not
+    // the chips still rendered in the strip behind it.
+    const list = within(dialog);
+    expect(list.getAllByText("cluster-17").length).toBeGreaterThan(0);
+    expect(list.queryByText("cluster-03")).toBeNull();
+  });
+
+  it("reports an empty search honestly", async () => {
+    await renderMembers(many(24));
+    fireEvent.click(screen.getByTestId("member-overflow"));
+    fireEvent.change(screen.getByLabelText("Search clusters in this view"), {
+      target: { value: "nope" },
+    });
+    expect(screen.getByText(/No cluster matches/)).toBeTruthy();
+  });
+
+  it("clicking a chip focuses that cluster and clicking again clears it", async () => {
+    await renderMembers(many(3));
+    fireEvent.click(screen.getByText("cluster-01"));
+    expect(useAppStore.getState().focusedClusterId).toBe("default::c1");
+    fireEvent.click(screen.getByText("cluster-01"));
+    expect(useAppStore.getState().focusedClusterId).toBeNull();
+  });
+
+  it("keeps the focused member visible even when it would overflow", async () => {
+    // A focus you cannot see is a trap — the chip that clears it must stay
+    // on screen.
+    await renderMembers(many(24));
+    act(() => {
+      useAppStore.getState().toggleFocusedCluster("default::c23");
+    });
+    expect(screen.getByText("cluster-23")).toBeTruthy();
+    act(() => {
+      useAppStore.getState().clearFocusedCluster();
+    });
+  });
+
+  it("marks the focused chip pressed for assistive tech", async () => {
+    await renderMembers(many(3));
+    fireEvent.click(screen.getByText("cluster-02"));
+    const chip = screen
+      .getAllByRole("button")
+      .find((b) => b.getAttribute("aria-label")?.startsWith("cluster-02"));
+    expect(chip?.getAttribute("aria-pressed")).toBe("true");
+    act(() => {
+      useAppStore.getState().clearFocusedCluster();
+    });
   });
 });

--- a/ui/src/components/VirtualClusterPanel.tsx
+++ b/ui/src/components/VirtualClusterPanel.tsx
@@ -1,7 +1,23 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAppStore, useResolvedTheme } from "../store";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useAppStore, useClusterLabels, useResolvedTheme } from "../store";
 import type { ContextInfo } from "../types";
-import { clusterAccent, type ThemeMode, FF_MONO, FS_MD, FS_XS, R_LG, R_MD } from "../theme";
+import {
+  clusterAccent,
+  type ThemeMode,
+  FF_MONO,
+  FS_MD,
+  FS_XS,
+  R_LG,
+  R_MD,
+  R_SM,
+} from "../theme";
 import {
   useClusterConnection,
   type ConnectState,
@@ -10,6 +26,15 @@ import {
   clusterColorIndexMap,
   defaultVirtualContextName,
 } from "../lib/multiCluster";
+import {
+  fitStrip,
+  healthCounts,
+  populatedBuckets,
+  rollupSummary,
+  shouldShowRollup,
+  type MemberHealth,
+  type StripMember,
+} from "../lib/clusterStrip";
 import { ReconnectBanner } from "./ClusterPanel";
 import { AddMenuItem, AddMenuTrigger, NamespaceButton } from "./ClusterBar";
 import { ResourceTable, type TableCluster } from "./ResourceTable";
@@ -93,6 +118,9 @@ export function VirtualClusterPanel({ mode, title, viewScopeId, contexts }: Prop
   // Stable color assignment by sorted member id, independent of order and
   // of which members happen to be reachable.
   const colorIdx = useMemo(() => clusterColorIndexMap(memberIds), [memberIds]);
+  const clusterLabels = useClusterLabels();
+  const shortName = (c: { id: string; name: string }) =>
+    clusterLabels[c.id]?.short ?? c.name;
 
   // The merged table only spans members whose connect landed — connecting
   // members join the fan as they arrive (backend watcher linger makes the
@@ -157,7 +185,7 @@ export function VirtualClusterPanel({ mode, title, viewScopeId, contexts }: Prop
         <ReconnectBanner
           key={c.id}
           mode={mode}
-          title={`${c.name}: reconnecting…`}
+          title={`${shortName(c)}: reconnecting…`}
           reason={
             clusterHealthReason[c.id] ??
             (conns[c.id]?.state.status === "error"
@@ -180,8 +208,8 @@ export function VirtualClusterPanel({ mode, title, viewScopeId, contexts }: Prop
             mode={mode}
             title={
               st?.status === "cancelled"
-                ? `${c.name}: connection cancelled`
-                : `${c.name}: could not connect`
+                ? `${shortName(c)}: connection cancelled`
+                : `${shortName(c)}: could not connect`
             }
             reason={st?.status === "error" ? st.message : null}
             onReconnect={() => conns[c.id]?.reconnect()}
@@ -192,7 +220,7 @@ export function VirtualClusterPanel({ mode, title, viewScopeId, contexts }: Prop
         <ReconnectBanner
           key={c.id}
           mode={mode}
-          title={`${c.name}: cluster unavailable`}
+          title={`${shortName(c)}: cluster unavailable`}
           reason={
             clusterHealthReason[c.id] ??
             "No response from the apiserver for 30s. Watchers and metrics have been torn down."
@@ -254,9 +282,7 @@ function VirtualClusterBar({
   colorIdx: Record<string, number>;
 }) {
   const t = useResolvedTheme().tokens;
-  const clusterHealth = useAppStore((s) => s.clusterHealth);
   const scopeExtras = useAppStore((s) => s.scopeExtras);
-  const removeScopeExtra = useAppStore((s) => s.removeScopeExtra);
   const addScopeExtra = useAppStore((s) => s.addScopeExtra);
   const allContexts = useAppStore((s) => s.contexts);
   const addDockTab = useAppStore((s) => s.addDockTab);
@@ -275,6 +301,9 @@ function VirtualClusterBar({
 
   const memberIds = contexts.map((c) => c.id);
   const addable = allContexts.filter((c) => !memberIds.includes(c.id));
+  const clusterLabels = useClusterLabels();
+  const shortName = (c: { id: string; name: string }) =>
+    clusterLabels[c.id]?.short ?? c.name;
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuMode, setMenuMode] = useState<AddMenuMode>("root");
@@ -339,23 +368,6 @@ function VirtualClusterBar({
     selectVirtualContext(id);
   };
 
-  const stateDot = (c: ContextInfo): { color: string; label: string } => {
-    // Auto-reconnecting wins over the underlying error/unavailable state so the
-    // dot matches the single "reconnecting…" strip the operator sees.
-    if (conns[c.id]?.autoReconnect != null) {
-      return { color: t.warn, label: "reconnecting" };
-    }
-    const st = conns[c.id]?.state.status;
-    if (st === "ok") {
-      return clusterHealth[c.id] === "unavailable"
-        ? { color: t.bad, label: "unavailable" }
-        : { color: t.good, label: "connected" };
-    }
-    if (st === "error" || st === "cancelled") {
-      return { color: t.bad, label: st };
-    }
-    return { color: t.unknown, label: "connecting" };
-  };
 
   return (
     <div
@@ -387,93 +399,13 @@ function VirtualClusterBar({
         aria-hidden
         style={{ width: 1, height: 16, background: t.border, flexShrink: 0 }}
       />
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 6,
-          flex: 1,
-          minWidth: 0,
-          overflow: "hidden",
-        }}
-      >
-        {contexts.map((c) => {
-          const dot = stateDot(c);
-          const isExtra = scopeExtras.includes(c.id);
-          return (
-            <Tooltip
-              key={c.id}
-              label={`${c.name} — ${dot.label}${isExtra ? " (ad-hoc)" : ""}`}
-            >
-              <span
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 6,
-                  padding: "3px 8px",
-                  borderRadius: R_MD,
-                  background: t.chip,
-                  border: `1px ${isExtra ? "dashed" : "solid"} ${t.borderSoft}`,
-                  fontSize: FS_XS,
-                  fontFamily: FF_MONO,
-                  color: t.textDim,
-                  whiteSpace: "nowrap",
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  maxWidth: 220,
-                }}
-              >
-                <span
-                  aria-hidden
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: "50%",
-                    background: clusterAccent(colorIdx[c.id] ?? 0),
-                    flexShrink: 0,
-                  }}
-                />
-                <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
-                  {c.name}
-                </span>
-                <span
-                  aria-hidden
-                  style={{
-                    width: 6,
-                    height: 6,
-                    borderRadius: "50%",
-                    background: dot.color,
-                    flexShrink: 0,
-                  }}
-                />
-                {isExtra && (
-                  <button
-                    type="button"
-                    aria-label={`Remove ${c.name} from this view`}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      removeScopeExtra(c.id);
-                    }}
-                    style={{
-                      border: "none",
-                      background: "transparent",
-                      color: t.textMuted,
-                      cursor: "pointer",
-                      padding: 0,
-                      display: "inline-flex",
-                      alignItems: "center",
-                      lineHeight: 1,
-                      fontSize: FS_XS,
-                    }}
-                  >
-                    ×
-                  </button>
-                )}
-              </span>
-            </Tooltip>
-          );
-        })}
-      </div>
+      <MemberStrip
+        contexts={contexts}
+        conns={conns}
+        colorIdx={colorIdx}
+        shortName={shortName}
+        qualifierFor={(c) => clusterLabels[c.id]?.qualifier ?? null}
+      />
 
       {/* Temporary (ad-hoc) views get a standing Save affordance — the
           same save flow the "+" menu offers, surfaced so the operator
@@ -591,7 +523,7 @@ function VirtualClusterBar({
               contexts.map((c) => (
                 <MenuRow
                   key={c.id}
-                  label={c.name}
+                  label={shortName(c)}
                   hint=""
                   dotColor={clusterAccent(colorIdx[c.id] ?? 0)}
                   onClick={() => {
@@ -599,7 +531,7 @@ function VirtualClusterBar({
                       addDockTab(
                         makeTerminalTab(
                           { mode: "shell", clusterId: c.id, namespace: null },
-                          c.name,
+                          shortName(c),
                         ),
                       );
                     } else {
@@ -628,8 +560,8 @@ function VirtualClusterBar({
                     key={c.id}
                     t={t}
                     icon={Icons.cluster}
-                    title={c.name}
-                    subtitle={c.cluster}
+                    title={shortName(c)}
+                    subtitle={clusterLabels[c.id]?.qualifier ?? c.cluster}
                     onClick={() => {
                       addScopeExtra(c.id);
                       setMenuOpen(false);
@@ -706,6 +638,468 @@ function VirtualClusterBar({
 // Minimal dropdown row for the VirtualClusterBar "+" menu. Kept local —
 // ClusterBar's AddMenuItem carries icon+subtitle chrome this compact menu
 // doesn't need.
+// The bar's member list. Scales from two clusters to a few dozen without a
+// magic cutoff: chips render while they fit the measured width, then a health
+// rollup summarises what's left and a "+N" pill opens the full list.
+//
+// The old strip was a plain flex row with `overflow: hidden`, so past a
+// handful of members the extras were clipped SILENTLY — no count, no way to
+// reach them, and an unreachable member could be invisible.
+function MemberStrip({
+  contexts,
+  conns,
+  colorIdx,
+  shortName,
+  qualifierFor,
+}: {
+  contexts: ContextInfo[];
+  conns: Record<string, MemberConn>;
+  colorIdx: Record<string, number>;
+  shortName: (c: { id: string; name: string }) => string;
+  qualifierFor: (c: ContextInfo) => string | null;
+}) {
+  const t = useResolvedTheme().tokens;
+  const clusterHealth = useAppStore((s) => s.clusterHealth);
+  const scopeExtras = useAppStore((s) => s.scopeExtras);
+  const removeScopeExtra = useAppStore((s) => s.removeScopeExtra);
+  const focusedClusterId = useAppStore((s) => s.focusedClusterId);
+  const toggleFocusedCluster = useAppStore((s) => s.toggleFocusedCluster);
+
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const overflowRef = useRef<HTMLDivElement | null>(null);
+
+  // Measured width of the strip. Seeded optimistically so the first paint
+  // shows chips rather than a "+N" that immediately expands.
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(640);
+  useLayoutEffect(() => {
+    const el = stripRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (typeof w === "number") setWidth(w);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const health = (c: ContextInfo): { bucket: MemberHealth; label: string } => {
+    // Auto-reconnecting wins over the underlying error/unavailable state so
+    // the chip matches the single "reconnecting…" strip the operator sees.
+    if (conns[c.id]?.autoReconnect != null) {
+      return { bucket: "connecting", label: "reconnecting" };
+    }
+    const st = conns[c.id]?.state.status;
+    if (st === "ok") {
+      return clusterHealth[c.id] === "unavailable"
+        ? { bucket: "bad", label: "unavailable" }
+        : { bucket: "ok", label: "connected" };
+    }
+    if (st === "error" || st === "cancelled") {
+      return { bucket: "bad", label: st };
+    }
+    return { bucket: "connecting", label: "connecting" };
+  };
+  const bucketColor = (b: MemberHealth) =>
+    b === "ok" ? t.good : b === "bad" ? t.bad : t.warn;
+
+  const byId = new Map(contexts.map((c) => [c.id, c]));
+  const members: StripMember[] = contexts.map((c) => ({
+    id: c.id,
+    label: shortName(c),
+    health: health(c).bucket,
+    removable: scopeExtras.includes(c.id),
+  }));
+
+  const counts = healthCounts(members);
+  // Chicken-and-egg: the rollup's width depends on whether anything is
+  // hidden, which depends on the space the rollup takes. Reserve for it
+  // whenever it *could* show (anything unhealthy), then decide for real.
+  const mayRollup = counts.connecting > 0 || counts.bad > 0;
+  const fit = fitStrip(members, width, {
+    pinnedId: focusedClusterId,
+    rollupBuckets: mayRollup ? populatedBuckets(counts) : 0,
+  });
+  const showRollup = shouldShowRollup(counts, fit.hidden.length);
+
+  useEffect(() => {
+    if (!overflowOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (overflowRef.current && !overflowRef.current.contains(e.target as Node))
+        setOverflowOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOverflowOpen(false);
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [overflowOpen]);
+  useEffect(() => {
+    if (!overflowOpen) setQuery("");
+  }, [overflowOpen]);
+
+  const chip = (m: StripMember) => {
+    const c = byId.get(m.id);
+    if (!c) return null;
+    const h = health(c);
+    const focused = focusedClusterId === m.id;
+    return (
+      <Tooltip
+        key={m.id}
+        label={`${c.name} — ${h.label}${m.removable ? " (ad-hoc)" : ""}${
+          focused ? " · showing only this cluster" : " · click to show only this cluster"
+        }`}
+      >
+        <span
+          role="button"
+          tabIndex={0}
+          aria-pressed={focused}
+          aria-label={`${c.name}, ${h.label}`}
+          onClick={() => toggleFocusedCluster(m.id)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              toggleFocusedCluster(m.id);
+            }
+          }}
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "3px 8px",
+            borderRadius: R_MD,
+            background: focused ? t.accentSoft : t.chip,
+            border: `1px ${m.removable ? "dashed" : "solid"} ${
+              focused ? t.accent : t.borderSoft
+            }`,
+            fontSize: FS_XS,
+            fontFamily: FF_MONO,
+            color: focused ? t.text : t.textDim,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            maxWidth: 220,
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: clusterAccent(colorIdx[m.id] ?? 0),
+              flexShrink: 0,
+            }}
+          />
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis" }}>
+            {m.label}
+          </span>
+          <span
+            aria-hidden
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: bucketColor(m.health),
+              flexShrink: 0,
+            }}
+          />
+          {m.removable && (
+            <button
+              type="button"
+              aria-label={`Remove ${c.name} from this view`}
+              onClick={(e) => {
+                e.stopPropagation();
+                removeScopeExtra(m.id);
+              }}
+              style={{
+                border: "none",
+                background: "transparent",
+                color: t.textMuted,
+                cursor: "pointer",
+                padding: 0,
+                display: "inline-flex",
+                alignItems: "center",
+                lineHeight: 1,
+                fontSize: FS_XS,
+              }}
+            >
+              ×
+            </button>
+          )}
+        </span>
+      </Tooltip>
+    );
+  };
+
+  const hiddenMatching = query.trim()
+    ? members.filter((m) => {
+        const c = byId.get(m.id);
+        const needle = query.trim().toLowerCase();
+        return (
+          m.label.toLowerCase().includes(needle) ||
+          (c?.name ?? "").toLowerCase().includes(needle)
+        );
+      })
+    : members;
+
+  return (
+    <div
+      ref={stripRef}
+      data-testid="member-strip"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        flex: 1,
+        minWidth: 0,
+        overflow: "hidden",
+      }}
+    >
+      {fit.visible.map(chip)}
+
+      {showRollup && (
+        <Tooltip label={rollupSummary(counts)}>
+          <span
+            data-testid="member-rollup"
+            aria-label={rollupSummary(counts)}
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              flexShrink: 0,
+              fontSize: FS_XS,
+              fontFamily: FF_MONO,
+              color: t.textMuted,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          >
+            {(["ok", "connecting", "bad"] as const)
+              .filter((b) => counts[b] > 0)
+              .map((b) => (
+                <span
+                  key={b}
+                  style={{ display: "inline-flex", alignItems: "center", gap: 3 }}
+                >
+                  <span
+                    aria-hidden
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: bucketColor(b),
+                    }}
+                  />
+                  {counts[b]}
+                </span>
+              ))}
+          </span>
+        </Tooltip>
+      )}
+
+      {fit.hidden.length > 0 && (
+        <div ref={overflowRef} style={{ position: "relative", flexShrink: 0 }}>
+          <button
+            type="button"
+            data-testid="member-overflow"
+            aria-haspopup="dialog"
+            aria-expanded={overflowOpen}
+            aria-label={`Show all ${members.length} clusters (${fit.hidden.length} not shown)`}
+            onClick={() => setOverflowOpen((v) => !v)}
+            style={{
+              border: `1px solid ${t.borderSoft}`,
+              background: overflowOpen ? t.accentSoft : t.chip,
+              color: overflowOpen ? t.accent : t.textDim,
+              borderRadius: R_MD,
+              padding: "3px 8px",
+              fontSize: FS_XS,
+              fontFamily: FF_MONO,
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+            }}
+          >
+            +{fit.hidden.length}
+          </button>
+          {overflowOpen && (
+            <div
+              role="dialog"
+              aria-label="All clusters in this view"
+              style={{
+                position: "absolute",
+                top: "calc(100% + 6px)",
+                left: 0,
+                zIndex: 30,
+                minWidth: 280,
+                maxWidth: 380,
+                maxHeight: 340,
+                overflowY: "auto",
+                background: t.surface,
+                border: `1px solid ${t.border}`,
+                borderRadius: R_MD,
+                boxShadow: "0 8px 28px rgba(0,0,0,0.28)",
+                padding: 4,
+              }}
+            >
+              {members.length > 8 && (
+                <input
+                  autoFocus
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search clusters…"
+                  aria-label="Search clusters in this view"
+                  style={{
+                    width: "100%",
+                    boxSizing: "border-box",
+                    margin: "2px 0 6px",
+                    padding: "5px 8px",
+                    border: `1px solid ${t.borderSoft}`,
+                    borderRadius: R_SM,
+                    background: t.chip,
+                    color: t.text,
+                    fontSize: FS_XS,
+                    fontFamily: FF_MONO,
+                    outline: "none",
+                  }}
+                />
+              )}
+              {hiddenMatching.length === 0 && (
+                <div
+                  style={{
+                    padding: "8px 8px 10px",
+                    fontSize: FS_XS,
+                    color: t.textMuted,
+                    fontFamily: FF_MONO,
+                  }}
+                >
+                  No cluster matches “{query.trim()}”.
+                </div>
+              )}
+              {hiddenMatching.map((m) => {
+                const c = byId.get(m.id);
+                if (!c) return null;
+                const h = health(c);
+                const focused = focusedClusterId === m.id;
+                const qualifier = qualifierFor(c);
+                return (
+                  <div
+                    key={m.id}
+                    role="button"
+                    tabIndex={0}
+                    aria-pressed={focused}
+                    title={c.name}
+                    onClick={() => {
+                      toggleFocusedCluster(m.id);
+                      setOverflowOpen(false);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        toggleFocusedCluster(m.id);
+                        setOverflowOpen(false);
+                      }
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "6px 8px",
+                      borderRadius: R_SM,
+                      cursor: "pointer",
+                      background: focused ? t.accentSoft : "transparent",
+                      color: focused ? t.text : t.textDim,
+                    }}
+                  >
+                    <span
+                      aria-hidden
+                      style={{
+                        width: 8,
+                        height: 8,
+                        borderRadius: "50%",
+                        background: clusterAccent(colorIdx[m.id] ?? 0),
+                        flexShrink: 0,
+                      }}
+                    />
+                    <span style={{ flex: 1, minWidth: 0 }}>
+                      <span
+                        style={{
+                          display: "block",
+                          fontSize: FS_XS,
+                          fontFamily: FF_MONO,
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {m.label}
+                      </span>
+                      {qualifier && (
+                        <span
+                          style={{
+                            display: "block",
+                            fontSize: FS_XS,
+                            fontFamily: FF_MONO,
+                            color: t.textMuted,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {qualifier}
+                        </span>
+                      )}
+                    </span>
+                    <span
+                      style={{
+                        fontSize: FS_XS,
+                        fontFamily: FF_MONO,
+                        color: bucketColor(m.health),
+                        flexShrink: 0,
+                      }}
+                    >
+                      {h.label}
+                    </span>
+                    {m.removable && (
+                      <button
+                        type="button"
+                        aria-label={`Remove ${c.name} from this view`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          removeScopeExtra(m.id);
+                        }}
+                        style={{
+                          border: "none",
+                          background: "transparent",
+                          color: t.textMuted,
+                          cursor: "pointer",
+                          padding: 0,
+                          display: "inline-flex",
+                          alignItems: "center",
+                          lineHeight: 1,
+                          fontSize: FS_XS,
+                          flexShrink: 0,
+                        }}
+                      >
+                        ×
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function MenuRow({
   label,
   hint,

--- a/ui/src/components/forwards/NewForwardForm.test.tsx
+++ b/ui/src/components/forwards/NewForwardForm.test.tsx
@@ -200,3 +200,48 @@ describe("NewForwardForm — global (DNS) mode", () => {
     });
   });
 });
+
+describe("NewForwardForm cluster picker labels", () => {
+  const GKE_A = "gke_development-d83ab4a8_europe-west4_truenv-03";
+  const GKE_B = "gke_development-d83ab4a8_europe-west4_autotest-01";
+  const gke = (name: string): ContextInfo => ({
+    ...ctx,
+    id: `default::${name}`,
+    name,
+    cluster: name,
+  });
+
+  it("labels each cluster with its short name plus the stripped coordinate", async () => {
+    // Without the coordinate, every context in one GKE project truncates to
+    // the same `gke_development-d83ab4a8…` in this narrow select.
+    useAppStore.setState({
+      contexts: [gke(GKE_A), gke(GKE_B)],
+      selectedContext: `default::${GKE_A}`,
+    });
+    mockForm([]);
+    render(<NewForwardForm t={t} onDone={() => {}} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText(
+          "truenv-03 · development-d83ab4a8 · europe-west4",
+        ).length,
+      ).toBeGreaterThan(0),
+    );
+    expect(screen.queryByText(GKE_A)).toBeNull();
+  });
+
+  it("falls back to the full name when shortening is off", async () => {
+    useAppStore.getState().patchSettings({ shortenClusterNames: false });
+    useAppStore.setState({
+      contexts: [gke(GKE_A)],
+      selectedContext: `default::${GKE_A}`,
+    });
+    mockForm([]);
+    render(<NewForwardForm t={t} onDone={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getAllByText(GKE_A).length).toBeGreaterThan(0),
+    );
+    useAppStore.getState().patchSettings({ shortenClusterNames: true });
+  });
+});

--- a/ui/src/components/forwards/NewForwardForm.tsx
+++ b/ui/src/components/forwards/NewForwardForm.tsx
@@ -17,7 +17,7 @@
 
 import { useEffect, useState } from "react";
 import { api } from "../../api";
-import { useAppStore } from "../../store";
+import { useAppStore, useClusterLabels } from "../../store";
 import type { Tokens } from "../../theme";
 import { FS_SM, FS_XS } from "../../theme";
 import type { ServicePick } from "../../types";
@@ -100,6 +100,7 @@ function ManualToggle({
 
 export function NewForwardForm({ t, onDone }: { t: Tokens; onDone: () => void }) {
   const contexts = useAppStore((s) => s.contexts);
+  const clusterLabels = useClusterLabels();
   const selectedContext = useAppStore((s) => s.selectedContext);
   const upsertForward = useAppStore((s) => s.upsertForward);
   const upsertGlobalForward = useAppStore((s) => s.upsertGlobalForward);
@@ -294,7 +295,16 @@ export function NewForwardForm({ t, onDone }: { t: Tokens; onDone: () => void })
     }
   };
 
-  const clusterOptions = contexts.map((c) => ({ value: c.id, label: c.name }));
+  // Short name + the coordinate it was stripped of. Without the coordinate
+  // every GKE context in one project truncates to the same
+  // `gke_development-d83ab4a8…` in this narrow select.
+  const clusterOptions = contexts.map((c) => {
+    const l = clusterLabels[c.id];
+    return {
+      value: c.id,
+      label: l?.qualifier ? `${l.short} · ${l.qualifier}` : l?.short ?? c.name,
+    };
+  });
 
   // --- Dynamic-field derivations ---
   const wantsServicePicker =

--- a/ui/src/lib/clusterName.test.ts
+++ b/ui/src/lib/clusterName.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest";
+import {
+  clusterLabels,
+  labelFor,
+  parseContextName,
+  type LabelSource,
+} from "./clusterName";
+
+// Every fixture below is a real-world shape taken from the provider's own
+// documentation, not an invented one — the parser is only worth anything if
+// it matches what the CLIs actually write.
+
+const ctx = (
+  name: string,
+  user: string | null = null,
+  id = `default::${name}`,
+): LabelSource => ({ id, name, user });
+
+describe("parseContextName — recognised schemes", () => {
+  it("splits a GKE context into cluster + project + location", () => {
+    const p = parseContextName(
+      "gke_production-4f83b34d_us-central1_prod-6",
+      null,
+    );
+    expect(p).toEqual({
+      provider: "gke",
+      short: "prod-6",
+      qualifiers: ["production-4f83b34d", "us-central1"],
+    });
+  });
+
+  it("keeps hyphenated GKE cluster names whole", () => {
+    expect(
+      parseContextName(
+        "gke_tld-production-d087a553_us-central1_gke-prod-hardworking-goose",
+        null,
+      ).short,
+    ).toBe("gke-prod-hardworking-goose");
+  });
+
+  it("splits an EKS cluster ARN into cluster + account + region", () => {
+    expect(
+      parseContextName(
+        "arn:aws:eks:us-east-2:111122223333:cluster/my-eks-cluster",
+        null,
+      ),
+    ).toEqual({
+      provider: "eks",
+      short: "my-eks-cluster",
+      qualifiers: ["111122223333", "us-east-2"],
+    });
+  });
+
+  it.each([
+    ["arn:aws-cn:eks:cn-north-1:111122223333:cluster/prod", "cn-north-1"],
+    [
+      "arn:aws-us-gov:eks:us-gov-west-1:111122223333:cluster/prod",
+      "us-gov-west-1",
+    ],
+  ])("handles the %s partition", (arn, region) => {
+    const p = parseContextName(arn, null);
+    expect(p.provider).toBe("eks");
+    expect(p.short).toBe("prod");
+    expect(p.qualifiers).toEqual(["111122223333", region]);
+  });
+
+  it("splits an eksctl context into cluster + region + identity", () => {
+    expect(
+      parseContextName("admin@my-cluster.eu-north-1.eksctl.io", null),
+    ).toEqual({
+      provider: "eksctl",
+      short: "my-cluster",
+      qualifiers: ["eu-north-1", "admin"],
+    });
+  });
+
+  it("handles the eksctl root-account identity", () => {
+    const p = parseContextName(
+      "iam-root-account@sigridjin-ekscluster-240413-3.ap-northeast-2.eksctl.io",
+      null,
+    );
+    expect(p.short).toBe("sigridjin-ekscluster-240413-3");
+    expect(p.qualifiers).toEqual(["ap-northeast-2", "iam-root-account"]);
+  });
+
+  it("parses an eksctl name with no identity prefix", () => {
+    expect(parseContextName("my-cluster.eu-north-1.eksctl.io", null)).toEqual({
+      provider: "eksctl",
+      short: "my-cluster",
+      qualifiers: ["eu-north-1"],
+    });
+  });
+
+  it("reduces an oc login context to the api host", () => {
+    expect(
+      parseContextName("default/api-ocp-example-com:6443/kubeadmin", null),
+    ).toEqual({
+      provider: "openshift",
+      short: "ocp-example-com",
+      qualifiers: ["default", "kubeadmin"],
+    });
+  });
+
+  it("drops the empty namespace segment of an oc context", () => {
+    expect(
+      parseContextName("/api-ocp-example-com:6443/kubeadmin", null).qualifiers,
+    ).toEqual(["kubeadmin"]);
+  });
+
+  it("recovers the AKS resource group from the user entry", () => {
+    expect(
+      parseContextName("myAKSCluster", "clusterUser_myResourceGroup_myAKSCluster"),
+    ).toEqual({
+      provider: "aks",
+      short: "myAKSCluster",
+      qualifiers: ["myResourceGroup"],
+    });
+  });
+
+  it("recovers a resource group that itself contains underscores", () => {
+    // `az` joins on `_` but Azure allows `_` inside a resource-group name, so
+    // the group can only be recovered by anchoring on the cluster name.
+    expect(
+      parseContextName("aks01", "clusterUser_my_rg_01_aks01").qualifiers,
+    ).toEqual(["my_rg_01"]);
+  });
+
+  it("recovers the region from a DigitalOcean context", () => {
+    expect(parseContextName("do-ams3-k8swim", null)).toEqual({
+      provider: "digitalocean",
+      short: "do-ams3-k8swim",
+      qualifiers: ["ams3"],
+    });
+  });
+});
+
+describe("parseContextName — never shortens what it can't prove", () => {
+  it.each([
+    "",
+    "minikube",
+    "kind-ruw-e2e",
+    "k3d-dev",
+    "rancher-desktop",
+    // GKE-ish but wrong arity / empty segments.
+    "gke_",
+    "gke_a_b",
+    "gke_a_b_c_d",
+    "gke__us-central1_prod",
+    "gke_project_us-central1_",
+    // ARN-ish but truncated.
+    "arn:aws:eks:us-east-1",
+    "arn:aws:eks:us-east-1:111122223333:cluster/",
+    "arn:aws:ec2:us-east-1:111122223333:instance/i-abc",
+    // eksctl-ish but missing a component.
+    ".eksctl.io",
+    "cluster.eksctl.io",
+    "my-cluster.eksctl.io",
+    // oc-ish but the middle segment isn't host:port.
+    "a/b/c",
+    "default/api-ocp-example-com/kubeadmin",
+  ])("leaves %o byte-identical", (name) => {
+    const p = parseContextName(name, null);
+    expect(p.short).toBe(name);
+    expect(p.qualifiers).toEqual([]);
+  });
+
+  it("never strips the AKS -admin suffix", () => {
+    // `foo` and `foo-admin` are different credentials that coexist in one
+    // kubeconfig; collapsing them would hide which one is connecting.
+    const p = parseContextName(
+      "myAKSCluster-admin",
+      "clusterAdmin_myResourceGroup_myAKSCluster",
+    );
+    expect(p.short).toBe("myAKSCluster-admin");
+    expect(p.qualifiers).toEqual(["myResourceGroup"]);
+  });
+
+  it("ignores a user entry that isn't AKS-shaped", () => {
+    expect(parseContextName("prod", "clusterUser_rg_other").provider).toBe(
+      "unknown",
+    );
+    expect(parseContextName("prod", "some-oidc-user").provider).toBe("unknown");
+  });
+
+  it("ignores a do- prefix that isn't followed by a region token", () => {
+    expect(parseContextName("do-not-shorten-me", null).provider).toBe(
+      "unknown",
+    );
+  });
+});
+
+describe("clusterLabels", () => {
+  const FLEET: LabelSource[] = [
+    ctx("gke_development-d83ab4a8_europe-west4_truenv-03"),
+    ctx("gke_production-4f83b34d_us-central1_prod-6"),
+    ctx("gke_production-4f83b34d_us-central1_prod-7"),
+    ctx("gke_production-4f83b34d_us-central1_analytics-2"),
+    ctx("kind-ruw-e2e"),
+  ];
+
+  it("shortens recognised names and leaves the rest alone", () => {
+    const labels = clusterLabels(FLEET, true);
+    expect(
+      labels["default::gke_production-4f83b34d_us-central1_prod-6"]!.short,
+    ).toBe("prod-6");
+    expect(labels["default::kind-ruw-e2e"]!.short).toBe("kind-ruw-e2e");
+    expect(labels["default::kind-ruw-e2e"]!.qualifier).toBeNull();
+  });
+
+  it("keeps the full name available for tooltips and search", () => {
+    const labels = clusterLabels(FLEET, true);
+    expect(
+      labels["default::gke_production-4f83b34d_us-central1_prod-6"]!.full,
+    ).toBe("gke_production-4f83b34d_us-central1_prod-6");
+  });
+
+  it("exposes the stripped coordinate as qualifier + group", () => {
+    const l = clusterLabels(FLEET, true)[
+      "default::gke_production-4f83b34d_us-central1_prod-6"
+    ]!;
+    expect(l.qualifier).toBe("production-4f83b34d · us-central1");
+    expect(l.groupLabel).toBe("production-4f83b34d · us-central1");
+    expect(l.groupKey).toBe("gke|production-4f83b34d|us-central1");
+  });
+
+  it("gives contexts from one project the same groupKey and others a different one", () => {
+    const labels = clusterLabels(FLEET, true);
+    const prod6 =
+      labels["default::gke_production-4f83b34d_us-central1_prod-6"]!.groupKey;
+    const prod7 =
+      labels["default::gke_production-4f83b34d_us-central1_prod-7"]!.groupKey;
+    const dev =
+      labels["default::gke_development-d83ab4a8_europe-west4_truenv-03"]!
+        .groupKey;
+    expect(prod6).toBe(prod7);
+    expect(dev).not.toBe(prod6);
+    expect(labels["default::kind-ruw-e2e"]!.groupKey).toBeNull();
+  });
+
+  it("leaves display fields untouched when disabled", () => {
+    const labels = clusterLabels(FLEET, false);
+    for (const c of FLEET) {
+      expect(labels[c.id]!.full).toBe(c.name);
+      expect(labels[c.id]!.short).toBe(c.name);
+      expect(labels[c.id]!.qualifier).toBeNull();
+    }
+  });
+
+  it("still resolves grouping keys when shortening is disabled", () => {
+    // The two settings are independent: the fleet must be able to bucket by
+    // project while rendering full names.
+    const labels = clusterLabels(FLEET, false);
+    expect(
+      labels["default::gke_production-4f83b34d_us-central1_prod-6"]!.groupKey,
+    ).toBe("gke|production-4f83b34d|us-central1");
+    expect(
+      labels["default::gke_production-4f83b34d_us-central1_prod-6"]!.groupKey,
+    ).toBe(
+      labels["default::gke_production-4f83b34d_us-central1_prod-7"]!.groupKey,
+    );
+    expect(labels["default::kind-ruw-e2e"]!.groupKey).toBeNull();
+  });
+
+  it("re-resolves when the enabled flag flips on the same array", () => {
+    const on = clusterLabels(FLEET, true);
+    const off = clusterLabels(FLEET, false);
+    expect(on["default::kind-ruw-e2e"]!.short).toBe("kind-ruw-e2e");
+    expect(
+      off["default::gke_production-4f83b34d_us-central1_prod-6"]!.short,
+    ).toBe("gke_production-4f83b34d_us-central1_prod-6");
+  });
+
+  it("reverts both sides of an ambiguous pair to their full names", () => {
+    // Same cluster segment, same project, different provider path: the
+    // shortened pair would be indistinguishable, so neither is shortened.
+    const fleet: LabelSource[] = [
+      ctx("gke_shared_us-central1_prod", null, "a"),
+      ctx("gke_shared_us-central1_prod", null, "b"),
+    ];
+    const labels = clusterLabels(fleet, true);
+    expect(labels["a"]!.short).toBe("gke_shared_us-central1_prod");
+    expect(labels["b"]!.short).toBe("gke_shared_us-central1_prod");
+    expect(labels["a"]!.qualifier).toBeNull();
+    // Grouping is unaffected — they really are in the same project.
+    expect(labels["a"]!.groupKey).toBe("gke|shared|us-central1");
+  });
+
+  it("keeps same-named clusters in different projects distinguishable", () => {
+    const fleet: LabelSource[] = [
+      ctx("gke_paylnx-production-3s33s33s_us-central1_prod-1", null, "a"),
+      ctx("gke_tld-production-d087a553_us-central1_prod-1", null, "b"),
+    ];
+    const labels = clusterLabels(fleet, true);
+    expect(labels["a"]!.short).toBe("prod-1");
+    expect(labels["b"]!.short).toBe("prod-1");
+    expect(labels["a"]!.qualifier).not.toBe(labels["b"]!.qualifier);
+  });
+
+  it("renders a unique short+qualifier pair for every context in a mixed fleet", () => {
+    const fleet: LabelSource[] = [
+      ...FLEET,
+      ctx("arn:aws:eks:us-east-2:111122223333:cluster/prod-6", null, "eks"),
+      ctx("admin@prod-6.eu-north-1.eksctl.io", null, "eksctl"),
+      ctx("prod-6", "clusterUser_rg-a_prod-6", "aks-a"),
+      ctx("prod-6", "clusterUser_rg-b_prod-6", "aks-b"),
+      ctx("do-ams3-prod-6", null, "do"),
+    ];
+    const labels = clusterLabels(fleet, true);
+    const rendered = fleet.map((c) => {
+      const l = labels[c.id]!;
+      return l.qualifier ? `${l.short} · ${l.qualifier}` : l.short;
+    });
+    expect(new Set(rendered).size).toBe(fleet.length);
+  });
+});
+
+describe("labelFor", () => {
+  it("returns the resolved label when the context exists", () => {
+    const labels = clusterLabels(
+      [ctx("gke_proj_us-central1_prod", null, "x")],
+      true,
+    );
+    expect(labelFor(labels, "x").short).toBe("prod");
+  });
+
+  it("falls back to the supplied name for a context missing from kubeconfig", () => {
+    expect(labelFor({}, "default::gone", "gone").short).toBe("gone");
+  });
+
+  it("falls back to the id when there is no name either", () => {
+    expect(labelFor({}, "default::gone").short).toBe("default::gone");
+  });
+});

--- a/ui/src/lib/clusterName.ts
+++ b/ui/src/lib/clusterName.ts
@@ -1,0 +1,303 @@
+// Shortening machine-generated kubeconfig context names. No React — every
+// function here is pure and unit-testable, and the memoised entry point is
+// shared by the fleet landing, the rail's open-cluster strip, the cluster
+// tabs, the command palette and the chat's view context so one cluster reads
+// the same everywhere.
+//
+// Managed-Kubernetes CLIs write context names that encode the whole cloud
+// coordinate, not just the cluster. A GKE-heavy kubeconfig is a wall of
+// near-identical 50-character strings where only the last token differs:
+//
+//   gke_production-4f83b34d_us-central1_prod-6
+//   gke_production-4f83b34d_us-central1_analytics-2
+//
+// We strip the coordinate down to the cluster segment and keep what we
+// stripped as `qualifiers` — surfaced next to the short name where there's
+// room, and used as the fleet landing's sub-grouping key.
+//
+// The hard rule: a shape we don't recognise is returned BYTE-IDENTICAL. There
+// is no heuristic fallback that trims "probably redundant" tokens, because a
+// wrong guess here points the operator at the wrong cluster.
+
+import type { ContextInfo } from "../types";
+
+/// The naming scheme a context name was recognised as. `unknown` covers
+/// kind / k3d / minikube / Rancher / hand-written contexts — all already
+/// short — and anything whose shape drifted from what we parse.
+export type ClusterProvider =
+  | "gke"
+  | "eks"
+  | "eksctl"
+  | "openshift"
+  | "aks"
+  | "digitalocean"
+  | "unknown";
+
+/// Result of parsing one context name in isolation. `short` equals the input
+/// name whenever nothing could be safely stripped.
+export type ParsedContext = {
+  provider: ClusterProvider;
+  short: string;
+  /// What was stripped (or, for schemes whose names are already short, what
+  /// we learned from elsewhere in the kubeconfig). Most specific first:
+  /// project/account before location/region.
+  qualifiers: string[];
+};
+
+/// A context's display strings, resolved against the whole fleet so the
+/// rendered pair is unambiguous.
+export type ClusterLabel = {
+  /// The original context name. Authoritative — belongs in every tooltip and
+  /// every search keyword string.
+  full: string;
+  /// What to render as the name.
+  short: string;
+  /// Dim suffix rendered next to `short` where there's horizontal room.
+  /// `null` when there's nothing to add.
+  qualifier: string | null;
+  /// Stable bucket key for the fleet landing's project sub-grouping. `null`
+  /// when the context has no qualifier to group by.
+  groupKey: string | null;
+  /// Human header for that bucket.
+  groupLabel: string | null;
+};
+
+/// The subset of `ContextInfo` label resolution needs. Taking a structural
+/// type (rather than `ContextInfo`) keeps the helper usable from tests and
+/// from `clusterTabLabel`, which already threads a narrowed shape around.
+export type LabelSource = Pick<ContextInfo, "id" | "name" | "user">;
+
+const EKS_ARN = /^arn:aws[\w-]*:eks:([^:]+):([^:]+):cluster\/(.+)$/;
+const EKSCTL_SUFFIX = ".eksctl.io";
+const AKS_USER = /^cluster(?:Admin|User)_(.+)$/;
+const AKS_ADMIN_SUFFIX = "-admin";
+const OPENSHIFT_SERVER = /^[A-Za-z0-9.-]+:\d+$/;
+// DigitalOcean regions are a short letter run plus a digit — nyc1, ams3,
+// sfo2, blr1. Anchored so a cluster merely *named* `do-something` doesn't
+// get mistaken for one.
+const DO_PREFIX = /^do-([a-z]{2,5}\d+)-(.+)$/;
+
+function unknown(name: string): ParsedContext {
+  return { provider: "unknown", short: name, qualifiers: [] };
+}
+
+/// `aws eks update-kubeconfig` defaults both the context and the user name to
+/// the cluster ARN. `aws[\w-]*` covers the `aws-cn` and `aws-us-gov`
+/// partitions, whose ARNs are otherwise identically shaped.
+function parseEksArn(name: string): ParsedContext | null {
+  const m = EKS_ARN.exec(name);
+  if (!m) return null;
+  const [, region, account, cluster] = m;
+  if (!region || !account || !cluster) return null;
+  return { provider: "eks", short: cluster, qualifiers: [account, region] };
+}
+
+/// eksctl writes `<identity>@<cluster>.<region>.eksctl.io`. The identity is
+/// the IAM principal that created the cluster (literally `iam-root-account`
+/// when that was the account root user). EKS cluster names can't contain
+/// dots, so the region is unambiguously the last dot-segment.
+function parseEksctl(name: string): ParsedContext | null {
+  if (!name.endsWith(EKSCTL_SUFFIX)) return null;
+  const body = name.slice(0, -EKSCTL_SUFFIX.length);
+  const at = body.indexOf("@");
+  const identity = at > 0 ? body.slice(0, at) : null;
+  const rest = at >= 0 ? body.slice(at + 1) : body;
+  const dot = rest.lastIndexOf(".");
+  if (dot <= 0 || dot === rest.length - 1) return null;
+  const cluster = rest.slice(0, dot);
+  const region = rest.slice(dot + 1);
+  if (!cluster || !region) return null;
+  return {
+    provider: "eksctl",
+    short: cluster,
+    qualifiers: identity ? [region, identity] : [region],
+  };
+}
+
+/// `gcloud container clusters get-credentials` writes
+/// `gke_<project>_<location>_<cluster>`. None of the three GCP segments may
+/// contain an underscore, so a 4-way split is exact rather than a guess.
+function parseGke(name: string): ParsedContext | null {
+  const parts = name.split("_");
+  if (parts.length !== 4) return null;
+  const [head, project, location, cluster] = parts;
+  if (head !== "gke") return null;
+  if (!project || !location || !cluster) return null;
+  return { provider: "gke", short: cluster, qualifiers: [project, location] };
+}
+
+/// `oc login` writes `<namespace>/<host-with-dots-dashed>:<port>/<user>`.
+/// The namespace segment is empty when no project is selected.
+function parseOpenShift(name: string): ParsedContext | null {
+  const seg = name.split("/");
+  if (seg.length !== 3) return null;
+  const namespace = seg[0] ?? "";
+  const server = seg[1] ?? "";
+  const user = seg[2] ?? "";
+  if (!OPENSHIFT_SERVER.test(server)) return null;
+  let host = server.replace(/:\d+$/, "");
+  if (host.startsWith("api-")) host = host.slice(4);
+  if (!host) return null;
+  return {
+    provider: "openshift",
+    short: host,
+    qualifiers: [namespace, user].filter((q) => q.length > 0),
+  };
+}
+
+/// AKS context names are ALREADY the bare cluster name (`myAKSCluster`, or
+/// `myAKSCluster-admin` for `--admin` credentials), so there is nothing to
+/// shorten. What we recover is the resource group, which `az aks
+/// get-credentials` puts only in the user entry — a long-standing gap that
+/// makes same-named clusters in two resource groups indistinguishable.
+///
+/// `-admin` is deliberately NOT stripped: `foo` and `foo-admin` are different
+/// credentials that legitimately coexist in one kubeconfig, and collapsing
+/// them would hide which one is connecting.
+///
+/// Resource-group names may themselves contain underscores, so the group is
+/// recovered by anchoring on the known cluster name at the end rather than by
+/// splitting on `_`.
+function parseAks(name: string, user: string | null): ParsedContext | null {
+  if (!user) return null;
+  const m = AKS_USER.exec(user);
+  if (!m) return null;
+  const rest = m[1] ?? "";
+  const cluster = name.endsWith(AKS_ADMIN_SUFFIX)
+    ? name.slice(0, -AKS_ADMIN_SUFFIX.length)
+    : name;
+  if (!cluster) return null;
+  const suffix = `_${cluster}`;
+  if (!rest.endsWith(suffix)) return null;
+  const group = rest.slice(0, -suffix.length);
+  if (!group) return null;
+  return { provider: "aks", short: name, qualifiers: [group] };
+}
+
+/// `doctl kubernetes cluster kubeconfig save` writes
+/// `do-<region>-<cluster>`. Already short enough to leave alone; we only
+/// recover the region so the fleet can group by it.
+function parseDigitalOcean(name: string): ParsedContext | null {
+  const m = DO_PREFIX.exec(name);
+  const region = m?.[1];
+  if (!region) return null;
+  return { provider: "digitalocean", short: name, qualifiers: [region] };
+}
+
+/// Parse one context name in isolation. `user` is the kubeconfig user entry
+/// (`ContextInfo.user`) — only AKS needs it, but it's cheap to thread.
+///
+/// Order matters only in that each branch is anchored tightly enough not to
+/// match another scheme's shape; the first match wins.
+export function parseContextName(
+  name: string,
+  user: string | null,
+): ParsedContext {
+  if (!name) return unknown(name);
+  return (
+    parseEksArn(name) ??
+    parseEksctl(name) ??
+    parseGke(name) ??
+    parseOpenShift(name) ??
+    parseAks(name, user) ??
+    parseDigitalOcean(name) ??
+    unknown(name)
+  );
+}
+
+function joinQualifiers(qualifiers: string[]): string | null {
+  return qualifiers.length > 0 ? qualifiers.join(" · ") : null;
+}
+
+function computeLabels(
+  contexts: readonly LabelSource[],
+  enabled: boolean,
+): Record<string, ClusterLabel> {
+  const parsed = contexts.map((c) => ({
+    c,
+    p: parseContextName(c.name, c.user ?? null),
+  }));
+
+  // Uniqueness pass. Shortening is only safe if the rendered pair still
+  // identifies exactly one cluster — otherwise a click connects to a
+  // different cluster than the operator read. Two contexts that collapse to
+  // the same `short · qualifier` both revert to their full names.
+  const seen = new Map<string, number>();
+  const renderKey = (p: ParsedContext) =>
+    `${p.short}|${p.qualifiers.join("|")}`;
+  for (const { p } of parsed) {
+    const k = renderKey(p);
+    seen.set(k, (seen.get(k) ?? 0) + 1);
+  }
+
+  const out: Record<string, ClusterLabel> = {};
+  for (const { c, p } of parsed) {
+    const coordinate = joinQualifiers(p.qualifiers);
+    // The grouping keys are derived from the PARSE, not from the display
+    // decision, so the fleet can bucket by project even with shortening
+    // turned off — the two settings are independent.
+    const groupKey = coordinate
+      ? `${p.provider}|${p.qualifiers.join("|")}`
+      : null;
+    const shortenable = enabled && (seen.get(renderKey(p)) ?? 0) === 1;
+    out[c.id] = {
+      full: c.name,
+      short: shortenable ? p.short : c.name,
+      qualifier: shortenable ? coordinate : null,
+      groupKey,
+      groupLabel: coordinate,
+    };
+  }
+  return out;
+}
+
+// One-entry memo. `contexts` is a stable array reference between store
+// updates, so the ~15 call sites that each ask for the map on render share a
+// single computation instead of re-parsing the fleet per component.
+let memoContexts: readonly LabelSource[] | null = null;
+let memoEnabled = false;
+let memoResult: Record<string, ClusterLabel> | null = null;
+
+/// Resolve display labels for the whole fleet, keyed by `ContextInfo.id`.
+///
+/// Always pass the COMPLETE context list, never a filtered or grouped subset:
+/// the uniqueness pass is list-aware, so feeding it a subset would let a
+/// label change when a search box is typed into.
+///
+/// `enabled` gates only the DISPLAY fields (`short` / `qualifier`).
+/// `groupKey` / `groupLabel` come from the parse either way, so the fleet's
+/// project grouping keeps working with shortening turned off.
+export function clusterLabels(
+  contexts: readonly LabelSource[],
+  enabled: boolean,
+): Record<string, ClusterLabel> {
+  if (memoResult && memoContexts === contexts && memoEnabled === enabled) {
+    return memoResult;
+  }
+  const result = computeLabels(contexts, enabled);
+  memoContexts = contexts;
+  memoEnabled = enabled;
+  memoResult = result;
+  return result;
+}
+
+/// Label lookup that degrades to the raw id for a context that has vanished
+/// from the kubeconfig (a stale tab, a virtual-context member pointing at a
+/// removed cluster). Callers rendering a possibly-missing cluster should use
+/// this rather than indexing the map directly.
+export function labelFor(
+  labels: Record<string, ClusterLabel>,
+  id: string,
+  fallback?: string | null,
+): ClusterLabel {
+  const hit = labels[id];
+  if (hit) return hit;
+  const name = fallback ?? id;
+  return {
+    full: name,
+    short: name,
+    qualifier: null,
+    groupKey: null,
+    groupLabel: null,
+  };
+}

--- a/ui/src/lib/clusterStrip.test.ts
+++ b/ui/src/lib/clusterStrip.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  chipWidthPx,
+  fitStrip,
+  healthCounts,
+  overflowPillPx,
+  populatedBuckets,
+  rollupSummary,
+  shouldShowRollup,
+  type StripMember,
+} from "./clusterStrip";
+
+const m = (
+  id: string,
+  label = id,
+  health: StripMember["health"] = "ok",
+  removable = false,
+): StripMember => ({ id, label, health, removable });
+
+describe("fitStrip", () => {
+  it("shows everything when it fits", () => {
+    const members = [m("a", "prod-6"), m("b", "prod-7")];
+    const fit = fitStrip(members, 1000);
+    expect(fit.visible).toHaveLength(2);
+    expect(fit.hidden).toHaveLength(0);
+  });
+
+  it("hides the tail and reports it when it does not fit", () => {
+    const members = Array.from({ length: 20 }, (_, i) =>
+      m(`c${i}`, `cluster-${i}`),
+    );
+    const fit = fitStrip(members, 400);
+    expect(fit.visible.length).toBeGreaterThan(0);
+    expect(fit.visible.length).toBeLessThan(20);
+    expect(fit.visible.length + fit.hidden.length).toBe(20);
+  });
+
+  it("leaves room for the overflow pill rather than clipping the last chip", () => {
+    const members = Array.from({ length: 8 }, (_, i) => m(`c${i}`, `abcdefgh`));
+    const width = 400;
+    const fit = fitStrip(members, width);
+    const used =
+      fit.visible.reduce((sum, x) => sum + chipWidthPx(x), 0) +
+      6 * Math.max(0, fit.visible.length - 1) +
+      6 +
+      overflowPillPx(fit.hidden.length);
+    expect(used).toBeLessThanOrEqual(width);
+  });
+
+  it("reserves width for the rollup", () => {
+    const members = Array.from({ length: 10 }, (_, i) => m(`c${i}`, `node-${i}`));
+    const without = fitStrip(members, 500).visible.length;
+    const withRollup = fitStrip(members, 500, { rollupBuckets: 3 }).visible
+      .length;
+    expect(withRollup).toBeLessThanOrEqual(without);
+  });
+
+  it("always keeps at least one chip, however narrow", () => {
+    const members = [m("a", "a-very-long-cluster-name-indeed"), m("b", "b")];
+    const fit = fitStrip(members, 10);
+    expect(fit.visible).toHaveLength(1);
+    expect(fit.hidden).toHaveLength(1);
+  });
+
+  it("pins the focused member first and never hides it", () => {
+    // A focus you cannot see is a trap: the table looks broken and the chip
+    // that would clear it is off-screen.
+    const members = Array.from({ length: 30 }, (_, i) =>
+      m(`c${i}`, `cluster-${i}`),
+    );
+    const fit = fitStrip(members, 300, { pinnedId: "c29" });
+    expect(fit.visible[0]!.id).toBe("c29");
+    expect(fit.hidden.some((x) => x.id === "c29")).toBe(false);
+  });
+
+  it("ignores a pinned id that is not a member", () => {
+    const members = [m("a"), m("b")];
+    const fit = fitStrip(members, 1000, { pinnedId: "gone" });
+    expect(fit.visible.map((x) => x.id)).toEqual(["a", "b"]);
+  });
+
+  it("handles an empty member list", () => {
+    expect(fitStrip([], 500)).toEqual({ visible: [], hidden: [] });
+  });
+
+  it("counts a removable chip as wider", () => {
+    expect(chipWidthPx(m("a", "same", "ok", true))).toBeGreaterThan(
+      chipWidthPx(m("a", "same", "ok", false)),
+    );
+  });
+});
+
+describe("healthCounts / rollup", () => {
+  const MIXED = [
+    m("a", "a", "ok"),
+    m("b", "b", "ok"),
+    m("c", "c", "connecting"),
+    m("d", "d", "bad"),
+  ];
+
+  it("buckets members by health", () => {
+    expect(healthCounts(MIXED)).toEqual({ ok: 2, connecting: 1, bad: 1 });
+  });
+
+  it("counts only populated buckets", () => {
+    expect(populatedBuckets(healthCounts(MIXED))).toBe(3);
+    expect(populatedBuckets(healthCounts([m("a")]))).toBe(1);
+    expect(populatedBuckets({ ok: 0, connecting: 0, bad: 0 })).toBe(0);
+  });
+
+  it("stays hidden when everything is healthy and nothing is hidden", () => {
+    // Two green clusters need no summary — the chips already say it.
+    expect(shouldShowRollup(healthCounts([m("a"), m("b")]), 0)).toBe(false);
+  });
+
+  it("shows once members are hidden", () => {
+    expect(shouldShowRollup(healthCounts([m("a"), m("b")]), 3)).toBe(true);
+  });
+
+  it("shows when anything is unhealthy, even with nothing hidden", () => {
+    expect(shouldShowRollup(healthCounts(MIXED), 0)).toBe(true);
+  });
+
+  it("summarises only the populated buckets", () => {
+    expect(rollupSummary(healthCounts(MIXED))).toBe(
+      "2 connected · 1 connecting · 1 unreachable",
+    );
+    expect(rollupSummary(healthCounts([m("a")]))).toBe("1 connected");
+    expect(rollupSummary({ ok: 0, connecting: 0, bad: 0 })).toBe("");
+  });
+});

--- a/ui/src/lib/clusterStrip.ts
+++ b/ui/src/lib/clusterStrip.ts
@@ -1,0 +1,152 @@
+// Pure layout + rollup helpers for the multi-cluster bar's member strip. No
+// React, no DOM — the bar measures its own width with a ResizeObserver and
+// hands the number here, so the fit decision is deterministic and testable.
+//
+// Why estimate widths instead of measuring each chip: measuring means
+// rendering every chip, reading its box, then hiding the overflow — a
+// render → measure → re-render loop that flickers on every resize and fights
+// the ResizeObserver that triggered it. The chips are a fixed shape (dot +
+// mono label + status dot), so a character-count estimate is accurate to a
+// few pixels and costs nothing. Same trade-off `cardBasisPx` makes on the
+// fleet landing.
+
+/// Coarse connection state of one member, collapsed to the three buckets the
+/// rollup counts. `connecting` also covers "no state yet".
+export type MemberHealth = "ok" | "connecting" | "bad";
+
+export type StripMember = {
+  id: string;
+  /// The text the chip renders (already shortened by `lib/clusterName`).
+  label: string;
+  health: MemberHealth;
+  /// Ad-hoc scope additions carry a removal ×, which makes the chip wider.
+  removable: boolean;
+};
+
+// Chip geometry, in px. Mirrors the styles in `VirtualClusterPanel`'s chip:
+// 8px horizontal padding either side, an 8px accent dot, a 6px status dot,
+// two 6px gaps, and a 1px border either side.
+const CHIP_CHROME = 8 * 2 + 8 + 6 + 6 * 2 + 2;
+// Mono at FS_XS — measured against the shipped mono stack at the default UI
+// scale. Slightly generous so a rounding error hides a chip rather than
+// clipping one.
+const CHIP_CHAR_PX = 6.6;
+// The × on an ad-hoc chip: glyph plus its gap.
+const REMOVE_PX = 14;
+/// Width the "+N" overflow pill needs. Grows a little with the digit count.
+export const overflowPillPx = (hidden: number): number =>
+  34 + String(hidden).length * 7;
+/// Width the health rollup needs for `n` populated buckets (dot + count each).
+export const rollupPx = (buckets: number): number => buckets * 30;
+/// Never collapse below this — a strip with no names at all is useless, so
+/// the first chip is always rendered even if it has to ellipsis.
+const MIN_VISIBLE = 1;
+
+export function chipWidthPx(m: StripMember): number {
+  return (
+    CHIP_CHROME +
+    m.label.length * CHIP_CHAR_PX +
+    (m.removable ? REMOVE_PX : 0)
+  );
+}
+
+export type StripFit = {
+  visible: StripMember[];
+  hidden: StripMember[];
+};
+
+/// Decide how many member chips fit in `availablePx`.
+///
+/// `pinnedId` (the focused member) is always placed first and always visible:
+/// a focus you can't see, and therefore can't click again to clear, is a trap
+/// — the table looks broken and nothing on screen explains why.
+///
+/// Reserves room for the overflow pill whenever anything would be hidden, and
+/// for the rollup when `rollupBuckets > 0`, so the trailing controls never
+/// push the last chip off-screen after the fact.
+export function fitStrip(
+  members: readonly StripMember[],
+  availablePx: number,
+  opts: { pinnedId?: string | null; rollupBuckets?: number } = {},
+): StripFit {
+  const ordered = orderPinnedFirst(members, opts.pinnedId ?? null);
+  if (ordered.length === 0) return { visible: [], hidden: [] };
+
+  const gap = 6;
+  const reserved = rollupPx(opts.rollupBuckets ?? 0);
+
+  // First pass: does everything fit with no overflow pill at all?
+  const totalPx =
+    ordered.reduce((sum, m) => sum + chipWidthPx(m), 0) +
+    gap * Math.max(0, ordered.length - 1) +
+    reserved;
+  if (totalPx <= availablePx) return { visible: [...ordered], hidden: [] };
+
+  // Second pass: fit as many as possible, leaving room for the pill. The
+  // pill's width depends on how many are hidden, which depends on how many
+  // fit — so budget for the worst case (every remaining member hidden) and
+  // let the real pill come out no wider.
+  let used = reserved;
+  let count = 0;
+  for (let i = 0; i < ordered.length; i++) {
+    const next = used + (i > 0 ? gap : 0) + chipWidthPx(ordered[i]!);
+    const stillHidden = ordered.length - (i + 1);
+    const pill = stillHidden > 0 ? gap + overflowPillPx(stillHidden) : 0;
+    if (next + pill > availablePx) break;
+    used = next;
+    count = i + 1;
+  }
+  const visibleCount = Math.max(MIN_VISIBLE, count);
+  return {
+    visible: ordered.slice(0, visibleCount),
+    hidden: ordered.slice(visibleCount),
+  };
+}
+
+function orderPinnedFirst(
+  members: readonly StripMember[],
+  pinnedId: string | null,
+): StripMember[] {
+  if (!pinnedId) return [...members];
+  const pinned = members.find((m) => m.id === pinnedId);
+  if (!pinned) return [...members];
+  return [pinned, ...members.filter((m) => m.id !== pinnedId)];
+}
+
+export type HealthCounts = { ok: number; connecting: number; bad: number };
+
+export function healthCounts(members: readonly StripMember[]): HealthCounts {
+  const out: HealthCounts = { ok: 0, connecting: 0, bad: 0 };
+  for (const m of members) out[m.health] += 1;
+  return out;
+}
+
+/// How many rollup buckets actually have members — drives both the reserved
+/// width and whether the rollup is worth rendering at all.
+export function populatedBuckets(counts: HealthCounts): number {
+  return (
+    (counts.ok > 0 ? 1 : 0) +
+    (counts.connecting > 0 ? 1 : 0) +
+    (counts.bad > 0 ? 1 : 0)
+  );
+}
+
+/// Whether to render the rollup. Two healthy clusters need no summary — the
+/// chips already say everything. It earns its space once members are hidden
+/// (the counts describe what you can't see) or once something is wrong.
+export function shouldShowRollup(
+  counts: HealthCounts,
+  hiddenCount: number,
+): boolean {
+  return hiddenCount > 0 || counts.connecting > 0 || counts.bad > 0;
+}
+
+/// Screen-reader / tooltip sentence for the rollup, e.g.
+/// "15 connected · 2 reconnecting · 1 unreachable".
+export function rollupSummary(counts: HealthCounts): string {
+  const bits: string[] = [];
+  if (counts.ok > 0) bits.push(`${counts.ok} connected`);
+  if (counts.connecting > 0) bits.push(`${counts.connecting} connecting`);
+  if (counts.bad > 0) bits.push(`${counts.bad} unreachable`);
+  return bits.join(" · ");
+}

--- a/ui/src/lib/clusterTabs.ts
+++ b/ui/src/lib/clusterTabs.ts
@@ -4,6 +4,7 @@
 // other open tab still uses.
 
 import { confirm } from "./dialog";
+import type { ClusterLabel } from "./clusterName";
 import { selectActiveClusterIds, useAppStore, type ClusterTab } from "../store";
 
 /// Live terminal/chat dock sessions a tab is holding. For the active tab these
@@ -70,10 +71,16 @@ export async function goToFleet(): Promise<void> {
 
 /// Human label for a tab: the context name for a single cluster, the virtual
 /// context's name for a merged view, falling back to the raw id.
+///
+/// `labels` is the fleet's resolved display map (`useClusterLabels()`), which
+/// shortens machine-generated context names. Callers in tight chrome (the
+/// rail strip, the header's tab menu) pass it and keep the full name in the
+/// tooltip; omitting it yields the raw context name.
 export function clusterTabLabel(
   tab: ClusterTab,
   contexts: { id: string; name: string }[],
   virtualContexts: { id: string; name: string }[],
+  labels?: Record<string, ClusterLabel>,
 ): string {
   if (tab.selectedVirtualContextId) {
     const v = virtualContexts.find((vc) => vc.id === tab.selectedVirtualContextId);
@@ -81,10 +88,21 @@ export function clusterTabLabel(
   }
   if (tab.selectedContext) {
     const c = contexts.find((cc) => cc.id === tab.selectedContext);
-    if (c) return c.name;
+    if (c) return labels?.[c.id]?.short ?? c.name;
     return tab.selectedContext;
   }
   return tab.selectedVirtualContextId ?? "cluster";
+}
+
+/// The full, unshortened context name behind a tab — for tooltips and
+/// `aria-label`s, so the operator can always recover what `clusterTabLabel`
+/// trimmed. Same fallbacks as `clusterTabLabel`.
+export function clusterTabFullLabel(
+  tab: ClusterTab,
+  contexts: { id: string; name: string }[],
+  virtualContexts: { id: string; name: string }[],
+): string {
+  return clusterTabLabel(tab, contexts, virtualContexts);
 }
 
 /// Primary (first) physical cluster id of a tab's scope — used to colour its

--- a/ui/src/lib/multiCluster.test.ts
+++ b/ui/src/lib/multiCluster.test.ts
@@ -12,9 +12,11 @@ import {
   mergeSearchHits,
   shortClusterNames,
   defaultVirtualContextName,
+  clusterDisplayMeta,
   namespaceClusterTags,
   type ScopedRow,
 } from "./multiCluster";
+import { clusterLabels } from "./clusterName";
 import { CLUSTER_ACCENTS, clusterAccent } from "../theme";
 import type { ClusterProbe } from "../types";
 
@@ -274,6 +276,65 @@ describe("defaultVirtualContextName", () => {
         ["eu + us", "eu + us (2)"],
       ),
     ).toBe("eu + us (3)");
+  });
+});
+
+describe("clusterDisplayMeta", () => {
+  const GKE_6 = "gke_production-4f83b34d_us-central1_prod-6";
+  const GKE_7 = "gke_production-4f83b34d_us-central1_prod-7";
+  const cluster = (name: string, colorIdx: number) => ({
+    id: `default::${name}`,
+    name,
+    colorIdx,
+  });
+
+  it("keeps the full context name for the tooltip", () => {
+    const clusters = [cluster(GKE_6, 0), cluster(GKE_7, 1)];
+    const meta = clusterDisplayMeta(
+      clusters,
+      clusterLabels(clusters.map((c) => ({ ...c, user: null })), true),
+    );
+    expect(meta[`default::${GKE_6}`]!.name).toBe(GKE_6);
+  });
+
+  it("composes provider shortening with sibling elision", () => {
+    const clusters = [cluster(GKE_6, 0), cluster(GKE_7, 1)];
+    const meta = clusterDisplayMeta(
+      clusters,
+      clusterLabels(clusters.map((c) => ({ ...c, user: null })), true),
+    );
+    // `prod-6` / `prod-7` after provider shortening, then the shared `prod`
+    // token elided across the visible members.
+    expect(meta[`default::${GKE_6}`]!.short).toBe("6");
+    expect(meta[`default::${GKE_7}`]!.short).toBe("7");
+  });
+
+  it("never collapses two members to the same short", () => {
+    // Same cluster segment in two projects: provider shortening keeps both
+    // as `prod-1`, so the elision pass must leave them distinguishable
+    // rather than produce a duplicate.
+    const a = cluster("gke_alpha_us-central1_prod-1", 0);
+    const b = cluster("gke_beta_us-central1_prod-1", 1);
+    const meta = clusterDisplayMeta(
+      [a, b],
+      clusterLabels([a, b].map((c) => ({ ...c, user: null })), true),
+    );
+    expect(meta[a.id]!.short).not.toBe(meta[b.id]!.short);
+  });
+
+  it("falls back to the raw name for a cluster with no label", () => {
+    const c = cluster("kind-e2e", 0);
+    const meta = clusterDisplayMeta([c], {});
+    expect(meta[c.id]).toEqual({ name: "kind-e2e", short: "kind-e2e", colorIdx: 0 });
+  });
+
+  it("leaves a single member untouched", () => {
+    const c = cluster(GKE_6, 0);
+    const meta = clusterDisplayMeta(
+      [c],
+      clusterLabels([{ ...c, user: null }], true),
+    );
+    expect(meta[c.id]!.short).toBe("prod-6");
   });
 });
 

--- a/ui/src/lib/multiCluster.ts
+++ b/ui/src/lib/multiCluster.ts
@@ -256,6 +256,50 @@ export function shortClusterNames(names: string[]): Record<string, string> {
   return out;
 }
 
+/// Display metadata for the table's synthetic Cluster column.
+///
+/// Composes the two shorteners. `labels` (from `lib/clusterName`) strips the
+/// provider coordinate — GKE project + location, an EKS ARN's account +
+/// region — giving the same base name the rail and the fleet show.
+/// `shortClusterNames` then elides whatever token run the visible members
+/// still share, because the Cluster column is the narrowest surface in the
+/// app and its rows are already badged by accent colour.
+///
+/// Order matters: run on raw context names, the prefix pass would eat the
+/// project segment, and its uniqueness guard would then revert BOTH siblings
+/// to their full 50-character names — the worst possible outcome for that
+/// column. `name` stays the full context name; it's what the tooltip and the
+/// partial-data strips show.
+///
+/// The one case where the raw names are the better input: when two members
+/// shorten to the SAME base (same cluster segment in two projects, where
+/// `ClusterLabel` disambiguates with a qualifier this column has no room
+/// for). Feeding the shortened names there would print two identical cells;
+/// the raw names let the elision pass keep the differing segment — the
+/// projects — which is exactly the distinguishing part.
+export function clusterDisplayMeta(
+  clusters: readonly { id: string; name: string; colorIdx: number }[],
+  labels: Record<string, { short: string }>,
+): Record<string, { name: string; short: string; colorIdx: number }> {
+  const shortened = clusters.map((c) => labels[c.id]?.short ?? c.name);
+  const distinct = new Set(shortened).size === shortened.length;
+  const base = new Map(
+    clusters.map((c, i) => [c.id, distinct ? shortened[i]! : c.name]),
+  );
+  const shorts = shortClusterNames([...base.values()]);
+  const out: Record<string, { name: string; short: string; colorIdx: number }> =
+    {};
+  for (const c of clusters) {
+    const short = base.get(c.id) ?? c.name;
+    out[c.id] = {
+      name: c.name,
+      short: shorts[short] ?? short,
+      colorIdx: c.colorIdx,
+    };
+  }
+  return out;
+}
+
 /// Per-namespace origin labels for the namespace modal in multi-cluster
 /// views. A namespace present on EVERY reporting member needs no label —
 /// only the ones that exist on a subset get tagged with the (compressed)

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -111,6 +111,120 @@ describe("darkConsole setting", () => {
   });
 });
 
+describe("cluster-name settings", () => {
+  it("both default to on", () => {
+    const s = useAppStore.getState().settings;
+    expect(s.shortenClusterNames).toBe(true);
+    expect(s.groupFleetByProject).toBe(true);
+  });
+
+  it("patchSettings toggles them independently", () => {
+    useAppStore.getState().patchSettings({ shortenClusterNames: false });
+    expect(useAppStore.getState().settings.shortenClusterNames).toBe(false);
+    expect(useAppStore.getState().settings.groupFleetByProject).toBe(true);
+    useAppStore.getState().patchSettings({ shortenClusterNames: true });
+    expect(useAppStore.getState().settings.shortenClusterNames).toBe(true);
+  });
+
+  it("survives a persist / hydrate round-trip when disabled", () => {
+    useAppStore.getState().patchSettings({
+      shortenClusterNames: false,
+      groupFleetByProject: false,
+    });
+    const prefs = buildPrefsPayload({ ...useAppStore.getState() });
+    expect(prefs.settings.shorten_cluster_names).toBe(false);
+    expect(prefs.settings.group_fleet_by_project).toBe(false);
+    useAppStore.getState().patchSettings({
+      shortenClusterNames: true,
+      groupFleetByProject: true,
+    });
+    useAppStore.getState().hydratePrefs(prefs);
+    const s = useAppStore.getState().settings;
+    expect(s.shortenClusterNames).toBe(false);
+    expect(s.groupFleetByProject).toBe(false);
+  });
+
+  it("defaults both on when hydrating prefs that predate them", () => {
+    // Restore the flags first so the assertion can't pass by accident.
+    useAppStore.getState().patchSettings({
+      shortenClusterNames: false,
+      groupFleetByProject: false,
+    });
+    const prefs = buildPrefsPayload({ ...useAppStore.getState() });
+    delete (prefs.settings as Record<string, unknown>).shorten_cluster_names;
+    delete (prefs.settings as Record<string, unknown>).group_fleet_by_project;
+    useAppStore.getState().hydratePrefs(prefs);
+    const s = useAppStore.getState().settings;
+    expect(s.shortenClusterNames).toBe(true);
+    expect(s.groupFleetByProject).toBe(true);
+  });
+});
+
+describe("focusedClusterId", () => {
+  it("defaults to null", () => {
+    expect(useAppStore.getState().focusedClusterId).toBeNull();
+  });
+
+  it("toggleFocusedCluster sets, then clears on a second call", () => {
+    useAppStore.getState().toggleFocusedCluster("default::a");
+    expect(useAppStore.getState().focusedClusterId).toBe("default::a");
+    useAppStore.getState().toggleFocusedCluster("default::a");
+    expect(useAppStore.getState().focusedClusterId).toBeNull();
+  });
+
+  it("switches focus straight to another cluster", () => {
+    useAppStore.getState().toggleFocusedCluster("default::a");
+    useAppStore.getState().toggleFocusedCluster("default::b");
+    expect(useAppStore.getState().focusedClusterId).toBe("default::b");
+    useAppStore.getState().clearFocusedCluster();
+    expect(useAppStore.getState().focusedClusterId).toBeNull();
+  });
+
+  it("clears when the focused member is dropped from the scope", () => {
+    // Otherwise the table stays filtered to a cluster that is no longer in
+    // view — an empty table with nothing on screen explaining why.
+    useAppStore.setState({ scopeExtras: ["default::b"] });
+    useAppStore.getState().toggleFocusedCluster("default::b");
+    useAppStore.getState().removeScopeExtra("default::b");
+    expect(useAppStore.getState().focusedClusterId).toBeNull();
+  });
+
+  it("leaves the focus alone when a different extra is dropped", () => {
+    useAppStore.setState({ scopeExtras: ["default::b", "default::c"] });
+    useAppStore.getState().toggleFocusedCluster("default::b");
+    useAppStore.getState().removeScopeExtra("default::c");
+    expect(useAppStore.getState().focusedClusterId).toBe("default::b");
+    useAppStore.getState().clearFocusedCluster();
+    useAppStore.setState({ scopeExtras: [] });
+  });
+
+  it("is per-tab: switching tabs restores that tab's focus", () => {
+    useAppStore.setState({
+      contexts: [
+        { id: "default::a", name: "a" } as never,
+        { id: "default::b", name: "b" } as never,
+      ],
+      openTabs: [],
+      activeTabId: null,
+      scopeExtras: [],
+    });
+    const s = useAppStore.getState();
+    s.openTab({ kind: "context", contextId: "default::a" });
+    const tabA = useAppStore.getState().activeTabId!;
+    useAppStore.getState().toggleFocusedCluster("default::a");
+
+    useAppStore.getState().openTab({ kind: "context", contextId: "default::b" });
+    // Fresh tab starts unfocused rather than inheriting the previous tab's.
+    expect(useAppStore.getState().focusedClusterId).toBeNull();
+
+    useAppStore.getState().switchTab(tabA);
+    expect(useAppStore.getState().focusedClusterId).toBe("default::a");
+
+    useAppStore.getState().clearFocusedCluster();
+    useAppStore.setState({ openTabs: [], activeTabId: null, contexts: [] });
+  });
+});
+
 describe("setPalette", () => {
   it("swaps palette inside the current theme", () => {
     useAppStore.getState().setTheme("default");

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { create } from "zustand";
+import { clusterLabels, type ClusterLabel } from "./lib/clusterName";
 import type {
   ClusterHealthStatus,
   ContextInfo,
@@ -213,6 +214,8 @@ export type ScopeSlice = {
   pendingDetail: DetailEntry | null;
   tableFilter: string;
   filterEditing: boolean;
+
+  focusedClusterId: string | null;
   kindClusters: Record<string, string[]>;
   dockTabs: DockTab[];
   dockActiveId: string | null;
@@ -340,6 +343,13 @@ type AppState = {
   // this flag lets the keyboard handler in `App.tsx` open it and the
   // input itself close it on Esc / Enter / blur.
   filterEditing: boolean;
+  // In a multi-cluster (virtual context / ad-hoc) view, restrict the merged
+  // table to one member. `null` = show every member. Set by clicking a chip
+  // in the multi-cluster bar; purely a view filter — it never touches the
+  // subscription fan-out, so every member keeps streaming and clearing the
+  // focus is instant with no refetch. Per-tab (lives in `ScopeSlice`), so
+  // two tabs can focus different members.
+  focusedClusterId: string | null;
 
   // Confirm-modal queue. Multiple opens stack; the topmost renders. Each
   // entry carries its `resolve` so the imperative `confirm()` helper can
@@ -439,6 +449,14 @@ type AppState = {
     // virtual context / unsaved ad-hoc set), only the last single cluster,
     // or always the fleet landing. Settings → General.
     startupScope: PrefsStartupScope;
+    // Render machine-generated context names (GKE, EKS ARNs, eksctl,
+    // OpenShift) as just the cluster segment, with what was stripped shown
+    // as a dim qualifier. Names we don't recognise are left untouched.
+    // Default on; toggled in Settings → Appearance.
+    shortenClusterNames: boolean;
+    // Bucket the fleet landing's cards by the project / account / region the
+    // shortened names were stripped of. Default on; Settings → Appearance.
+    groupFleetByProject: boolean;
   };
 
   setContexts: (cs: ContextInfo[]) => void;
@@ -483,6 +501,13 @@ type AppState = {
   /// Drop an ad-hoc scope addition. Clears row selection — selected rows may
   /// belong to the removed cluster.
   removeScopeExtra: (contextId: string) => void;
+
+  /// Toggle the merged table's focus onto one member cluster. Passing the id
+  /// that is already focused clears it, so a second click on the same chip is
+  /// "show everything again".
+  toggleFocusedCluster: (clusterId: string) => void;
+  /// Clear the focus outright (the "showing 1 of N" chip's ×).
+  clearFocusedCluster: () => void;
 
   setKinds: (ks: ResourceKind[]) => void;
   setKindsError: (err: string) => void;
@@ -621,6 +646,7 @@ function emptyScopeSlice(): ScopeSlice {
     pendingDetail: null,
     tableFilter: "",
     filterEditing: false,
+    focusedClusterId: null,
     // Dynamic-kind availability is per-scope — the rail republishes after
     // re-discovering CRDs on the new scope's members.
     kindClusters: {},
@@ -642,6 +668,7 @@ function captureScopeSlice(s: AppState): ScopeSlice {
     pendingDetail: s.pendingDetail,
     tableFilter: s.tableFilter,
     filterEditing: s.filterEditing,
+    focusedClusterId: s.focusedClusterId,
     kindClusters: s.kindClusters,
     dockTabs: s.dockTabs,
     dockActiveId: s.dockActiveId,
@@ -844,6 +871,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   tableCount: null,
   tableFilter: "",
   filterEditing: false,
+  focusedClusterId: null,
 
   modals: [],
   toasts: [],
@@ -879,6 +907,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     fleetView: "tiles",
     darkConsole: true,
     startupScope: "latest_view",
+    shortenClusterNames: true,
+    groupFleetByProject: true,
   },
 
   appVersion: null,
@@ -1062,7 +1092,18 @@ export const useAppStore = create<AppState>((set, get) => ({
     set((s) => ({
       scopeExtras: s.scopeExtras.filter((id) => id !== contextId),
       selection: new Map<string, SelectionMeta>(),
+      // Dropping the focused member would otherwise leave the table filtered
+      // to a cluster that is no longer in scope — an empty table with no
+      // visible cause.
+      focusedClusterId:
+        s.focusedClusterId === contextId ? null : s.focusedClusterId,
     })),
+
+  toggleFocusedCluster: (clusterId) =>
+    set((s) => ({
+      focusedClusterId: s.focusedClusterId === clusterId ? null : clusterId,
+    })),
+  clearFocusedCluster: () => set({ focusedClusterId: null }),
 
   setKindsLoading: () => set({ kindsStatus: "loading", kindsError: null }),
   setKinds: (ks) =>
@@ -1587,6 +1628,10 @@ export const useAppStore = create<AppState>((set, get) => ({
         // gets the console treatment without re-opting.
         darkConsole: prefs.settings.dark_console ?? true,
         startupScope,
+        // Older prefs predate both flags; default on so existing installs
+        // pick up the shorter names without visiting Settings.
+        shortenClusterNames: prefs.settings.shorten_cluster_names ?? true,
+        groupFleetByProject: prefs.settings.group_fleet_by_project ?? true,
       },
       // `prefs.update` lands populated by `#[serde(default)]` on the Rust side
       // for prefs.json files written before this block existed.
@@ -1802,6 +1847,8 @@ export function buildPrefsPayload(s: {
       fleet_view: s.settings.fleetView,
       dark_console: s.settings.darkConsole,
       startup_scope: s.settings.startupScope,
+      shorten_cluster_names: s.settings.shortenClusterNames,
+      group_fleet_by_project: s.settings.groupFleetByProject,
     },
     ui: {
       selected_context: s.selectedContext,
@@ -1914,6 +1961,23 @@ export function useActiveClusterEpoch(): number {
     for (const id of selectActiveClusterIds(s)) sum += s.clusterEpoch[id] ?? 0;
     return sum;
   });
+}
+
+/// Display labels for every context in the fleet, keyed by `ContextInfo.id`.
+///
+/// The shortening pass is list-aware (it guarantees the rendered
+/// `short + qualifier` pair identifies exactly one cluster), so this hook
+/// deliberately reads the WHOLE `contexts` array rather than a filtered or
+/// grouped subset — otherwise a label could change as a search box is typed
+/// into. `clusterLabels` memoises on the array reference, so the ~15 call
+/// sites share one computation per store update.
+///
+/// Subscribing here is also what makes the Settings toggle live: a component
+/// that renders `c.name` directly won't repaint when the flag flips.
+export function useClusterLabels(): Record<string, ClusterLabel> {
+  const contexts = useAppStore((s) => s.contexts);
+  const enabled = useAppStore((s) => s.settings.shortenClusterNames);
+  return useMemo(() => clusterLabels(contexts, enabled), [contexts, enabled]);
 }
 
 /// Resolve the active theme into a ready-to-use bag of tokens, typography,

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -297,6 +297,13 @@ export type PrefsSettings = {
   dark_console: boolean;
   /// Optional for payloads from transitional builds; absent ⇒ "latest_view".
   startup_scope?: PrefsStartupScope;
+  /// Render machine-generated context names (GKE / EKS ARN / eksctl /
+  /// OpenShift) as just the cluster segment. Optional for payloads from
+  /// transitional builds; absent ⇒ true.
+  shorten_cluster_names?: boolean;
+  /// Bucket the fleet landing by the project / account / region that
+  /// shortening stripped. Absent ⇒ true.
+  group_fleet_by_project?: boolean;
 };
 export type PrefsUiState = {
   selected_context: string | null;


### PR DESCRIPTION
## Summary

Managed-Kubernetes CLIs write context names that encode the whole cloud coordinate, not just the cluster. A GKE-heavy kubeconfig renders as a wall of near-identical 50-character strings where only the last token differs, and the same names ellipsis into uselessness in the rail, the tabs and every picker. This adds a provider-aware shortener, buckets the fleet landing by the coordinate it strips, and rebuilds the multi-cluster bar so it scales past a handful of members.

## Related issues

_None._

## Type of change

- [x] Feature (non-breaking change that adds capability)

## What it does

New pure module `ui/src/lib/clusterName.ts` parses the shapes the CLIs actually write:

| context name | short | qualifier |
|---|---|---|
| `gke_<project>_<location>_<cluster>` | `<cluster>` | project · location |
| `arn:aws[-cn\|-us-gov]:eks:<region>:<acct>:cluster/<name>` | `<name>` | account · region |
| `<identity>@<cluster>.<region>.eksctl.io` | `<cluster>` | region · identity |
| `<ns>/<host-dashed>:<port>/<user>` (oc login) | host minus `api-` | ns · user |
| AKS `<cluster>` / `<cluster>-admin` | **unchanged** | resource group (from the user entry) |
| DigitalOcean, kind, k3d, minikube, Rancher | **unchanged** | — |

Anything unrecognised is returned **byte-identical**. There is no heuristic fallback that trims "probably redundant" tokens, because a wrong guess here points the operator at the wrong cluster.

Two Appearance settings, both on by default and **independent of each other**: `shorten_cluster_names` gates only the display fields, while the grouping keys come from the parse — so the fleet can bucket by project while rendering full names.

The multi-cluster bar's member strip was a flex row with `overflow: hidden`: past a handful of members the extras were clipped **silently** — no count, no way to reach them, and an unreachable member could be invisible. `ui/src/lib/clusterStrip.ts` now fits chips to the ResizeObserver-measured width, then adds a health rollup and a `+N` pill opening a searchable list of every member. Clicking a chip focuses the merged table on that cluster.

## Decisions worth reviewing

- **AKS `-admin` is never stripped.** `foo` and `foo-admin` are different credentials that legitimately coexist in one kubeconfig; collapsing them would hide which one is connecting. AKS gains only collision-safety here (the resource group is recovered from the `clusterUser_<rg>_<cluster>` user entry, anchored on the cluster name because RG names may themselves contain underscores).
- **Labels resolve against the whole fleet**, never a filtered subset, so a label cannot change as a search box is typed into. If two contexts would render an identical `short + qualifier` pair, **both** revert to their full names.
- **Full names stay authoritative** in tooltips, in every search keyword string (typing `gke_production-…` still matches a row labelled `prod-6`), in kubeconfig-mutation prompts, in connection diagnostics, and in the chat's view context — the agent may hand that name to `kubectl --context`.
- **Auto-generated virtual-context names deliberately use full names.** `defaultVirtualContextName` runs its own sibling-elision pass; fed short names it double-compresses (`prod-1` + `prod-1` from two projects → "prod-1 + prod-1"; `prod-1` + `prod-2` → "1 + 2"). That name is persisted as the context's identity.
- **The pre-existing sibling-elision shortener is folded into the same pipeline** via `clusterDisplayMeta` rather than left as a second system. Fed raw GKE names, its common-prefix pass ate the project segment, after which its uniqueness guard reverted *both* siblings to their full 50-character names in the narrowest column in the app. It now runs on the provider-shortened names, falling back to the raw ones when two members shorten alike so the differing projects stay visible.
- **Cluster focus is a view filter only** — the subscription fan-out is untouched, so every member keeps streaming and clearing needs no refetch. The focused chip is pinned first and never hidden (a focus you cannot see is a trap); dropping its member from the scope clears the focus, and a stale id is ignored.

## How was this tested?

- `cargo fmt --all -- --check`, `make clippy` (`-D warnings`), `make test` — 551 backend tests pass.
- `make test-frontend` — 1411 frontend tests pass across 102 files.
- New unit suites: `ui/src/lib/clusterName.test.ts` (47) and `ui/src/lib/clusterStrip.test.ts` (15), every fixture a real-world shape taken from the provider's own docs, plus malformed-input cases asserting nothing is shortened.
- New render/behaviour tests in `FleetLanding`, `OpenClustersStrip`, `AppHeader`, `CommandPalette`, `VirtualClusterPanel`, `PortForwardsPanel`, `NewForwardForm`, `ResourceTable.multi`, and store tests for the settings round-trip and the per-tab focus.
- Rust: two `prefs.rs` tests covering the legacy-prefs default and the disabled round-trip.

## Screenshots / recordings

_Not attached — see the note below._

## Checklist

- [x] PR title follows Conventional Commits.
- [x] `cargo fmt --all -- --check` is clean.
- [x] `make clippy` is clean (`-D warnings`).
- [x] `make test` passes; `make test-frontend` passes.
- [x] No `unwrap()` outside `#[cfg(test)]`.
- [x] No `any` in TypeScript; no hardcoded hex values; no `invoke()` with stringly-typed names.
- [x] Architectural rules from `README.md` / `CLAUDE.md` are satisfied.
- [x] No new Tauri command (the settings ride the existing `set_prefs` round-trip).
- [x] No new kind detail panel.
- [x] No new agent tool.
- [x] I am the author of these changes and agree to release them under Apache-2.0.

## Notes for reviewers

**Not verified in the running app.** Everything here is covered by typecheck and tests, but the desktop app was never launched against a real kubeconfig, so the visual claims are unconfirmed: tile packing density, the project sub-header layout (the singleton-remainder bucket is the case most likely to look odd), and the ClusterBar two-line cluster stat.

One number is calibrated by eye rather than measured: `CHIP_CHAR_PX = 6.6` in `clusterStrip.ts`, the per-character width estimate at `FS_XS` mono. If it is off you will see one chip too many or too few before the `+N` pill. Widths are estimated rather than measured on purpose — measuring means render → read box → hide overflow, a loop that flickers against the ResizeObserver that triggered it, the same trade-off `cardBasisPx` already makes on the fleet landing.

Default-ON is a visible behaviour change for every existing user on first launch. Mitigated by tooltips and full-name search, but worth a conscious ack. Azure / DigitalOcean / kind users get no shortening at all — only collision-safety.
