### PR TITLE
fix(auth): diagnose GKE session expiry, kill the plugin spawn storm, and offer an in-app login

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -538,7 +538,15 @@ pub(crate) async fn pin_cloud_identity_cmd(
     })?;
     tokio::task::spawn_blocking(move || {
         ferrisscope_core::cloud_identity::pin_identity(&path, &context_name, &identity)
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        // `pin_identity` clears the caches core knows about: the plugin's
+        // default slot and the app's per-identity ones. It cannot know about
+        // this third slot — the one a Dock terminal's `kubectl` writes beside
+        // its scratch kubeconfig — and a token minted under the pre-pin
+        // identity would keep being served there for up to an hour, which is
+        // precisely the staleness the pin exists to end.
+        crate::terminal::clear_plugin_slot(&crate::terminal::plugin_cache_slot());
+        Ok(())
     })
     .await
     .map_err(|e| format!("pin identity task failed: {e}"))?
@@ -3612,6 +3620,39 @@ pub(crate) async fn terminal_open_shell(
                 default_namespace: namespace,
             },
             extras,
+        )
+        .await
+}
+
+/// Open a PTY running `gcloud auth login` to renew a lapsed cloud session.
+///
+/// The remedy for `Error::ExecReauthRequired`, and the one terminal session that
+/// deliberately does **not** resolve a kubeconfig: it exists because the connect
+/// failed, so there is no cluster to point one at. `cluster_id` is carried only
+/// as the ownership label every session gets, so a later disconnect closes this
+/// one too.
+///
+/// `account` is what the failing context pins, or `None` for an unpinned context
+/// (gcloud then renews whichever account is active — the same one that context
+/// would have used). It lands in an argv element, so it is validated here rather
+/// than trusted for having come from our own hint.
+#[tauri::command]
+pub(crate) async fn cloud_login_open(
+    cluster_id: String,
+    account: Option<String>,
+    on_event: tauri::ipc::Channel<crate::terminal::TerminalEvent>,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    if let Some(account) = &account {
+        ferrisscope_core::cloud_identity::validate_identity(account).map_err(|e| e.to_string())?;
+    }
+    state
+        .terminals
+        .spawn_with_extras(
+            cluster_id,
+            on_event,
+            SpawnSpec::CloudLogin { account },
+            Vec::new(),
         )
         .await
 }

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -537,16 +537,18 @@ pub(crate) async fn pin_cloud_identity_cmd(
         format!("could not locate the kubeconfig file backing {name} — nothing was written")
     })?;
     tokio::task::spawn_blocking(move || {
-        ferrisscope_core::cloud_identity::pin_identity(&path, &context_name, &identity)
-            .map_err(|e| e.to_string())?;
-        // `pin_identity` clears the caches core knows about: the plugin's
-        // default slot and the app's per-identity ones. It cannot know about
-        // this third slot — the one a Dock terminal's `kubectl` writes beside
-        // its scratch kubeconfig — and a token minted under the pre-pin
-        // identity would keep being served there for up to an hour, which is
-        // precisely the staleness the pin exists to end.
+        let pinned =
+            ferrisscope_core::cloud_identity::pin_identity(&path, &context_name, &identity);
+        // Unconditional, and deliberately not behind `?` on the line above.
+        // `pin_identity` rewrites the kubeconfig *before* it clears caches, so a
+        // failure reported there can still mean the new `--account` is already
+        // on disk. Skipping this clear in that case would leave a Dock terminal
+        // serving the pre-pin identity's token for up to an hour — precisely the
+        // staleness the pin exists to end. Core clears the slots it knows about
+        // (the plugin default and the app's per-identity ones); this third slot,
+        // written beside a terminal session's scratch kubeconfig, is ours.
         crate::terminal::clear_plugin_slot(&crate::terminal::plugin_cache_slot());
-        Ok(())
+        pinned.map_err(|e| e.to_string())
     })
     .await
     .map_err(|e| format!("pin identity task failed: {e}"))?

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -255,6 +255,7 @@ fn main() {
             commands::get_prefs,
             commands::set_prefs,
             commands::terminal_open_shell,
+            commands::cloud_login_open,
             commands::terminal_open_exec,
             commands::terminal_open_kubectl,
             commands::terminal_write,

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -470,6 +470,11 @@ fn main() {
                     let _ = tokio::time::timeout(std::time::Duration::from_secs(3), gf.shutdown())
                         .await;
                 });
+                // A terminal session's kubectl leaves a live access token in the
+                // cache dir. Session close reclaims it while the app runs; quitting
+                // with a terminal open would otherwise leave it there indefinitely,
+                // and nothing prunes that directory.
+                terminal::clear_plugin_slot(&terminal::plugin_cache_slot());
             }
         });
 }

--- a/crates/app/src/terminal.rs
+++ b/crates/app/src/terminal.rs
@@ -520,6 +520,13 @@ fn which_on_path(name: &str) -> Option<PathBuf> {
     None
 }
 
+/// Characters `cmd.exe` treats as syntax rather than data.
+///
+/// Only the Windows login path is re-parsed by a shell, but the check runs
+/// everywhere so its test does too — see the `--account` handling in
+/// [`build_command`].
+const CMD_METACHARACTERS: &str = "\"&|^<>%()!";
+
 fn build_command(id: &str, spec: &SpawnSpec) -> Result<(CommandBuilder, Vec<PathBuf>), String> {
     match spec {
         SpawnSpec::Shell {
@@ -630,6 +637,21 @@ fn build_command(id: &str, spec: &SpawnSpec) -> Result<(CommandBuilder, Vec<Path
             if let Some(account) = account {
                 // One argv element, so a leading `-` inside the value cannot
                 // become a separate flag. Validated at the command boundary too.
+                //
+                // That atomicity is an argv property, and on Windows this argv
+                // is re-parsed by `cmd.exe`, which honours neither portable-pty's
+                // MSVCRT quoting nor a backslash-escaped quote — a `"` would end
+                // the quoted run and leave the rest to parse as cmd syntax (the
+                // CVE-2024-24576 class). Rejecting cmd's metacharacters restores
+                // the guarantee on every platform. Cross-platform on purpose: a
+                // value carrying one is not an account on Unix either, and a
+                // rule that holds everywhere is one fewer thing to be wrong
+                // about on the platform we develop on least.
+                if let Some(bad) = account.chars().find(|c| CMD_METACHARACTERS.contains(*c)) {
+                    return Err(format!(
+                        "account contains {bad:?}, which cannot appear in a cloud account name"
+                    ));
+                }
                 cmd.arg(format!("--account={account}"));
             }
             apply_login_env(&mut cmd);
@@ -932,6 +954,26 @@ mod tests {
             .collect()
     }
 
+    /// The launcher `build_command` puts in front of `gcloud` on this platform.
+    #[cfg(windows)]
+    const LOGIN_LAUNCHER: &[&str] = &["cmd.exe", "/c"];
+    #[cfg(not(windows))]
+    const LOGIN_LAUNCHER: &[&str] = &[];
+
+    /// A login argv with the platform launcher stripped, so every claim about
+    /// the *gcloud* argv below is one assertion instead of two cfg-gated ones.
+    /// The prefix itself is pinned by `the_login_argv_names_its_interpreter`.
+    fn login_argv(spec: &SpawnSpec) -> Vec<String> {
+        let args = argv(spec);
+        let prefix: Vec<&str> = args
+            .iter()
+            .take(LOGIN_LAUNCHER.len())
+            .map(String::as_str)
+            .collect();
+        assert_eq!(prefix, LOGIN_LAUNCHER, "unexpected launcher prefix");
+        args[LOGIN_LAUNCHER.len()..].to_vec()
+    }
+
     /// Stand-in for a PTY child: reports "still running" for `pending` polls,
     /// then the given status. Enough to exercise the reaper without a real PTY.
     #[derive(Debug)]
@@ -1064,7 +1106,7 @@ mod tests {
 
     #[test]
     fn cloud_login_runs_gcloud_non_interactively_for_one_account() {
-        let args = argv(&SpawnSpec::CloudLogin {
+        let args = login_argv(&SpawnSpec::CloudLogin {
             account: Some("a@example.com".to_owned()),
         });
         assert_eq!(
@@ -1084,7 +1126,7 @@ mod tests {
 
     #[test]
     fn cloud_login_without_an_account_renews_the_active_one() {
-        let args = argv(&SpawnSpec::CloudLogin { account: None });
+        let args = login_argv(&SpawnSpec::CloudLogin { account: None });
         assert_eq!(args, vec!["gcloud", "auth", "login", "--quiet"]);
         assert!(
             !args.iter().any(|a| a.starts_with("--account")),
@@ -1093,10 +1135,59 @@ mod tests {
     }
 
     #[test]
+    fn the_login_argv_names_its_interpreter() {
+        // The gcloud SDK ships `gcloud.cmd` on Windows and portable-pty spawns
+        // through raw `CreateProcessW`, which cannot execute a batch file, so
+        // the interpreter has to be explicit there. Everywhere else `gcloud` is
+        // a real executable and naming a shell would be wrong.
+        let args = argv(&SpawnSpec::CloudLogin { account: None });
+        if cfg!(windows) {
+            assert_eq!(&args[..3], ["cmd.exe", "/c", "gcloud"]);
+        } else {
+            assert_eq!(args[0], "gcloud");
+        }
+    }
+
+    #[test]
+    fn an_account_cannot_carry_cmd_syntax() {
+        // `cmd.exe` re-parses the Windows login argv and does not honour the
+        // MSVCRT quoting portable-pty emits, so a quote in this value would end
+        // the quoted run and hand the rest to the shell. Rejected on every
+        // platform: no cloud account contains one, and a cfg-gated rule would
+        // only ever be exercised by the CI runner we read the least.
+        for bad in ["a@x.com\" & calc", "a@x.com|x", "a%PATH%@x.com", "a@x.com^"] {
+            assert!(
+                build_command(
+                    "t0",
+                    &SpawnSpec::CloudLogin {
+                        account: Some(bad.to_owned()),
+                    },
+                )
+                .is_err(),
+                "{bad:?} must not reach the argv"
+            );
+        }
+        // A real account, and the one legitimate value with punctuation in it,
+        // must still build — the guard is not allowed to cost the feature.
+        for ok in ["a@example.com", "svc-1@proj.iam.gserviceaccount.com"] {
+            assert!(
+                build_command(
+                    "t0",
+                    &SpawnSpec::CloudLogin {
+                        account: Some(ok.to_owned()),
+                    },
+                )
+                .is_ok(),
+                "{ok:?} must still build"
+            );
+        }
+    }
+
+    #[test]
     fn an_account_cannot_smuggle_a_second_flag_into_the_argv() {
         // The command boundary validates this value, but the argv shape is the
         // structural guarantee: one element, so `-` inside it is data.
-        let args = argv(&SpawnSpec::CloudLogin {
+        let args = login_argv(&SpawnSpec::CloudLogin {
             account: Some("--update-adc x".to_owned()),
         });
         assert_eq!(args.len(), 5);

--- a/crates/app/src/terminal.rs
+++ b/crates/app/src/terminal.rs
@@ -60,6 +60,19 @@ pub(crate) enum SpawnSpec {
         /// own its lifecycle and tear it down with the terminal tab.
         cleanup: Option<PodCleanup>,
     },
+    /// Run `gcloud auth login` to renew a lapsed cloud session.
+    ///
+    /// The only spec that touches no cluster and writes no scratch kubeconfig:
+    /// it exists precisely because the *connect* failed, so there is nothing to
+    /// point a kubeconfig at. It runs in a PTY for the same reason the operator
+    /// has to run it in a terminal by hand — gcloud refuses to perform an
+    /// identity challenge without one.
+    CloudLogin {
+        /// Account to renew. `None` renews whichever one gcloud has active,
+        /// matching an unpinned context's behaviour. Validated at the command
+        /// boundary before it reaches this argv.
+        account: Option<String>,
+    },
 }
 
 /// Resource the terminal session owns and must delete when it closes. Today
@@ -248,7 +261,12 @@ impl TerminalRegistry {
     }
 
     pub(crate) async fn close(&self, id: &str) -> Option<PodCleanup> {
-        let removed = self.sessions.lock().await.remove(id);
+        let (removed, remaining) = {
+            let mut map = self.sessions.lock().await;
+            let removed = map.remove(id);
+            (removed, map.len())
+        };
+        clear_plugin_slot_if_idle(remaining, &plugin_cache_slot());
         removed.and_then(|s| s.cleanup.lock().ok().and_then(|mut g| g.take()))
     }
 
@@ -264,10 +282,12 @@ impl TerminalRegistry {
         &self,
         cluster_id: &str,
     ) -> (usize, Vec<PodCleanup>) {
-        let removed = {
+        let (removed, remaining) = {
             let mut map = self.sessions.lock().await;
-            drain_cluster_sessions(&mut map, cluster_id, |s| s.cluster_id.as_str())
+            let removed = drain_cluster_sessions(&mut map, cluster_id, |s| s.cluster_id.as_str());
+            (removed, map.len())
         };
+        clear_plugin_slot_if_idle(remaining, &plugin_cache_slot());
         let closed = removed.len();
         let mut cleanups = Vec::new();
         for session in removed {
@@ -524,6 +544,28 @@ fn build_command(id: &str, spec: &SpawnSpec) -> Result<(CommandBuilder, Vec<Path
             apply_common_env(&mut cmd, &merged_env, context_name);
             Ok((cmd, scratch_files))
         }
+        SpawnSpec::CloudLogin { account } => {
+            let mut cmd = CommandBuilder::new("gcloud");
+            cmd.arg("auth");
+            cmd.arg("login");
+            // `--quiet` answers gcloud's own yes/no questions with their
+            // defaults. The one that matters: when the account already has
+            // credentials — always true here, since its session merely lapsed —
+            // gcloud asks "You are already authenticated … continue (Y/n)?".
+            // The browser challenge is not a prompt and still runs; without
+            // this flag the session would sit on that question instead.
+            cmd.arg("--quiet");
+            if let Some(account) = account {
+                // One argv element, so a leading `-` inside the value cannot
+                // become a separate flag. Validated at the command boundary too.
+                cmd.arg(format!("--account={account}"));
+            }
+            apply_login_env(&mut cmd);
+            if let Some(home) = directories::UserDirs::new().map(|u| u.home_dir().to_path_buf()) {
+                cmd.cwd(home);
+            }
+            Ok((cmd, Vec::new()))
+        }
     }
 }
 
@@ -547,12 +589,16 @@ fn apply_common_env(cmd: &mut CommandBuilder, kubeconfig_env: &str, context_name
             cmd.env(key, v);
         }
     }
-    // PATH: prepend our managed-bin dir so a managed kubectl (installed via
-    // settings → Tools) is preferred over anything the parent shell exposes.
-    // We always set PATH explicitly so child processes see a deterministic
-    // search order regardless of how the operator launched FerrisScope.
+    cmd.env("PATH", resolved_path());
+}
+
+/// PATH for every PTY child: our managed-bin dir first so a managed kubectl
+/// (installed via Settings → Tools) wins over anything the parent shell
+/// exposes, then the inherited entries. Always set explicitly so children see a
+/// deterministic search order regardless of how the operator launched the app.
+fn resolved_path() -> String {
     let inherited = std::env::var("PATH").unwrap_or_default();
-    let combined = match crate::kubectl_install::managed_bin_dir() {
+    match crate::kubectl_install::managed_bin_dir() {
         Some(dir) if dir.is_dir() => {
             let mut entries = vec![dir];
             entries.extend(std::env::split_paths(&inherited));
@@ -561,8 +607,52 @@ fn apply_common_env(cmd: &mut CommandBuilder, kubeconfig_env: &str, context_name
                 .unwrap_or(inherited)
         }
         _ => inherited,
-    };
-    cmd.env("PATH", combined);
+    }
+}
+
+/// Environment for `gcloud auth login`. Deliberately wider than
+/// [`apply_common_env`] in one respect: the whole point of the session is that
+/// gcloud opens a **browser**, and `xdg-open` needs the desktop-session
+/// variables to find one. Proxy and `CLOUDSDK_*` variables come along because
+/// gcloud needs them to reach the token endpoint and to resolve which config
+/// directory it is renewing credentials in.
+fn apply_login_env(cmd: &mut CommandBuilder) {
+    cmd.env("TERM", "xterm-256color");
+    cmd.env("COLORTERM", "truecolor");
+    for key in [
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "SHELL",
+        // Browser launch.
+        "DISPLAY",
+        "WAYLAND_DISPLAY",
+        "XDG_RUNTIME_DIR",
+        "XDG_SESSION_TYPE",
+        "XDG_CURRENT_DESKTOP",
+        "DBUS_SESSION_BUS_ADDRESS",
+        "BROWSER",
+        // gcloud's own configuration and network reach.
+        "CLOUDSDK_CONFIG",
+        "CLOUDSDK_PYTHON",
+        "CLOUDSDK_ACTIVE_CONFIG_NAME",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "NO_PROXY",
+        "no_proxy",
+        "REQUESTS_CA_BUNDLE",
+        "SSL_CERT_FILE",
+    ] {
+        if let Ok(v) = std::env::var(key) {
+            cmd.env(key, v);
+        }
+    }
+    cmd.env("PATH", resolved_path());
 }
 
 /// Write a tiny override kubeconfig that pins `current-context` (and
@@ -579,14 +669,70 @@ fn apply_common_env(cmd: &mut CommandBuilder, kubeconfig_env: &str, context_name
 /// source's cluster/user with empty strings, which makes kubectl fall back
 /// to `localhost:8080` ("connection refused"). Copying cluster/user from the
 /// source keeps the merged context complete.
+/// Where a session's scratch kubeconfig is written.
+///
+/// Also decides where any credential plugin the session runs caches its token:
+/// `gke-gcloud-auth-plugin` writes beside the kubeconfig it resolves, and the
+/// scratch file is first in the session's `KUBECONFIG`. Hence
+/// [`plugin_cache_slot`] — the slot is a consequence of this directory, not a
+/// separate choice.
+fn scratch_dir() -> PathBuf {
+    directories::ProjectDirs::from("dev", "ferrisscope", "ferrisscope")
+        .map_or_else(std::env::temp_dir, |d| d.cache_dir().to_path_buf())
+}
+
+/// The gcloud plugin token cache a terminal session's `kubectl` writes.
+///
+/// Distinct from both `~/.kube/gke_gcloud_auth_plugin_cache` (the operator's own
+/// shell) and the per-identity slots in `ferrisscope_core::exec_auth` (the app's
+/// kube clients). Three independent slots, which is what keeps them from
+/// evicting each other's tokens — but it also means a cache invalidation has to
+/// name each one.
+pub(crate) fn plugin_cache_slot() -> PathBuf {
+    scratch_dir().join("gke_gcloud_auth_plugin_cache")
+}
+
+/// Delete the token cache a terminal session left behind, but only once no
+/// session can still be using it.
+///
+/// A live access token has no business outliving the sessions that minted it,
+/// and nothing prunes this directory. Sessions share the slot deliberately — a
+/// new tab reuses the warm token instead of paying a fresh `gcloud` round trip —
+/// so the delete waits for the last one to close.
+pub(crate) fn clear_plugin_slot_if_idle(remaining: usize, path: &Path) {
+    if remaining > 0 {
+        return;
+    }
+    clear_plugin_slot(path);
+}
+
+/// Delete the slot now, whatever is open.
+///
+/// For invalidation rather than hygiene: an identity pin must not leave a token
+/// minted as the previous identity readable, and an open terminal simply re-mints
+/// on its next `kubectl`.
+pub(crate) fn clear_plugin_slot(path: &Path) {
+    if let Err(e) = std::fs::remove_file(path) {
+        // Already gone is the normal case (no plugin ran, or a parallel close
+        // beat us). Anything else is worth a line but never worth failing a
+        // close over.
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::debug!(
+                path = %path.display(),
+                error = %e,
+                "terminal token cache cleanup failed"
+            );
+        }
+    }
+}
+
 fn write_scratch_kubeconfig(
     id: &str,
     source: &Path,
     context_name: &str,
     default_namespace: Option<&str>,
 ) -> Result<(PathBuf, String), String> {
-    let dir = directories::ProjectDirs::from("dev", "ferrisscope", "ferrisscope")
-        .map_or_else(std::env::temp_dir, |d| d.cache_dir().to_path_buf());
+    let dir = scratch_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir cache: {e}"))?;
     let path = dir.join(format!("term-{id}-{}.yaml", std::process::id()));
 
@@ -688,7 +834,112 @@ fn source_context_cluster_user(
 
 #[cfg(test)]
 mod tests {
+    use super::{build_command, SpawnSpec};
     use std::collections::HashMap;
+
+    fn argv(spec: &SpawnSpec) -> Vec<String> {
+        let (cmd, scratch) = build_command("t0", spec).expect("build");
+        assert!(
+            scratch.is_empty(),
+            "a login session owns no scratch files to clean up"
+        );
+        cmd.get_argv()
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn the_token_slot_sits_beside_the_scratch_kubeconfig() {
+        // Not an arbitrary path: the gcloud plugin caches beside whichever
+        // kubeconfig it resolves, and the scratch file is first in the session's
+        // KUBECONFIG. If these two ever diverge, cleanup silently stops finding
+        // the file it is supposed to remove.
+        let slot = super::plugin_cache_slot();
+        assert_eq!(slot.parent(), Some(super::scratch_dir().as_path()));
+        assert_eq!(
+            slot.file_name().and_then(|n| n.to_str()),
+            Some("gke_gcloud_auth_plugin_cache")
+        );
+    }
+
+    #[test]
+    fn the_token_slot_survives_a_close_while_other_sessions_hold_it() {
+        // Sessions share the slot on purpose — a second tab reuses the warm
+        // token instead of paying another gcloud round trip.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let slot = dir.path().join("gke_gcloud_auth_plugin_cache");
+        std::fs::write(&slot, "{}").expect("write");
+
+        super::clear_plugin_slot_if_idle(1, &slot);
+        assert!(slot.exists(), "a live session still needs this token");
+
+        super::clear_plugin_slot_if_idle(0, &slot);
+        assert!(
+            !slot.exists(),
+            "an access token must not outlive the last session that could use it"
+        );
+    }
+
+    #[test]
+    fn clearing_an_absent_slot_is_not_an_error() {
+        // The common case: no plugin ever ran, or a parallel close won the race.
+        let dir = tempfile::tempdir().expect("tempdir");
+        super::clear_plugin_slot_if_idle(0, &dir.path().join("never-written"));
+        super::clear_plugin_slot(&dir.path().join("never-written"));
+    }
+
+    #[test]
+    fn an_identity_pin_clears_the_slot_even_with_terminals_open() {
+        // Invalidation, not hygiene: after a pin, a token minted as the previous
+        // identity must stop being served. An open terminal just re-mints.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let slot = dir.path().join("gke_gcloud_auth_plugin_cache");
+        std::fs::write(&slot, "{}").expect("write");
+        super::clear_plugin_slot(&slot);
+        assert!(!slot.exists());
+    }
+
+    #[test]
+    fn cloud_login_runs_gcloud_non_interactively_for_one_account() {
+        let args = argv(&SpawnSpec::CloudLogin {
+            account: Some("a@example.com".to_owned()),
+        });
+        assert_eq!(
+            args,
+            vec![
+                "gcloud",
+                "auth",
+                "login",
+                // Without this, gcloud stops on "you are already authenticated,
+                // continue (Y/n)?" — always the case here, since the account's
+                // session merely lapsed — and the PTY would hang.
+                "--quiet",
+                "--account=a@example.com",
+            ]
+        );
+    }
+
+    #[test]
+    fn cloud_login_without_an_account_renews_the_active_one() {
+        let args = argv(&SpawnSpec::CloudLogin { account: None });
+        assert_eq!(args, vec!["gcloud", "auth", "login", "--quiet"]);
+        assert!(
+            !args.iter().any(|a| a.starts_with("--account")),
+            "an unpinned context must not have an account invented for it"
+        );
+    }
+
+    #[test]
+    fn an_account_cannot_smuggle_a_second_flag_into_the_argv() {
+        // The command boundary validates this value, but the argv shape is the
+        // structural guarantee: one element, so `-` inside it is data.
+        let args = argv(&SpawnSpec::CloudLogin {
+            account: Some("--update-adc x".to_owned()),
+        });
+        assert_eq!(args.len(), 5);
+        assert_eq!(args[4], "--account=--update-adc x");
+    }
 
     #[test]
     fn drain_cluster_sessions_removes_only_named_cluster() {

--- a/crates/app/src/terminal.rs
+++ b/crates/app/src/terminal.rs
@@ -18,6 +18,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
@@ -383,7 +384,66 @@ fn forward_output(
             }
         }
     }
-    let _ = on_event.send(TerminalEvent::Exit { code: 0 });
+    let _ = on_event.send(TerminalEvent::Exit {
+        code: reap_exit_code(&session.child),
+    });
+}
+
+/// How long to keep polling for the child's status after the PTY hit EOF.
+/// EOF normally *follows* the child exiting, so the first poll almost always
+/// answers; the budget only covers the inverse case (a read error while the
+/// child still lives).
+const REAP_BUDGET: Duration = Duration::from_secs(2);
+
+/// Exit code reported when the child's real status could not be established.
+///
+/// Deliberately non-zero. Callers treat 0 as "the command succeeded" — the
+/// reauth login acts on it by reconnecting — so an unknown status must never
+/// masquerade as success.
+const EXIT_CODE_UNKNOWN: i32 = -1;
+
+/// The child's real exit code, polled rather than waited.
+///
+/// `Child::wait` would be simpler but it blocks while holding the session's
+/// child lock, which [`Session::kill_child`] also takes — a cluster disconnect
+/// would then hang on a child that never exits. `try_wait` releases the lock
+/// between polls, so a kill can always get in.
+fn reap_exit_code(child: &StdMutex<Box<dyn portable_pty::Child + Send + Sync>>) -> i32 {
+    reap_exit_code_within(child, REAP_BUDGET)
+}
+
+/// [`reap_exit_code`] with the budget injected, so the give-up arm is testable
+/// without a multi-second test.
+fn reap_exit_code_within(
+    child: &StdMutex<Box<dyn portable_pty::Child + Send + Sync>>,
+    budget: Duration,
+) -> i32 {
+    let deadline = Instant::now() + budget;
+    loop {
+        match child.lock() {
+            Ok(mut child) => match child.try_wait() {
+                Ok(Some(status)) => return exit_code_of(&status),
+                // Still running: fall through to the sleep below, having
+                // dropped the lock at the end of this arm.
+                Ok(None) => {}
+                Err(e) => {
+                    tracing::debug!(error = %e, "pty child status unavailable");
+                    return EXIT_CODE_UNKNOWN;
+                }
+            },
+            Err(_) => return EXIT_CODE_UNKNOWN,
+        }
+        if Instant::now() >= deadline {
+            return EXIT_CODE_UNKNOWN;
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// A signalled child reports the signal name and code 1; anything non-zero is a
+/// failure to every caller, so the distinction doesn't need to survive here.
+fn exit_code_of(status: &portable_pty::ExitStatus) -> i32 {
+    i32::try_from(status.exit_code()).unwrap_or(EXIT_CODE_UNKNOWN)
 }
 
 fn extract_debug_pod_name(s: &str) -> Option<String> {
@@ -545,6 +605,18 @@ fn build_command(id: &str, spec: &SpawnSpec) -> Result<(CommandBuilder, Vec<Path
             Ok((cmd, scratch_files))
         }
         SpawnSpec::CloudLogin { account } => {
+            // On Windows the gcloud SDK ships `gcloud.cmd`, and portable-pty
+            // spawns through raw `CreateProcessW`, which cannot execute a batch
+            // file — so the interpreter has to be explicit there. Elsewhere
+            // `gcloud` is a real executable on PATH.
+            #[cfg(windows)]
+            let mut cmd = {
+                let mut c = CommandBuilder::new("cmd.exe");
+                c.arg("/c");
+                c.arg("gcloud");
+                c
+            };
+            #[cfg(not(windows))]
             let mut cmd = CommandBuilder::new("gcloud");
             cmd.arg("auth");
             cmd.arg("login");
@@ -733,7 +805,16 @@ fn write_scratch_kubeconfig(
     default_namespace: Option<&str>,
 ) -> Result<(PathBuf, String), String> {
     let dir = scratch_dir();
+    // The credential plugin caches a live access token in here (see
+    // `plugin_cache_slot`), so the directory is owner-only rather than whatever
+    // the umask allows.
     std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir cache: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| format!("chmod cache dir: {e}"))?;
+    }
     let path = dir.join(format!("term-{id}-{}.yaml", std::process::id()));
 
     let mut doc = serde_yaml::Mapping::new();
@@ -834,8 +915,10 @@ fn source_context_cluster_user(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_command, SpawnSpec};
+    use super::{build_command, reap_exit_code_within, SpawnSpec, EXIT_CODE_UNKNOWN, REAP_BUDGET};
     use std::collections::HashMap;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
 
     fn argv(spec: &SpawnSpec) -> Vec<String> {
         let (cmd, scratch) = build_command("t0", spec).expect("build");
@@ -847,6 +930,85 @@ mod tests {
             .iter()
             .map(|a| a.to_string_lossy().into_owned())
             .collect()
+    }
+
+    /// Stand-in for a PTY child: reports "still running" for `pending` polls,
+    /// then the given status. Enough to exercise the reaper without a real PTY.
+    #[derive(Debug)]
+    struct FakeChild {
+        pending: usize,
+        status: Option<portable_pty::ExitStatus>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct FakeKiller;
+
+    impl portable_pty::ChildKiller for FakeKiller {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+            Box::new(self.clone())
+        }
+    }
+
+    impl portable_pty::ChildKiller for FakeChild {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+        fn clone_killer(&self) -> Box<dyn portable_pty::ChildKiller + Send + Sync> {
+            Box::new(FakeKiller)
+        }
+    }
+
+    impl portable_pty::Child for FakeChild {
+        fn try_wait(&mut self) -> std::io::Result<Option<portable_pty::ExitStatus>> {
+            if self.pending > 0 {
+                self.pending -= 1;
+                return Ok(None);
+            }
+            Ok(self.status.clone())
+        }
+        fn wait(&mut self) -> std::io::Result<portable_pty::ExitStatus> {
+            unreachable!("the reaper must poll, never block holding the child lock")
+        }
+        fn process_id(&self) -> Option<u32> {
+            None
+        }
+        #[cfg(windows)]
+        fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
+            None
+        }
+    }
+
+    fn child(
+        pending: usize,
+        code: Option<u32>,
+    ) -> StdMutex<Box<dyn portable_pty::Child + Send + Sync>> {
+        StdMutex::new(Box::new(FakeChild {
+            pending,
+            status: code.map(portable_pty::ExitStatus::with_exit_code),
+        }))
+    }
+
+    #[test]
+    fn a_failed_command_reports_its_real_exit_code() {
+        // The reason this matters: the reauth login treats 0 as "renewed" and
+        // reconnects. Reporting 0 for a failed `gcloud auth login` would send the
+        // operator into a reconnect that re-fails, with the real reason hidden.
+        assert_eq!(reap_exit_code_within(&child(0, Some(1)), REAP_BUDGET), 1);
+        assert_eq!(reap_exit_code_within(&child(0, Some(0)), REAP_BUDGET), 0);
+        // EOF usually precedes the child's status being reapable by a poll or two.
+        assert_eq!(reap_exit_code_within(&child(3, Some(7)), REAP_BUDGET), 7);
+    }
+
+    #[test]
+    fn an_unreapable_child_never_reports_success() {
+        // A child still running when the budget expires has an unknown status,
+        // and unknown must not read as success.
+        let code = reap_exit_code_within(&child(usize::MAX, None), Duration::from_millis(60));
+        assert_eq!(code, EXIT_CODE_UNKNOWN);
+        assert_ne!(code, 0, "unknown must never masquerade as success");
     }
 
     #[test]

--- a/crates/core/src/cloud_identity/aws.rs
+++ b/crates/core/src/cloud_identity/aws.rs
@@ -190,6 +190,7 @@ pub fn compose_hint(error: &str, profiles: &Identities) -> Option<ConnectHint> {
                     .to_owned(),
             ],
         }),
+        reauth: None,
     })
 }
 

--- a/crates/core/src/cloud_identity/azure.rs
+++ b/crates/core/src/cloud_identity/azure.rs
@@ -159,6 +159,7 @@ pub fn compose_hint(error: &str, accounts: &Identities) -> Option<ConnectHint> {
         // mutating global `az` state behind a button that looks like a
         // kubeconfig edit.
         pin: None,
+        reauth: None,
     })
 }
 

--- a/crates/core/src/cloud_identity/gcloud.rs
+++ b/crates/core/src/cloud_identity/gcloud.rs
@@ -51,10 +51,15 @@ const CONFIGURATIONS_DIR: &str = "configurations";
 /// Configuration gcloud falls back to when [`ACTIVE_CONFIG_FILE`] is absent.
 const DEFAULT_CONFIG_NAME: &str = "default";
 
-/// The `gke-gcloud-auth-plugin` global token cache. Shared by every tool on the
-/// machine (kubectl included) and regenerated on the next plugin run, which is
-/// what makes deleting it a safe recovery step.
-const PLUGIN_CACHE_FILE: &str = "gke_gcloud_auth_plugin_cache";
+/// The `gke-gcloud-auth-plugin` token cache. Regenerated on the next plugin
+/// run, which is what makes deleting it a safe recovery step.
+///
+/// The plugin writes it beside the kubeconfig it resolves — `filepath.Dir` of
+/// client-go's `GetDefaultFilename()`, i.e. the first existing `KUBECONFIG`
+/// entry, else `~/.kube/config`. So this name appears both in the default
+/// location ([`plugin_cache_path`], shared with kubectl) and in each slot
+/// [`crate::exec_auth`] hands the plugin.
+pub(crate) const PLUGIN_CACHE_FILE: &str = "gke_gcloud_auth_plugin_cache";
 
 /// gcloud's config directory: `CLOUDSDK_CONFIG` when set, else the per-platform
 /// default. `None` when neither the override nor a home directory is resolvable.
@@ -220,7 +225,96 @@ pub fn compose_hint(error: &str, accounts: &Identities) -> Option<ConnectHint> {
                     .to_owned(),
             ],
         }),
+        reauth: None,
     })
+}
+
+/// Build the "your Google session expired" note.
+///
+/// Unlike [`compose_hint`] this has no gates to pass: the plugin's own stderr
+/// already told us exactly what happened, so there is nothing to infer and no
+/// risk of a confident guess about the wrong problem. `account` is the pinned
+/// account when the context has one; an unpinned context renews whichever
+/// account gcloud has active.
+///
+/// Offers no pin. Pinning writes an `--account` flag, and the account was never
+/// the problem here — its session lapsed. Pinning would leave the operator with
+/// the same failure and an edited kubeconfig.
+#[must_use]
+pub fn compose_reauth_hint(account: Option<&str>, accounts: &Identities) -> ConnectHint {
+    let whose = account
+        .map(|a| format!("The Google session for {a}"))
+        .unwrap_or_else(|| {
+            accounts.active.as_ref().map_or_else(
+                || "Your active Google session".to_owned(),
+                |a| format!("The Google session for {a} (this context's active account)"),
+            )
+        });
+    let command = account.map_or_else(
+        || "gcloud auth login".to_owned(),
+        |a| format!("gcloud auth login --account={a}"),
+    );
+    ConnectHint {
+        provider: Provider::Gcloud,
+        title: "Google session expired".to_owned(),
+        detail: format!(
+            "{whose} has expired, so gke-gcloud-auth-plugin could not mint a token. Renewing it \
+             needs an identity challenge — usually a browser — which the app cannot show you: it \
+             runs the plugin without a terminal, and gcloud refuses to prompt there \
+             (\"cannot prompt during non-interactive execution\"). Run the command below in a \
+             terminal, then reconnect. Your credentials are intact; only the session lapsed, and \
+             an org session-length policy will lapse it again on its own schedule."
+        ),
+        authenticated_as: None,
+        identities: accounts.identities.clone(),
+        active_identity: accounts.active.clone(),
+        pin: None,
+        reauth: Some(super::ReauthOffer {
+            command,
+            account: account.map(str::to_owned),
+        }),
+    }
+}
+
+/// Why a gcloud-family exec plugin exited non-zero, to the extent its stderr
+/// says. Drives which remedy we offer, and the remedies have nothing in common.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecFailure {
+    /// The refresh token is intact but the org's session policy wants a fresh
+    /// identity challenge, which needs a terminal (usually a browser) the app
+    /// cannot offer. Cured only by an interactive `gcloud auth login`.
+    ReauthRequired,
+    /// No usable credentials for that account at all — never logged in, or the
+    /// grant was revoked.
+    CredentialsInvalid,
+    /// Anything else: a broken plugin, a bad `--account`, gcloud not installed.
+    Other,
+}
+
+/// Classify a plugin's stderr.
+///
+/// Reauth is tested first and wins: gcloud prints the same "Please run: $ gcloud
+/// auth login" footer for a lapsed session as for absent credentials, so the
+/// footer distinguishes nothing while the reauth sentence does.
+#[must_use]
+pub fn classify_exec_failure(stderr: &str) -> ExecFailure {
+    let m = stderr.to_ascii_lowercase();
+    if m.contains("reauthentication failed")
+        || m.contains("reauthentication required")
+        || m.contains("reauth")
+        || (m.contains("cannot prompt") && m.contains("non-interactive"))
+    {
+        return ExecFailure::ReauthRequired;
+    }
+    if m.contains("invalid_grant")
+        || m.contains("does not have valid credentials")
+        || m.contains("do not have valid credentials")
+        || m.contains("no credentialed accounts")
+        || m.contains("was not found in credentialed accounts")
+    {
+        return ExecFailure::CredentialsInvalid;
+    }
+    ExecFailure::Other
 }
 
 /// Write `--account=<identity>` into an exec mapping, replacing any prior form.
@@ -289,9 +383,14 @@ pub fn clear_plugin_cache_at(path: &Path) -> std::io::Result<()> {
     }
 }
 
-/// `~/.kube/gke_gcloud_auth_plugin_cache`. Deliberately *not* derived from
-/// `KUBECONFIG` — the plugin always writes it next to the default kube home,
-/// regardless of which kubeconfig is in play.
+/// `~/.kube/gke_gcloud_auth_plugin_cache` — the slot the plugin uses when no
+/// `KUBECONFIG` steers it elsewhere, and therefore the one it shares with the
+/// operator's kubectl.
+///
+/// Not the only slot: the path is `filepath.Dir` of client-go's
+/// `GetDefaultFilename()`, so a set `KUBECONFIG` moves the cache next to its
+/// first existing entry. [`crate::exec_auth::clear_cache_slots`] covers the
+/// ones we create.
 #[must_use]
 pub fn plugin_cache_path() -> Option<PathBuf> {
     home_dir().map(|h| h.join(".kube").join(PLUGIN_CACHE_FILE))
@@ -304,6 +403,76 @@ mod tests {
         kubeconfig_fixture, read_args, FORBIDDEN_403, KUBECONFIG_YAML,
     };
     use crate::cloud_identity::{backup_path, tests::pin};
+
+    /// Verbatim stderr from `gke-gcloud-auth-plugin` when the org's Cloud
+    /// session length has lapsed. Captured from a real GKE context, account
+    /// name replaced — the exact wording is what the classifier keys on, so a
+    /// paraphrase here would test nothing.
+    const REAUTH_STDERR: &str = "print credential failed with error: Failed to retrieve access \
+         token:: failure while executing gcloud, with args [config config-helper --format=json \
+         --account=a@example.com]: exit status 1 (err: ERROR: \
+         (gcloud.config.config-helper) There was a problem refreshing your current auth tokens: \
+         Reauthentication failed. cannot prompt during non-interactive execution.\nPlease run:\n\n \
+         $ gcloud auth login\n\nto obtain new credentials.\n)";
+
+    #[test]
+    fn a_lapsed_session_is_classified_as_reauth() {
+        assert_eq!(
+            classify_exec_failure(REAUTH_STDERR),
+            ExecFailure::ReauthRequired
+        );
+        // The bare sentence, without the plugin's wrapper.
+        assert_eq!(
+            classify_exec_failure(
+                "Reauthentication failed. cannot prompt during non-interactive execution."
+            ),
+            ExecFailure::ReauthRequired
+        );
+        // Older gcloud phrasing.
+        assert_eq!(
+            classify_exec_failure("ERROR: (gcloud.auth) reauth required"),
+            ExecFailure::ReauthRequired
+        );
+    }
+
+    #[test]
+    fn absent_credentials_are_not_a_reauth() {
+        // Both shapes end with the same "Please run: $ gcloud auth login"
+        // footer as a lapsed session, so the footer must not be what decides.
+        assert_eq!(
+            classify_exec_failure(
+                "ERROR: (gcloud.config.config-helper) There was a problem refreshing your current \
+                 auth tokens: ('invalid_grant: Bad Request', ...)\nPlease run:\n\n  $ gcloud auth \
+                 login\n"
+            ),
+            ExecFailure::CredentialsInvalid
+        );
+        assert_eq!(
+            classify_exec_failure(
+                "ERROR: (gcloud.config.config-helper) You do not currently have an active account \
+                 selected.\nERROR: no credentialed accounts."
+            ),
+            ExecFailure::CredentialsInvalid
+        );
+    }
+
+    #[test]
+    fn unrelated_plugin_failures_stay_other() {
+        assert_eq!(
+            classify_exec_failure("exec: \"gcloud\": executable file not found in $PATH"),
+            ExecFailure::Other
+        );
+        assert_eq!(
+            classify_exec_failure("cannot construct google default token source"),
+            ExecFailure::Other
+        );
+        assert_eq!(classify_exec_failure(""), ExecFailure::Other);
+        // "credentials" on its own is not a verdict either way.
+        assert_eq!(
+            classify_exec_failure("invalid credentials for project foo"),
+            ExecFailure::Other
+        );
+    }
 
     fn write(path: &Path, body: &str) {
         if let Some(parent) = path.parent() {

--- a/crates/core/src/cloud_identity/mod.rs
+++ b/crates/core/src/cloud_identity/mod.rs
@@ -419,7 +419,11 @@ pub fn pin_identity(kubeconfig: &Path, context: &str, identity: &str) -> Result<
 /// A newline in an env value or a control character in an argv element is never
 /// legitimate here, and the length cap stops a pathological value from bloating
 /// the file we're about to rewrite.
-fn validate_identity(identity: &str) -> Result<()> {
+/// # Errors
+///
+/// [`Error::Invalid`] when the value is empty, over [`MAX_LEN`], or carries
+/// control characters.
+pub fn validate_identity(identity: &str) -> Result<()> {
     if identity.is_empty() {
         return Err(Error::Invalid("identity must not be empty".to_owned()));
     }

--- a/crates/core/src/cloud_identity/mod.rs
+++ b/crates/core/src/cloud_identity/mod.rs
@@ -77,6 +77,22 @@ pub struct PinOffer {
     pub effects: Vec<String>,
 }
 
+/// What an operator has to run to renew a lapsed cloud session.
+///
+/// Separate from [`PinOffer`] because there is nothing for the app to write: the
+/// provider wants an identity challenge (usually a browser round trip), and a
+/// GUI process spawning the plugin has no terminal to host one. The remedy is a
+/// command the operator runs, after which the app's next connect succeeds.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ReauthOffer {
+    /// Verbatim command to run, complete with the account flag when the context
+    /// pins one.
+    pub command: String,
+    /// Account whose session lapsed. `None` when the context is unpinned, in
+    /// which case whichever account the CLI has active is the one to renew.
+    pub account: Option<String>,
+}
+
 /// An actionable note to render alongside a failed connect.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ConnectHint {
@@ -94,6 +110,10 @@ pub struct ConnectHint {
     /// `None` when the provider has no per-context pin at all (Azure): the note
     /// then explains the CLI command to run instead.
     pub pin: Option<PinOffer>,
+    /// Set instead of [`Self::pin`] when the failure was a lapsed cloud session
+    /// rather than identity drift. Pinning cannot fix that — only an interactive
+    /// login can — so the two are mutually exclusive in practice.
+    pub reauth: Option<ReauthOffer>,
 }
 
 /// Pull the identity out of an apiserver RBAC denial (`User "x" cannot …`).
@@ -138,6 +158,20 @@ pub fn forbidden_user(message: &str) -> Option<String> {
         rest = &rest[idx + marker.len()..];
     }
     None
+}
+
+/// Does this error look like a cloud session that needs an interactive renewal?
+///
+/// Matches both ends of the same failure: the plugin's own stderr (which
+/// [`crate::exec_auth`] captures and puts in the error) and our rendering of
+/// [`crate::Error::ExecReauthRequired`], so the note survives whichever layer
+/// formatted the string that reaches the frontend.
+#[must_use]
+pub fn looks_like_reauth(message: &str) -> bool {
+    gcloud::classify_exec_failure(message) == gcloud::ExecFailure::ReauthRequired
+        || message
+            .to_ascii_lowercase()
+            .contains("cloud session expired")
 }
 
 /// Does this error string look like a genuine RBAC 403?
@@ -301,9 +335,13 @@ fn hint_for_context_with(
     error: &str,
     probe: &dyn Fn(Provider) -> Identities,
 ) -> Result<Option<ConnectHint>> {
-    // Cheapest gate first: most connect failures aren't 403s at all, and
-    // bailing here avoids reading the kubeconfig a second time.
-    if !is_forbidden(error) {
+    // Two different failures reach here. A 403 means the connect *authenticated*
+    // and was refused, which is where identity drift shows up. A lapsed cloud
+    // session never gets that far — the exec plugin refuses to produce a token
+    // at all — so it needs its own gate, and it must come first: the reauth
+    // message is not a 403 and would otherwise be dropped by the check below.
+    let reauth = looks_like_reauth(error);
+    if !reauth && !is_forbidden(error) {
         return Ok(None);
     }
     let Some(spec) = crate::cluster::exec_spec_for_context(context_name, source_path)? else {
@@ -312,6 +350,23 @@ fn hint_for_context_with(
     let Some((provider, binding)) = classify(&spec.command, &spec.args, &spec.env) else {
         return Ok(None);
     };
+    if reauth {
+        // Only gcloud is claimed here. AWS mints per call (no session to lapse),
+        // and kubelogin's device/interactive modes fail differently — inventing
+        // matching prose for either would be guessing.
+        if provider != Provider::Gcloud {
+            return Ok(None);
+        }
+        let account = match &binding {
+            Binding::Pinned { identity } => Some(identity.clone()),
+            Binding::FollowsActive => None,
+        };
+        let identities = probe(provider);
+        return Ok(Some(gcloud::compose_reauth_hint(
+            account.as_deref(),
+            &identities,
+        )));
+    }
     // A pinned context can't be suffering identity drift, whatever the
     // provider — the 403 is a plain RBAC gap.
     if binding != Binding::FollowsActive {
@@ -349,6 +404,7 @@ pub fn pin_identity(kubeconfig: &Path, context: &str, identity: &str) -> Result<
         context,
         identity,
         gcloud::plugin_cache_path().as_deref(),
+        crate::exec_auth::slots_root().as_deref(),
     )
 }
 
@@ -381,7 +437,8 @@ fn validate_identity(identity: &str) -> Result<()> {
     Ok(())
 }
 
-/// [`pin_identity`] with the gcloud token cache location injected.
+/// [`pin_identity`] with both token cache locations injected: the plugin's
+/// default file and the root of the slots we hand it ourselves.
 ///
 /// Exists so tests can exercise the real code path — including the
 /// gcloud-only cache clear — without reaching into the developer's `$HOME` and
@@ -391,6 +448,7 @@ fn pin_identity_at(
     context: &str,
     identity: &str,
     gcloud_cache: Option<&Path>,
+    slots_root: Option<&Path>,
 ) -> Result<()> {
     let identity = identity.trim();
     validate_identity(identity)?;
@@ -430,6 +488,17 @@ fn pin_identity_at(
             gcloud::clear_plugin_cache_at(cache).map_err(|e| {
                 Error::Invalid(format!(
                     "account pinned, but clearing the gcloud auth plugin token cache failed: {e}"
+                ))
+            })?;
+        }
+        // The default slot above isn't the only one: every slot
+        // `crate::exec_auth` hands the plugin can hold a token minted under the
+        // pre-pin identity too, and the newly pinned account reads a *different*
+        // slot, so a stale one would sit there until it expired.
+        if let Some(root) = slots_root {
+            crate::exec_auth::clear_cache_slots_at(root).map_err(|e| {
+                Error::Invalid(format!(
+                    "account pinned, but clearing the app's auth token cache failed: {e}"
                 ))
             })?;
         }
@@ -846,6 +915,96 @@ mod tests {
         assert_eq!(hint("nope", FORBIDDEN_403, &no_probe).expect("hint"), None);
     }
 
+    /// Verbatim from `Error::ExecReauthRequired`'s rendering of a real plugin
+    /// failure — the string the frontend actually hands back to `connect_hint`.
+    const REAUTH_ERROR: &str = "cloud session expired for a@example.com — run \
+         `gcloud auth login --account=a@example.com` in a terminal (ERROR: \
+         (gcloud.config.config-helper) There was a problem refreshing your current auth tokens: \
+         Reauthentication failed. cannot prompt during non-interactive execution.)";
+
+    #[test]
+    fn a_lapsed_session_gets_a_reauth_note_not_a_pin() {
+        // This failure never reaches the apiserver, so it carries no 403 and
+        // the drift gates would drop it. It also must not offer a pin: the
+        // account is fine, its session isn't, and pinning would edit the
+        // operator's kubeconfig for nothing.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let pinned = KUBECONFIG_YAML.replace(
+            "      command: gke-gcloud-auth-plugin",
+            "      command: gke-gcloud-auth-plugin\n      args: [\"--account=a@example.com\"]",
+        );
+        let path = kubeconfig_fixture(tmp.path(), &pinned);
+        let hint = hint_for_context_with("gke", Some(&path), REAUTH_ERROR, &two_accounts)
+            .expect("hint")
+            .expect("a reauth note");
+
+        assert_eq!(hint.provider, Provider::Gcloud);
+        assert_eq!(hint.pin, None);
+        let offer = hint.reauth.expect("reauth offer");
+        assert_eq!(offer.account.as_deref(), Some("a@example.com"));
+        assert_eq!(offer.command, "gcloud auth login --account=a@example.com");
+        assert!(hint.detail.contains("terminal"));
+    }
+
+    #[test]
+    fn a_lapsed_session_on_an_unpinned_context_renews_the_active_account() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let hint = hint_for_context_with(
+            "gke",
+            Some(&path),
+            "Reauthentication failed. cannot prompt during non-interactive execution.",
+            &two_accounts,
+        )
+        .expect("hint")
+        .expect("a reauth note");
+
+        let offer = hint.reauth.expect("reauth offer");
+        assert_eq!(
+            offer.account, None,
+            "an unpinned context has no account of its own to name"
+        );
+        assert_eq!(
+            offer.command, "gcloud auth login",
+            "so the command must not invent one either"
+        );
+        // The note still says which account gcloud would renew.
+        assert!(hint.detail.contains("b@example.com"));
+    }
+
+    #[test]
+    fn the_reauth_gate_stays_inside_gcloud() {
+        // AWS mints a token per call, so there is no session to lapse; kubelogin
+        // fails differently. Matching prose for either would be invention.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        for ctx in ["eks", "aks"] {
+            assert_eq!(
+                hint_for_context_with(ctx, Some(&path), REAUTH_ERROR, &two_accounts).expect("hint"),
+                None,
+                "{ctx} must not be handed gcloud's reauth wording"
+            );
+        }
+        // Nor does a context with no exec plugin at all.
+        assert_eq!(
+            hint_for_context_with("plain", Some(&path), REAUTH_ERROR, &no_probe).expect("hint"),
+            None
+        );
+    }
+
+    #[test]
+    fn an_ordinary_403_is_still_drift_not_reauth() {
+        // The two gates must not bleed: a plain RBAC denial keeps offering the
+        // pin, with no reauth offer attached.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let hint = hint_for_context_with("gke", Some(&path), FORBIDDEN_403, &two_accounts)
+            .expect("hint")
+            .expect("a drift note");
+        assert!(hint.pin.is_some());
+        assert_eq!(hint.reauth, None);
+    }
+
     #[test]
     fn hint_refuses_a_context_that_already_names_an_identity() {
         // The gate that stops the note firing on a correctly-pinned context.
@@ -1130,7 +1289,13 @@ users:
     /// the gcloud-only cache clear runs for real without touching the
     /// developer's `~/.kube`.
     pub(super) fn pin(path: &Path, ctx: &str, identity: &str) -> Result<()> {
-        pin_identity_at(path, ctx, identity, Some(&path.with_extension("cache")))
+        pin_identity_at(
+            path,
+            ctx,
+            identity,
+            Some(&path.with_extension("cache")),
+            Some(&path.with_extension("slots")),
+        )
     }
 
     #[test]

--- a/crates/core/src/cluster.rs
+++ b/crates/core/src/cluster.rs
@@ -32,6 +32,7 @@ use tower_http::{
     decompression::DecompressionLayer, set_header::SetRequestHeaderLayer, ServiceExt as _,
 };
 
+use crate::exec_auth::{self, redact_and_truncate};
 use crate::sources::SshSourceConfig;
 use crate::ssh::{SshSession, TunnelHandle};
 use crate::{Error, Result};
@@ -273,77 +274,6 @@ fn auth_exec_run_in_chain(
     None
 }
 
-/// Make a plugin's raw stderr safe and compact for display: drop lines that
-/// look like they carry a credential (token JSON, JWT/base64 runs, Bearer
-/// headers), strip blank lines, and cap total length. Conservative on what it
-/// flags as secret so genuine error text ("reauth required", "invalid
-/// credentials") survives.
-fn redact_and_truncate(s: &str) -> String {
-    const MAX: usize = 1500;
-    let mut lines: Vec<&str> = Vec::new();
-    let mut redacted_any = false;
-    for line in s.lines() {
-        let t = line.trim_end();
-        if t.is_empty() {
-            continue;
-        }
-        if looks_secretish(t) {
-            redacted_any = true;
-            continue;
-        }
-        lines.push(t);
-    }
-    let mut out = lines.join("\n");
-    if redacted_any {
-        out.push_str("\n[credential material redacted]");
-    }
-    let out = out.trim().to_string();
-    let mut out = if out.len() > MAX {
-        let mut end = MAX;
-        while !out.is_char_boundary(end) {
-            end -= 1;
-        }
-        let mut truncated = out[..end].to_string();
-        truncated.push_str(" … (truncated)");
-        truncated
-    } else {
-        out
-    };
-    if out.is_empty() {
-        out = "(plugin produced no output)".to_string();
-    }
-    out
-}
-
-/// Heuristic: does this line likely contain a secret value (not merely the word
-/// "credentials")? Catches token JSON fields, `Bearer` headers, and long
-/// base64url/JWT runs. Excludes `/` and `.` from the run alphabet so file paths
-/// and dotted hostnames don't trip it.
-fn looks_secretish(line: &str) -> bool {
-    let lower = line.to_ascii_lowercase();
-    if lower.contains("\"token\"")
-        || lower.contains("token=")
-        || lower.contains("bearer ")
-        || lower.contains("id_token")
-        || lower.contains("access_token")
-        || lower.contains("\"password\"")
-        || lower.contains("client-secret")
-    {
-        return true;
-    }
-    let mut run = 0usize;
-    let mut max_run = 0usize;
-    for c in line.chars() {
-        if c.is_ascii_alphanumeric() || matches!(c, '+' | '_' | '-' | '=') {
-            run += 1;
-            max_run = max_run.max(run);
-        } else {
-            run = 0;
-        }
-    }
-    max_run >= 40
-}
-
 /// Walk the [`std::error::Error`] source chain looking for an `io::Error` of
 /// kind `NotFound`. Depends only on the std error trait + an `io::Error`
 /// downcast, so it's robust to kube-rs's internal error-enum shape changing
@@ -447,7 +377,7 @@ impl Cluster {
     /// `source_path = None` reads the default kubeconfig (env / ~/.kube/config);
     /// `Some(path)` loads from that specific file (used for user-added sources).
     pub async fn connect(context_name: &str, source_path: Option<&Path>) -> Result<Self> {
-        let kubeconfig = match source_path {
+        let mut kubeconfig = match source_path {
             Some(p) => Kubeconfig::read_from(p)?,
             None => Kubeconfig::read()?,
         };
@@ -455,6 +385,33 @@ impl Cluster {
         // consumed, so a later ENOENT from that plugin can be turned into an
         // actionable error instead of a raw "No such file or directory".
         let exec_command = exec_plugin_for_context(&kubeconfig, context_name);
+        // Run the gcloud auth plugin once ourselves, before kube-rs spawns it
+        // per `Client`. Two payoffs: its stderr is ours to read (kube-rs
+        // inherits it, so `AuthExecRun` arrives empty), and a success warms the
+        // token-cache slot the later spawns read instead of each shelling out to
+        // gcloud. See `crate::exec_auth`.
+        if let Some(prepared) = exec_auth::prepare(&mut kubeconfig, context_name) {
+            match exec_auth::preflight(&prepared, None).await {
+                exec_auth::PreflightOutcome::Failed { code, stderr } => {
+                    return Err(exec_auth::failure_error(&prepared, code, stderr));
+                }
+                exec_auth::PreflightOutcome::Missing => {
+                    return Err(Error::ExecPluginNotFound {
+                        hint: exec_install_hint(&prepared.command),
+                        command: prepared.command,
+                    });
+                }
+                // No information — a spawn that failed for an unrelated reason,
+                // or one slower than the preflight budget. Connecting anyway
+                // keeps a working cluster reachable; kube-rs gets its own try.
+                exec_auth::PreflightOutcome::Inconclusive(why) => tracing::debug!(
+                    target: "ferrisscope::auth",
+                    context = context_name,
+                    "exec preflight inconclusive ({why})"
+                ),
+                exec_auth::PreflightOutcome::Warmed => {}
+            }
+        }
         let options = KubeConfigOptions {
             context: Some(context_name.to_owned()),
             ..Default::default()
@@ -1333,50 +1290,6 @@ users:
         // Env presence covers the full diagnostic key set, values never leaked.
         assert_eq!(diag.env_presence.len(), DIAG_ENV_KEYS.len());
         assert!(diag.env_presence.iter().any(|e| e.key == "HOME"));
-    }
-
-    #[test]
-    fn redact_and_truncate_keeps_error_text_drops_secrets() {
-        let raw = "ERROR: (gcloud.auth) reauth required\n\
-                   invalid credentials for project foo\n\
-                   token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTABCDEFGH\n";
-        let out = redact_and_truncate(raw);
-        // Human-readable diagnostics survive…
-        assert!(out.contains("reauth required"));
-        // …including a line that merely mentions "credentials" (no secret value).
-        assert!(out.contains("invalid credentials for project foo"));
-        // …but the token line is gone, replaced by a marker.
-        assert!(!out.contains("eyJhbGci"));
-        assert!(!out.contains("token="));
-        assert!(out.contains("[credential material redacted]"));
-    }
-
-    #[test]
-    fn redact_and_truncate_caps_length_and_handles_empty() {
-        // Long but non-secret text (spaces break the base64-run heuristic).
-        let long = "err line ".repeat(1000);
-        let out = redact_and_truncate(&long);
-        assert!(out.len() <= 1500 + 32);
-        assert!(out.ends_with("… (truncated)"));
-        assert_eq!(
-            redact_and_truncate("   \n  \n"),
-            "(plugin produced no output)"
-        );
-    }
-
-    #[test]
-    fn looks_secretish_flags_tokens_not_paths() {
-        assert!(looks_secretish("\"token\": \"abc\""));
-        assert!(looks_secretish("Authorization: Bearer abc123"));
-        assert!(looks_secretish(&format!("blob {}", "A".repeat(45))));
-        // File paths and dotted hostnames must NOT be flagged.
-        assert!(!looks_secretish(
-            "/Users/me/.config/gcloud/application_default_credentials.json"
-        ));
-        assert!(!looks_secretish(
-            "could not reach oauth2.googleapis.com:443"
-        ));
-        assert!(!looks_secretish("invalid credentials"));
     }
 
     // kube-rs surfaces a non-zero plugin exit as `AuthError::AuthExecRun`, which

--- a/crates/core/src/cluster.rs
+++ b/crates/core/src/cluster.rs
@@ -391,7 +391,7 @@ impl Cluster {
         // token-cache slot the later spawns read instead of each shelling out to
         // gcloud. See `crate::exec_auth`.
         if let Some(prepared) = exec_auth::prepare(&mut kubeconfig, context_name) {
-            match exec_auth::preflight(&prepared, None).await {
+            match exec_auth::preflight(&prepared).await {
                 exec_auth::PreflightOutcome::Failed { code, stderr } => {
                     return Err(exec_auth::failure_error(&prepared, code, stderr));
                 }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -28,6 +28,20 @@ pub enum Error {
         stderr: String,
     },
 
+    /// The plugin ran and refused because the cloud session lapsed: the
+    /// credentials are intact, but the provider wants an identity challenge that
+    /// needs a terminal (and usually a browser) the app cannot offer. Separate
+    /// from [`Error::ExecPluginFailed`] because the only remedy is an
+    /// interactive login, not a plugin or PATH fix.
+    #[error("cloud session expired for {} — run `gcloud auth login{}` in a terminal ({message})",
+        account.as_deref().unwrap_or("the active account"),
+        account.as_ref().map(|a| format!(" --account={a}")).unwrap_or_default())]
+    ExecReauthRequired {
+        command: String,
+        account: Option<String>,
+        message: String,
+    },
+
     #[error("context not found: {0}")]
     ContextNotFound(String),
 

--- a/crates/core/src/exec_auth.rs
+++ b/crates/core/src/exec_auth.rs
@@ -33,6 +33,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use directories::ProjectDirs;
@@ -52,6 +53,26 @@ pub const PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(8);
 /// identity is a cache slot per identity.
 const SLOTS_DIR: &str = "authcache";
 
+/// One lock per cache slot, so concurrent connects sharing an identity take
+/// turns at a cold slot instead of each spawning gcloud. Keyed by slot
+/// directory; slotless invocations share one entry, which is the same
+/// serialisation they'd want anyway (they contend on the plugin's default file).
+static SLOT_LOCKS: OnceLock<std::sync::Mutex<HashMap<PathBuf, Arc<tokio::sync::Mutex<()>>>>> =
+    OnceLock::new();
+
+fn slot_lock(dir: Option<&Path>) -> Arc<tokio::sync::Mutex<()>> {
+    let key = dir.map_or_else(|| PathBuf::from("<default>"), Path::to_path_buf);
+    let table = SLOT_LOCKS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
+    let mut guard = match table.lock() {
+        Ok(g) => g,
+        // A poisoned table would only mean some earlier holder panicked; the
+        // contents are still sound, and refusing to preflight over it would be
+        // worse than serialising slightly wrong.
+        Err(e) => e.into_inner(),
+    };
+    Arc::clone(guard.entry(key).or_default())
+}
+
 /// A context's exec plugin, resolved and ready to run, plus the cache slot we
 /// pointed it at.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -64,6 +85,9 @@ pub struct PreparedExec {
     /// The gcloud account this invocation authenticates as, when the context
     /// pins one. `None` means it follows `gcloud config set account`.
     pub identity: Option<String>,
+    /// The exec entry's `apiVersion`, carried so our `KUBERNETES_EXEC_INFO`
+    /// matches what kube-rs will send rather than a guess.
+    pub api_version: Option<String>,
     /// Directory the plugin will read/write its token cache in. `None` when the
     /// slot could not be prepared — the plugin then falls back to its default
     /// location, which is exactly the pre-existing behaviour.
@@ -123,6 +147,7 @@ pub fn prepare_in(
         return None;
     }
     let args = exec.args.clone().unwrap_or_default();
+    let api_version = exec.api_version.clone();
     let mut env = exec_env_pairs(exec.env.as_ref());
 
     let identity = match gcloud::binding_for(command_basename(&command), &args, &env) {
@@ -156,6 +181,7 @@ pub fn prepare_in(
         args,
         env,
         identity,
+        api_version,
         cache_dir,
     })
 }
@@ -165,21 +191,38 @@ pub fn prepare_in(
 /// Stdin is `null` rather than inherited: a GUI process has nothing useful
 /// there, and an inherited-but-dead stdin is what makes gcloud believe it may
 /// prompt and then fail with a message no one sees.
-pub async fn preflight(prepared: &PreparedExec, api_version: Option<&str>) -> PreflightOutcome {
+pub async fn preflight(prepared: &PreparedExec) -> PreflightOutcome {
+    preflight_with_budget(prepared, PREFLIGHT_TIMEOUT).await
+}
+
+/// [`preflight`] with the wall-clock cap injected, so the timeout arm is
+/// testable without a multi-second test.
+pub async fn preflight_with_budget(prepared: &PreparedExec, budget: Duration) -> PreflightOutcome {
+    // One run per slot at a time. Connecting a fleet (or several tabs) fires
+    // parallel connects, and without this each one misses the same cold slot and
+    // spawns its own `gcloud` — the storm this module exists to remove. The
+    // waiters still run the plugin, but by then the slot is warm, so they hit the
+    // cache instead of gcloud (measured ~3ms vs ~1.2s) and the plugin itself
+    // decides whether the token is still good — no expiry parsing here.
+    let lock = slot_lock(prepared.cache_dir.as_deref());
+    let _guard = lock.lock().await;
+
     let mut cmd = tokio::process::Command::new(&prepared.command);
     cmd.args(&prepared.args)
         .envs(prepared.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
-        .env("KUBERNETES_EXEC_INFO", exec_info(api_version))
+        .env(
+            "KUBERNETES_EXEC_INFO",
+            exec_info(prepared.api_version.as_deref()),
+        )
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true);
 
-    match tokio::time::timeout(PREFLIGHT_TIMEOUT, cmd.output()).await {
-        Err(_) => PreflightOutcome::Inconclusive(format!(
-            "timed out after {}s",
-            PREFLIGHT_TIMEOUT.as_secs()
-        )),
+    match tokio::time::timeout(budget, cmd.output()).await {
+        Err(_) => {
+            PreflightOutcome::Inconclusive(format!("timed out after {}ms", budget.as_millis()))
+        }
         Ok(Err(e)) if e.kind() == std::io::ErrorKind::NotFound => PreflightOutcome::Missing,
         Ok(Err(e)) => PreflightOutcome::Inconclusive(e.to_string()),
         Ok(Ok(out)) if out.status.success() => PreflightOutcome::Warmed,
@@ -280,6 +323,11 @@ fn prepare_slot(root: Option<&Path>, identity: Option<&str>) -> std::io::Result<
         )
     })?;
     let dir = root.join(slot_name(identity));
+    // The plugin drops a live access token in here, so the directory is as
+    // sensitive as the file: created 0700 rather than left at whatever the
+    // process umask says.
+    create_private_dir(root)?;
+    create_private_dir(&dir)?;
     let kubeconfig = dir.join("config");
     crate::atomic_write::atomic_write_sync_mode(
         &kubeconfig,
@@ -287,6 +335,18 @@ fn prepare_slot(root: Option<&Path>, identity: Option<&str>) -> std::io::Result<
         Some(0o600),
     )?;
     Ok(Slot { dir, kubeconfig })
+}
+
+/// `mkdir -p` with owner-only permissions on unix. Idempotent, and tightens an
+/// existing directory that was created before this rule.
+fn create_private_dir(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
 }
 
 /// Filesystem-safe directory name for an identity. Unpinned contexts share one
@@ -672,6 +732,26 @@ users:
         clear_cache_slots_at(&root.path().join("never-created")).expect("missing root");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn slot_directories_are_owner_only() {
+        // The plugin writes a live access token into this directory, so the
+        // directory is as sensitive as the file inside it.
+        use std::os::unix::fs::PermissionsExt;
+        let root = root();
+        let mut kubeconfig = kc(KUBECONFIG);
+        let dir = prepare_in(&mut kubeconfig, "gke_p_r_c", Some(root.path()))
+            .expect("prepared")
+            .cache_dir
+            .expect("cache dir");
+        for path in [root.path(), dir.as_path()] {
+            let mode = std::fs::metadata(path).expect("stat").permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "{path:?} is group/world accessible");
+        }
+        let file = std::fs::metadata(dir.join("config")).expect("stat");
+        assert_eq!(file.permissions().mode() & 0o777, 0o600);
+    }
+
     #[test]
     fn slot_names_stay_filesystem_safe() {
         assert_eq!(slot_name(None), "active");
@@ -750,6 +830,7 @@ users:
                 args: vec!["-c".to_owned(), body.to_owned()],
                 env: Vec::new(),
                 identity: Some("a@example.com".to_owned()),
+                api_version: Some("client.authentication.k8s.io/v1beta1".to_owned()),
                 cache_dir: None,
             }
         }
@@ -757,7 +838,7 @@ users:
         #[tokio::test]
         async fn success_is_warmed() {
             let p = plugin("echo '{\"kind\":\"ExecCredential\"}'");
-            assert_eq!(preflight(&p, None).await, PreflightOutcome::Warmed);
+            assert_eq!(preflight(&p).await, PreflightOutcome::Warmed);
         }
 
         #[tokio::test]
@@ -767,7 +848,7 @@ users:
                  current auth tokens: Reauthentication failed. cannot prompt during \
                  non-interactive execution.' 1>&2; exit 1",
             );
-            let out = preflight(&p, None).await;
+            let out = preflight(&p).await;
             let PreflightOutcome::Failed { code, stderr } = out else {
                 panic!("expected Failed, got {out:?}");
             };
@@ -786,7 +867,7 @@ users:
         #[tokio::test]
         async fn other_failures_stay_generic() {
             let p = plugin("echo 'boom: bad config' 1>&2; exit 3");
-            let out = preflight(&p, None).await;
+            let out = preflight(&p).await;
             let PreflightOutcome::Failed { code, stderr } = out else {
                 panic!("expected Failed, got {out:?}");
             };
@@ -807,13 +888,13 @@ users:
                 .to_string_lossy()
                 .into_owned();
             p.args.clear();
-            assert_eq!(preflight(&p, None).await, PreflightOutcome::Missing);
+            assert_eq!(preflight(&p).await, PreflightOutcome::Missing);
         }
 
         #[tokio::test]
         async fn stdout_is_used_when_the_plugin_writes_its_error_there() {
             let p = plugin("echo 'failed on stdout'; exit 1");
-            let out = preflight(&p, None).await;
+            let out = preflight(&p).await;
             let PreflightOutcome::Failed { stderr, .. } = out else {
                 panic!("expected Failed, got {out:?}");
             };
@@ -826,7 +907,7 @@ users:
         async fn the_injected_kubeconfig_reaches_the_child() {
             let mut p = plugin("echo \"$KUBECONFIG\" 1>&2; exit 1");
             p.env = vec![("KUBECONFIG".to_owned(), "/slot/config".to_owned())];
-            let out = preflight(&p, None).await;
+            let out = preflight(&p).await;
             let PreflightOutcome::Failed { stderr, .. } = out else {
                 panic!("expected Failed, got {out:?}");
             };
@@ -838,7 +919,7 @@ users:
         #[tokio::test]
         async fn exec_info_is_passed_to_the_child() {
             let p = plugin("echo \"$KUBERNETES_EXEC_INFO\" 1>&2; exit 1");
-            let out = preflight(&p, None).await;
+            let out = preflight(&p).await;
             let PreflightOutcome::Failed { stderr, .. } = out else {
                 panic!("expected Failed, got {out:?}");
             };
@@ -847,21 +928,70 @@ users:
             assert_eq!(v["spec"]["interactive"], false);
         }
 
+        /// The invariant that keeps a working cluster reachable: a plugin
+        /// slower than the budget must report "no information", never a failure
+        /// the connect aborts on.
         #[tokio::test]
         async fn an_overrunning_plugin_is_inconclusive_not_fatal() {
-            // Exercise the real timeout arm with a budget short enough to keep
-            // the suite fast: same primitive, same outcome mapping.
-            let mut cmd = tokio::process::Command::new("/bin/sh");
-            cmd.args(["-c", "sleep 30"])
-                .stdin(Stdio::null())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .kill_on_drop(true);
+            let p = plugin("sleep 30");
+            let out = preflight_with_budget(&p, Duration::from_millis(150)).await;
+            match out {
+                PreflightOutcome::Inconclusive(why) => assert!(
+                    why.contains("timed out"),
+                    "the reason must say what happened: {why}"
+                ),
+                other => panic!("a hung plugin must not abort a connect, got {other:?}"),
+            }
+        }
+
+        /// Concurrent connects sharing an identity (a fleet, or several tabs)
+        /// must take turns at the slot instead of each spawning gcloud.
+        #[tokio::test]
+        async fn concurrent_preflights_on_one_slot_are_serialised() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let log = dir.path().join("overlaps");
+            // Each run claims its own marker, then counts how many exist. Under
+            // the lock the answer is always 1. Counting (rather than testing for
+            // one shared marker) makes the detection deterministic: without the
+            // lock every run holds its marker for the whole sleep, so any
+            // overlapping pair sees at least two.
+            let mut p = plugin(&format!(
+                "d={d}; : > $d/mark.$$; n=$(ls $d/mark.* | wc -l); \
+                 [ \"$n\" -gt 1 ] && echo overlap >> {l}; sleep 0.15; rm -f $d/mark.$$; exit 0",
+                d = dir.path().display(),
+                l = log.display()
+            ));
+            p.cache_dir = Some(dir.path().to_path_buf());
+
+            let runs = futures::future::join_all((0..4).map(|_| preflight(&p))).await;
             assert!(
-                tokio::time::timeout(Duration::from_millis(200), cmd.output())
-                    .await
-                    .is_err(),
-                "a hung plugin must not block a connect forever"
+                runs.iter().all(|r| *r == PreflightOutcome::Warmed),
+                "every run should succeed: {runs:?}"
+            );
+            assert!(
+                !log.exists(),
+                "two plugin runs overlapped on one slot: {:?}",
+                std::fs::read_to_string(&log)
+            );
+        }
+
+        /// Different identities must not serialise against each other — they
+        /// own different slots and can mint in parallel.
+        #[tokio::test]
+        async fn different_slots_do_not_block_each_other() {
+            let a = tempfile::tempdir().expect("tempdir");
+            let b = tempfile::tempdir().expect("tempdir");
+            let mut pa = plugin("sleep 0.3");
+            pa.cache_dir = Some(a.path().to_path_buf());
+            let mut pb = plugin("sleep 0.3");
+            pb.cache_dir = Some(b.path().to_path_buf());
+
+            let started = tokio::time::Instant::now();
+            let _ = tokio::join!(preflight(&pa), preflight(&pb));
+            assert!(
+                started.elapsed() < Duration::from_millis(550),
+                "two identities ran back to back instead of together: {:?}",
+                started.elapsed()
             );
         }
     }

--- a/crates/core/src/exec_auth.rs
+++ b/crates/core/src/exec_auth.rs
@@ -1,0 +1,868 @@
+//! Exec-credential preflight, and an app-owned token-cache slot for the gcloud
+//! auth plugins.
+//!
+//! `gke-gcloud-auth-plugin` mints nothing itself: it shells out to
+//! `gcloud config config-helper --format=json [--account=X]` and caches the
+//! result in a file *next to the kubeconfig it resolves*, keyed on
+//! `(current-context, extra_args, expiry)` — see `cred.go` upstream. Two
+//! consequences drive this module.
+//!
+//! **One slot, N identities.** The cache path comes from
+//! `filepath.Dir(clientcmd.NewDefaultPathOptions().GetDefaultFilename())`, so a
+//! plain `~/.kube/config` setup gets exactly one slot for every account. A
+//! machine with several gcloud accounts therefore evicts its own token on every
+//! cluster switch, and each miss is a fresh `gcloud` spawn — multiplied by the
+//! number of `Client`s built from one `Config`, because kube-rs mints a separate
+//! `RefreshableToken` per `auth_layer()` call. Pointing the plugin at a
+//! per-identity scratch kubeconfig (via a `KUBECONFIG` entry in the exec `env`
+//! block, which kube-rs forwards to the child) moves the cache file into a
+//! directory we own, one per identity, so the slots stop colliding.
+//!
+//! **The real error is invisible.** kube-rs inherits the plugin's stderr
+//! whenever `interactiveMode` isn't `Never`, so an `AuthExecRun` error carries
+//! an empty `stderr` and the actual cause — "Reauthentication failed. cannot
+//! prompt during non-interactive execution." — goes to the app's own stderr.
+//! Running the plugin ourselves once, with stderr piped, is the only way to
+//! read it; a successful run also warms the slot the subsequent kube-rs spawns
+//! will read, turning a spawn storm into cache hits.
+//!
+//! Deliberately scoped to the gcloud family: the semantics above are gcloud's,
+//! and a `KUBECONFIG` we invented could change behaviour for a plugin that
+//! reads it for other reasons.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use directories::ProjectDirs;
+use kube::config::Kubeconfig;
+
+use crate::cloud_identity::{command_basename, gcloud, Binding};
+use crate::error::Error;
+
+/// Wall-clock cap on our own plugin run. Sized to leave room for the apiserver
+/// round trip inside the app's connect timeout: a cold `gcloud` (Python start +
+/// token exchange) lands in the low seconds, and anything slower is better
+/// handled by letting kube-rs try than by holding the connect open.
+pub const PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Directory holding one scratch kubeconfig per identity. The plugin writes its
+/// token cache beside whichever kubeconfig it resolves, so a directory per
+/// identity is a cache slot per identity.
+const SLOTS_DIR: &str = "authcache";
+
+/// A context's exec plugin, resolved and ready to run, plus the cache slot we
+/// pointed it at.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedExec {
+    pub command: String,
+    pub args: Vec<String>,
+    /// The exec `env` block as `(name, value)`, including the `KUBECONFIG` we
+    /// injected when a slot was prepared.
+    pub env: Vec<(String, String)>,
+    /// The gcloud account this invocation authenticates as, when the context
+    /// pins one. `None` means it follows `gcloud config set account`.
+    pub identity: Option<String>,
+    /// Directory the plugin will read/write its token cache in. `None` when the
+    /// slot could not be prepared — the plugin then falls back to its default
+    /// location, which is exactly the pre-existing behaviour.
+    pub cache_dir: Option<PathBuf>,
+}
+
+/// What one preflight run told us.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreflightOutcome {
+    /// Credentials produced; the cache slot now holds a live token.
+    Warmed,
+    /// The plugin ran and exited non-zero. `stderr` is already redacted and
+    /// truncated.
+    Failed { code: String, stderr: String },
+    /// The binary isn't on the PATH the app sees.
+    Missing,
+    /// Spawn failed for some other reason, or the run outlived
+    /// [`PREFLIGHT_TIMEOUT`]. Callers must treat this as "no information" and
+    /// continue connecting — kube-rs gets its own attempt.
+    Inconclusive(String),
+}
+
+/// Resolve `context_name`'s exec plugin, give it a private cache slot, and
+/// return what a preflight needs. `None` when the context has no exec plugin or
+/// the plugin isn't one of gcloud's.
+///
+/// Mutates `kubeconfig` in memory only: the injected `KUBECONFIG` env entry has
+/// to be visible to kube-rs's own spawns, and the only channel for that is the
+/// exec `env` block of the config we hand to `Config::from_custom_kubeconfig`.
+/// Nothing is written back to the operator's file.
+pub fn prepare(kubeconfig: &mut Kubeconfig, context_name: &str) -> Option<PreparedExec> {
+    prepare_in(kubeconfig, context_name, slots_root().as_deref())
+}
+
+/// [`prepare`] against an explicit slots root, so tests never write into the
+/// developer's real config directory. `None` disables the private slot.
+pub fn prepare_in(
+    kubeconfig: &mut Kubeconfig,
+    context_name: &str,
+    slots_root: Option<&Path>,
+) -> Option<PreparedExec> {
+    let user = kubeconfig
+        .contexts
+        .iter()
+        .find(|c| c.name == context_name)
+        .and_then(|c| c.context.as_ref())
+        .and_then(|ctx| ctx.user.clone())?;
+    let exec = kubeconfig
+        .auth_infos
+        .iter_mut()
+        .find(|a| a.name == user)
+        .and_then(|a| a.auth_info.as_mut())
+        .and_then(|ai| ai.exec.as_mut())?;
+
+    let command = exec.command.clone()?;
+    if !gcloud::OWNS_COMMANDS.contains(&command_basename(&command)) {
+        return None;
+    }
+    let args = exec.args.clone().unwrap_or_default();
+    let mut env = exec_env_pairs(exec.env.as_ref());
+
+    let identity = match gcloud::binding_for(command_basename(&command), &args, &env) {
+        Some(Binding::Pinned { identity }) => Some(identity),
+        _ => None,
+    };
+
+    // A failure here costs us the private slot, not the connect: the plugin
+    // simply keeps using its default cache location.
+    let cache_dir = match prepare_slot(slots_root, identity.as_deref()) {
+        Ok(slot) => {
+            set_env(exec, "KUBECONFIG", &slot.kubeconfig.to_string_lossy());
+            env.retain(|(k, _)| k != "KUBECONFIG");
+            env.push((
+                "KUBECONFIG".to_owned(),
+                slot.kubeconfig.to_string_lossy().into_owned(),
+            ));
+            Some(slot.dir)
+        }
+        Err(e) => {
+            tracing::debug!(
+                target: "ferrisscope::auth",
+                "exec cache slot unavailable, falling back to the plugin default ({e})"
+            );
+            None
+        }
+    };
+
+    Some(PreparedExec {
+        command,
+        args,
+        env,
+        identity,
+        cache_dir,
+    })
+}
+
+/// Run the plugin once, with stdin closed and stderr captured.
+///
+/// Stdin is `null` rather than inherited: a GUI process has nothing useful
+/// there, and an inherited-but-dead stdin is what makes gcloud believe it may
+/// prompt and then fail with a message no one sees.
+pub async fn preflight(prepared: &PreparedExec, api_version: Option<&str>) -> PreflightOutcome {
+    let mut cmd = tokio::process::Command::new(&prepared.command);
+    cmd.args(&prepared.args)
+        .envs(prepared.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
+        .env("KUBERNETES_EXEC_INFO", exec_info(api_version))
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    match tokio::time::timeout(PREFLIGHT_TIMEOUT, cmd.output()).await {
+        Err(_) => PreflightOutcome::Inconclusive(format!(
+            "timed out after {}s",
+            PREFLIGHT_TIMEOUT.as_secs()
+        )),
+        Ok(Err(e)) if e.kind() == std::io::ErrorKind::NotFound => PreflightOutcome::Missing,
+        Ok(Err(e)) => PreflightOutcome::Inconclusive(e.to_string()),
+        Ok(Ok(out)) if out.status.success() => PreflightOutcome::Warmed,
+        Ok(Ok(out)) => {
+            let raw = if out.stderr.is_empty() {
+                String::from_utf8_lossy(&out.stdout)
+            } else {
+                String::from_utf8_lossy(&out.stderr)
+            };
+            PreflightOutcome::Failed {
+                code: out
+                    .status
+                    .code()
+                    .map_or_else(|| out.status.to_string(), |c| c.to_string()),
+                stderr: redact_and_truncate(&raw),
+            }
+        }
+    }
+}
+
+/// Turn a [`PreflightOutcome::Failed`] into the most specific error we can
+/// justify. A lapsed cloud session is its own variant because the remedy
+/// (interactive login) is nothing like the remedy for a broken plugin.
+#[must_use]
+pub fn failure_error(prepared: &PreparedExec, code: String, stderr: String) -> Error {
+    match gcloud::classify_exec_failure(&stderr) {
+        gcloud::ExecFailure::ReauthRequired => Error::ExecReauthRequired {
+            command: prepared.command.clone(),
+            account: prepared.identity.clone(),
+            message: stderr,
+        },
+        _ => Error::ExecPluginFailed {
+            command: prepared.command.clone(),
+            code,
+            stderr,
+        },
+    }
+}
+
+/// Every token cache file we own. Callers that invalidate credentials (an
+/// identity pin) must clear these too: they are as capable of holding a token
+/// minted under the previous identity as the plugin's default slot is.
+///
+/// # Errors
+///
+/// Propagates I/O errors other than a missing file or missing root.
+pub fn clear_cache_slots() -> std::io::Result<()> {
+    let Some(root) = slots_root() else {
+        return Ok(());
+    };
+    clear_cache_slots_at(&root)
+}
+
+/// [`clear_cache_slots`] against an explicit root.
+///
+/// # Errors
+///
+/// Propagates I/O errors other than a missing file or missing root.
+pub fn clear_cache_slots_at(root: &Path) -> std::io::Result<()> {
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => return Err(e),
+    };
+    for entry in entries.flatten() {
+        let cache = entry.path().join(gcloud::PLUGIN_CACHE_FILE);
+        match std::fs::remove_file(&cache) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// `<config>/authcache`. `None` when no config directory resolves.
+#[must_use]
+pub fn slots_root() -> Option<PathBuf> {
+    ProjectDirs::from("dev", "ferrisscope", "ferrisscope").map(|p| p.config_dir().join(SLOTS_DIR))
+}
+
+struct Slot {
+    dir: PathBuf,
+    kubeconfig: PathBuf,
+}
+
+/// Create the identity's slot directory and (re)write its scratch kubeconfig.
+///
+/// The file exists for two properties the plugin reads out of it: the directory
+/// it lives in (where the token cache lands) and its `current-context` (part of
+/// the cache key). It carries no cluster, user, or credential material, so
+/// there is nothing here to keep in sync with the operator's kubeconfig.
+fn prepare_slot(root: Option<&Path>, identity: Option<&str>) -> std::io::Result<Slot> {
+    let root = root.ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no config directory for this platform",
+        )
+    })?;
+    let dir = root.join(slot_name(identity));
+    let kubeconfig = dir.join("config");
+    crate::atomic_write::atomic_write_sync_mode(
+        &kubeconfig,
+        scratch_kubeconfig().as_bytes(),
+        Some(0o600),
+    )?;
+    Ok(Slot { dir, kubeconfig })
+}
+
+/// Filesystem-safe directory name for an identity. Unpinned contexts share one
+/// slot ("active"), which matches what they share upstream: a single cache entry
+/// keyed on an empty `extra_args`.
+fn slot_name(identity: Option<&str>) -> String {
+    let Some(identity) = identity else {
+        return "active".to_owned();
+    };
+    let cleaned: String = identity
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '@') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = cleaned.trim_matches('.');
+    if trimmed.is_empty() {
+        "active".to_owned()
+    } else {
+        // Long identities (assumed-role ARNs elsewhere in this family) must not
+        // blow past a filesystem's per-component limit.
+        trimmed.chars().take(80).collect()
+    }
+}
+
+/// Context name written into every slot's scratch kubeconfig.
+///
+/// **Constant on purpose.** The plugin's cache is only valid while the
+/// `current-context` it recorded still equals the one it resolves now, and it
+/// compares them for equality — the value itself is never used for anything
+/// else. Writing the *target* context here would therefore invalidate the slot
+/// on every switch between two clusters on the same account, which is the
+/// common case and exactly the gcloud spawn this module exists to avoid. A
+/// gcloud access token is account-scoped, not cluster-scoped, so one warm token
+/// per identity is not just cheaper but correct.
+const SLOT_CONTEXT: &str = "ferrisscope-auth-slot";
+
+/// The minimum client-go will load: `GetStartingConfig` only needs the document
+/// to parse for `current-context` to come back set.
+fn scratch_kubeconfig() -> String {
+    let doc = serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Config",
+        "preferences": {},
+        "clusters": [],
+        "contexts": [],
+        "users": [],
+        "current-context": SLOT_CONTEXT,
+    });
+    serde_yaml::to_string(&doc).unwrap_or_else(|_| {
+        // `Value` serialization cannot fail, but a panic here would take a
+        // connect down for a cache optimisation.
+        format!("apiVersion: v1\nkind: Config\ncurrent-context: {SLOT_CONTEXT}\n")
+    })
+}
+
+/// The `KUBERNETES_EXEC_INFO` client-go would pass. `interactive: false` is the
+/// honest value — we closed stdin.
+fn exec_info(api_version: Option<&str>) -> String {
+    let api_version = api_version.unwrap_or("client.authentication.k8s.io/v1beta1");
+    serde_json::json!({
+        "kind": "ExecCredential",
+        "apiVersion": api_version,
+        "spec": { "interactive": false },
+    })
+    .to_string()
+}
+
+fn exec_env_pairs(env: Option<&Vec<HashMap<String, String>>>) -> Vec<(String, String)> {
+    env.map(|entries| {
+        entries
+            .iter()
+            .filter_map(|e| Some((e.get("name")?.clone(), e.get("value")?.clone())))
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+/// Set (or replace) one `{name, value}` entry in an exec `env` block.
+fn set_env(exec: &mut kube::config::ExecConfig, name: &str, value: &str) {
+    let entries = exec.env.get_or_insert_with(Vec::new);
+    entries.retain(|e| e.get("name").map(String::as_str) != Some(name));
+    let mut entry = HashMap::new();
+    entry.insert("name".to_owned(), name.to_owned());
+    entry.insert("value".to_owned(), value.to_owned());
+    entries.push(entry);
+}
+
+/// Make a plugin's raw stderr safe and compact for display: drop lines that
+/// look like they carry a credential (token JSON, JWT/base64 runs, Bearer
+/// headers), strip blank lines, and cap total length. Conservative on what it
+/// flags as secret so genuine error text ("reauth required", "invalid
+/// credentials") survives.
+#[must_use]
+pub fn redact_and_truncate(s: &str) -> String {
+    const MAX: usize = 1500;
+    let mut lines: Vec<&str> = Vec::new();
+    let mut redacted_any = false;
+    for line in s.lines() {
+        let t = line.trim_end();
+        if t.is_empty() {
+            continue;
+        }
+        if looks_secretish(t) {
+            redacted_any = true;
+            continue;
+        }
+        lines.push(t);
+    }
+    let mut out = lines.join("\n");
+    if redacted_any {
+        out.push_str("\n[credential material redacted]");
+    }
+    let out = out.trim().to_string();
+    let mut out = if out.len() > MAX {
+        let mut end = MAX;
+        while !out.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut truncated = out[..end].to_string();
+        truncated.push_str(" … (truncated)");
+        truncated
+    } else {
+        out
+    };
+    if out.is_empty() {
+        out = "(plugin produced no output)".to_string();
+    }
+    out
+}
+
+/// Heuristic: does this line likely contain a secret value (not merely the word
+/// "credentials")? Catches token JSON fields, `Bearer` headers, and long
+/// base64url/JWT runs. Excludes `/` and `.` from the run alphabet so file paths
+/// and dotted hostnames don't trip it.
+fn looks_secretish(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    if lower.contains("\"token\"")
+        || lower.contains("token=")
+        || lower.contains("bearer ")
+        || lower.contains("id_token")
+        || lower.contains("access_token")
+        || lower.contains("\"password\"")
+        || lower.contains("client-secret")
+    {
+        return true;
+    }
+    let mut run = 0usize;
+    let mut max_run = 0usize;
+    for c in line.chars() {
+        if c.is_ascii_alphanumeric() || matches!(c, '+' | '_' | '-' | '=') {
+            run += 1;
+            max_run = max_run.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    max_run >= 40
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KUBECONFIG: &str = r"
+apiVersion: v1
+kind: Config
+current-context: gke_p_r_c
+clusters:
+- name: c
+  cluster:
+    server: https://example.invalid
+contexts:
+- name: gke_p_r_c
+  context:
+    cluster: c
+    user: u
+users:
+- name: u
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+      args: ['--account=a@example.com']
+      interactiveMode: IfAvailable
+      provideClusterInfo: true
+";
+
+    fn kc(yaml: &str) -> Kubeconfig {
+        serde_yaml::from_str(yaml).expect("parse kubeconfig")
+    }
+
+    fn injected_kubeconfig(kubeconfig: &Kubeconfig) -> Option<String> {
+        let exec = kubeconfig.auth_infos[0].auth_info.as_ref()?.exec.as_ref()?;
+        exec.env.as_ref()?.iter().find_map(|e| {
+            (e.get("name").map(String::as_str) == Some("KUBECONFIG")).then(|| e["value"].clone())
+        })
+    }
+
+    /// A slots root inside a tempdir: `prepare` writes files, and a test that
+    /// wrote into the developer's real config directory would be a bug.
+    fn root() -> tempfile::TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    #[test]
+    fn prepare_pins_the_identity_and_injects_a_private_slot() {
+        let root = root();
+        let mut kubeconfig = kc(KUBECONFIG);
+        let prepared =
+            prepare_in(&mut kubeconfig, "gke_p_r_c", Some(root.path())).expect("prepared");
+
+        assert_eq!(prepared.command, "gke-gcloud-auth-plugin");
+        assert_eq!(prepared.identity.as_deref(), Some("a@example.com"));
+
+        // The env the child gets must agree with the env written into the
+        // kubeconfig kube-rs will spawn from — they are the same cache slot.
+        let injected = injected_kubeconfig(&kubeconfig).expect("KUBECONFIG injected");
+        let from_pairs = prepared
+            .env
+            .iter()
+            .find(|(k, _)| k == "KUBECONFIG")
+            .map(|(_, v)| v.clone())
+            .expect("KUBECONFIG in pairs");
+        assert_eq!(injected, from_pairs);
+
+        let dir = prepared.cache_dir.expect("cache dir");
+        assert_eq!(Path::new(&injected).parent(), Some(dir.as_path()));
+        assert!(dir.ends_with("a@example.com"), "slot per identity: {dir:?}");
+    }
+
+    #[test]
+    fn the_scratch_kubeconfig_parses_and_names_a_context() {
+        let body = scratch_kubeconfig();
+        let parsed: Kubeconfig = serde_yaml::from_str(&body).expect("scratch parses");
+        assert_eq!(parsed.current_context.as_deref(), Some(SLOT_CONTEXT));
+        assert!(parsed.clusters.is_empty());
+        assert!(parsed.auth_infos.is_empty());
+    }
+
+    #[test]
+    fn every_cluster_on_one_account_shares_the_same_warm_token() {
+        // Measured: a slot whose `current-context` changes costs a full gcloud
+        // spawn (~1.2s) on every switch, because that field is half the plugin's
+        // cache key. Two contexts on one account must therefore produce byte
+        // identical slots — otherwise each switch invalidates the other's token
+        // and this module makes things slower, not faster.
+        let root = root();
+        let mut a = kc(KUBECONFIG);
+        let mut b = kc(&KUBECONFIG.replace("gke_p_r_c", "gke_p_r_other"));
+        let sa = prepare_in(&mut a, "gke_p_r_c", Some(root.path())).expect("prepared");
+        let sb = prepare_in(&mut b, "gke_p_r_other", Some(root.path())).expect("prepared");
+
+        assert_eq!(sa.cache_dir, sb.cache_dir, "same account, same slot");
+        let path = sa.cache_dir.expect("cache dir").join("config");
+        let body = std::fs::read_to_string(&path).expect("read scratch");
+        assert!(
+            !body.contains("gke_p_r_c") && !body.contains("gke_p_r_other"),
+            "no target context may reach the cache key: {body}"
+        );
+    }
+
+    #[test]
+    fn unpinned_contexts_share_one_slot() {
+        let yaml = KUBECONFIG.replace("      args: ['--account=a@example.com']\n", "");
+        let root = root();
+        let mut kubeconfig = kc(&yaml);
+        let prepared =
+            prepare_in(&mut kubeconfig, "gke_p_r_c", Some(root.path())).expect("prepared");
+        assert_eq!(prepared.identity, None);
+        assert!(prepared.args.is_empty());
+        assert!(
+            prepared.cache_dir.expect("cache dir").ends_with("active"),
+            "an unpinned context has no identity to key a slot on"
+        );
+    }
+
+    #[test]
+    fn non_gcloud_plugins_are_left_completely_alone() {
+        let yaml = KUBECONFIG.replace("gke-gcloud-auth-plugin", "aws-iam-authenticator");
+        let root = root();
+        let mut kubeconfig = kc(&yaml);
+        assert_eq!(
+            prepare_in(&mut kubeconfig, "gke_p_r_c", Some(root.path())),
+            None
+        );
+        assert_eq!(
+            injected_kubeconfig(&kubeconfig),
+            None,
+            "a foreign plugin's env must not gain a KUBECONFIG we invented"
+        );
+    }
+
+    #[test]
+    fn contexts_without_an_exec_block_are_skipped() {
+        let yaml = KUBECONFIG
+            .split("    exec:")
+            .next()
+            .expect("split")
+            .to_owned()
+            + "    token: abc\n";
+        let root = root();
+        let mut kubeconfig = kc(&yaml);
+        assert_eq!(
+            prepare_in(&mut kubeconfig, "gke_p_r_c", Some(root.path())),
+            None
+        );
+    }
+
+    #[test]
+    fn a_prepared_slot_replaces_a_kubeconfig_supplied_kubeconfig_var() {
+        let yaml = KUBECONFIG.replace(
+            "      interactiveMode: IfAvailable\n",
+            "      interactiveMode: IfAvailable\n      env:\n      - name: KUBECONFIG\n        value: /somewhere/else\n",
+        );
+        let root = root();
+        let mut kubeconfig = kc(&yaml);
+        let prepared =
+            prepare_in(&mut kubeconfig, "gke_p_r_c", Some(root.path())).expect("prepared");
+        let count = prepared
+            .env
+            .iter()
+            .filter(|(k, _)| k == "KUBECONFIG")
+            .count();
+        assert_eq!(count, 1, "exactly one KUBECONFIG wins");
+        assert_ne!(
+            prepared
+                .env
+                .iter()
+                .find(|(k, _)| k == "KUBECONFIG")
+                .map(|(_, v)| v.as_str()),
+            Some("/somewhere/else")
+        );
+    }
+
+    #[test]
+    fn a_context_still_connects_when_no_slot_can_be_prepared() {
+        let mut kubeconfig = kc(KUBECONFIG);
+        let prepared = prepare_in(&mut kubeconfig, "gke_p_r_c", None).expect("prepared");
+        assert_eq!(prepared.cache_dir, None);
+        assert_eq!(
+            injected_kubeconfig(&kubeconfig),
+            None,
+            "with no slot there is nothing to point the plugin at"
+        );
+        // The plugin is still runnable — it just uses its own default cache.
+        assert_eq!(prepared.command, "gke-gcloud-auth-plugin");
+    }
+
+    #[test]
+    fn clearing_slots_drops_every_cached_token_and_keeps_the_slots() {
+        let root = root();
+        let mut kubeconfig = kc(KUBECONFIG);
+        let a = prepare_in(&mut kubeconfig, "gke_p_r_c", Some(root.path()))
+            .expect("prepared")
+            .cache_dir
+            .expect("cache dir");
+        let cache = a.join(gcloud::PLUGIN_CACHE_FILE);
+        std::fs::write(&cache, "{}").expect("write cache");
+        let scratch = a.join("config");
+
+        clear_cache_slots_at(root.path()).expect("clear");
+
+        assert!(
+            !cache.exists(),
+            "a token minted as the old identity must go"
+        );
+        assert!(
+            scratch.exists(),
+            "the scratch kubeconfig is not a credential — dropping it would just \
+             force a rewrite"
+        );
+    }
+
+    #[test]
+    fn clearing_slots_is_fine_when_there_is_nothing_to_clear() {
+        let root = root();
+        clear_cache_slots_at(root.path()).expect("empty root");
+        clear_cache_slots_at(&root.path().join("never-created")).expect("missing root");
+    }
+
+    #[test]
+    fn slot_names_stay_filesystem_safe() {
+        assert_eq!(slot_name(None), "active");
+        assert_eq!(slot_name(Some("a@example.com")), "a@example.com");
+        assert_eq!(slot_name(Some("../../etc/passwd")), "_.._etc_passwd");
+        assert_eq!(slot_name(Some("..")), "active");
+        assert_eq!(slot_name(Some("a/b\\c:d")), "a_b_c_d");
+        assert_eq!(slot_name(Some(&"x".repeat(200))).len(), 80);
+    }
+
+    #[test]
+    fn exec_info_declares_a_non_interactive_run() {
+        let v: serde_json::Value =
+            serde_json::from_str(&exec_info(Some("client.authentication.k8s.io/v1")))
+                .expect("json");
+        assert_eq!(v["apiVersion"], "client.authentication.k8s.io/v1");
+        assert_eq!(v["spec"]["interactive"], false);
+    }
+
+    #[test]
+    fn redact_and_truncate_keeps_error_text_drops_secrets() {
+        let raw = "ERROR: (gcloud.auth) reauth required\n\
+                   invalid credentials for project foo\n\
+                   token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQ1Njc4OTABCDEFGH\n";
+        let out = redact_and_truncate(raw);
+        // Human-readable diagnostics survive…
+        assert!(out.contains("reauth required"));
+        // …including a line that merely mentions "credentials" (no secret value).
+        assert!(out.contains("invalid credentials for project foo"));
+        // …but the token line is gone, replaced by a marker.
+        assert!(!out.contains("eyJhbGci"));
+        assert!(!out.contains("token="));
+        assert!(out.contains("[credential material redacted]"));
+    }
+
+    #[test]
+    fn redact_and_truncate_caps_length_and_handles_empty() {
+        // Long but non-secret text (spaces break the base64-run heuristic).
+        let long = "err line ".repeat(1000);
+        let out = redact_and_truncate(&long);
+        assert!(out.len() <= 1500 + 32);
+        assert!(out.ends_with("… (truncated)"));
+        assert_eq!(
+            redact_and_truncate("   \n  \n"),
+            "(plugin produced no output)"
+        );
+    }
+
+    #[test]
+    fn looks_secretish_flags_tokens_not_paths() {
+        assert!(looks_secretish("\"token\": \"abc\""));
+        assert!(looks_secretish("Authorization: Bearer abc123"));
+        assert!(looks_secretish(&format!("blob {}", "A".repeat(45))));
+        // File paths and dotted hostnames must NOT be flagged.
+        assert!(!looks_secretish(
+            "/Users/me/.config/gcloud/application_default_credentials.json"
+        ));
+        assert!(!looks_secretish(
+            "could not reach oauth2.googleapis.com:443"
+        ));
+        assert!(!looks_secretish("invalid credentials"));
+    }
+
+    #[cfg(unix)]
+    mod spawned {
+        use super::*;
+
+        /// A stand-in plugin, expressed as `sh -c <body>` rather than a script
+        /// we chmod and exec: writing an executable and immediately exec'ing it
+        /// races other threads' `fork`/`exec` (an inherited write fd makes the
+        /// exec fail with ETXTBSY), which is a flake in a test, not a behaviour
+        /// worth exercising.
+        fn plugin(body: &str) -> PreparedExec {
+            PreparedExec {
+                command: "/bin/sh".to_owned(),
+                args: vec!["-c".to_owned(), body.to_owned()],
+                env: Vec::new(),
+                identity: Some("a@example.com".to_owned()),
+                cache_dir: None,
+            }
+        }
+
+        #[tokio::test]
+        async fn success_is_warmed() {
+            let p = plugin("echo '{\"kind\":\"ExecCredential\"}'");
+            assert_eq!(preflight(&p, None).await, PreflightOutcome::Warmed);
+        }
+
+        #[tokio::test]
+        async fn reauth_stderr_survives_to_the_error() {
+            let p = plugin(
+                "echo 'ERROR: (gcloud.config.config-helper) There was a problem refreshing your \
+                 current auth tokens: Reauthentication failed. cannot prompt during \
+                 non-interactive execution.' 1>&2; exit 1",
+            );
+            let out = preflight(&p, None).await;
+            let PreflightOutcome::Failed { code, stderr } = out else {
+                panic!("expected Failed, got {out:?}");
+            };
+            assert_eq!(code, "1");
+            match failure_error(&p, code, stderr) {
+                Error::ExecReauthRequired {
+                    account, message, ..
+                } => {
+                    assert_eq!(account.as_deref(), Some("a@example.com"));
+                    assert!(message.contains("Reauthentication failed"));
+                }
+                other => panic!("expected ExecReauthRequired, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn other_failures_stay_generic() {
+            let p = plugin("echo 'boom: bad config' 1>&2; exit 3");
+            let out = preflight(&p, None).await;
+            let PreflightOutcome::Failed { code, stderr } = out else {
+                panic!("expected Failed, got {out:?}");
+            };
+            assert_eq!(code, "3");
+            assert!(matches!(
+                failure_error(&p, code, stderr),
+                Error::ExecPluginFailed { .. }
+            ));
+        }
+
+        #[tokio::test]
+        async fn a_missing_binary_is_reported_as_missing() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let mut p = plugin("true");
+            p.command = dir
+                .path()
+                .join("not-installed")
+                .to_string_lossy()
+                .into_owned();
+            p.args.clear();
+            assert_eq!(preflight(&p, None).await, PreflightOutcome::Missing);
+        }
+
+        #[tokio::test]
+        async fn stdout_is_used_when_the_plugin_writes_its_error_there() {
+            let p = plugin("echo 'failed on stdout'; exit 1");
+            let out = preflight(&p, None).await;
+            let PreflightOutcome::Failed { stderr, .. } = out else {
+                panic!("expected Failed, got {out:?}");
+            };
+            assert!(stderr.contains("failed on stdout"));
+        }
+
+        /// The whole point of the slot: whatever `prepare` injected has to be
+        /// what the child actually resolves its cache path from.
+        #[tokio::test]
+        async fn the_injected_kubeconfig_reaches_the_child() {
+            let mut p = plugin("echo \"$KUBECONFIG\" 1>&2; exit 1");
+            p.env = vec![("KUBECONFIG".to_owned(), "/slot/config".to_owned())];
+            let out = preflight(&p, None).await;
+            let PreflightOutcome::Failed { stderr, .. } = out else {
+                panic!("expected Failed, got {out:?}");
+            };
+            assert_eq!(stderr, "/slot/config");
+        }
+
+        /// `KUBERNETES_EXEC_INFO` is what client-go passes; a plugin that reads
+        /// it must see a well-formed document from us too.
+        #[tokio::test]
+        async fn exec_info_is_passed_to_the_child() {
+            let p = plugin("echo \"$KUBERNETES_EXEC_INFO\" 1>&2; exit 1");
+            let out = preflight(&p, None).await;
+            let PreflightOutcome::Failed { stderr, .. } = out else {
+                panic!("expected Failed, got {out:?}");
+            };
+            let v: serde_json::Value = serde_json::from_str(&stderr).expect("valid exec info");
+            assert_eq!(v["kind"], "ExecCredential");
+            assert_eq!(v["spec"]["interactive"], false);
+        }
+
+        #[tokio::test]
+        async fn an_overrunning_plugin_is_inconclusive_not_fatal() {
+            // Exercise the real timeout arm with a budget short enough to keep
+            // the suite fast: same primitive, same outcome mapping.
+            let mut cmd = tokio::process::Command::new("/bin/sh");
+            cmd.args(["-c", "sleep 30"])
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true);
+            assert!(
+                tokio::time::timeout(Duration::from_millis(200), cmd.output())
+                    .await
+                    .is_err(),
+                "a hung plugin must not block a connect forever"
+            );
+        }
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod atomic_write;
 pub mod cloud_identity;
 pub mod cluster;
 pub mod error;
+pub mod exec_auth;
 pub mod fleet;
 pub mod globalfwd;
 pub mod health;

--- a/crates/fdpass-ext/src/lib.rs
+++ b/crates/fdpass-ext/src/lib.rs
@@ -250,8 +250,23 @@ mod tests {
                 // It should accept connections.
                 let _conn = std::net::TcpStream::connect(("127.0.0.1", port)).unwrap();
                 got.set_nonblocking(true).unwrap();
-                let accepted = got.accept();
-                assert!(accepted.is_ok(), "accept on passed socket failed");
+                // `connect` returns once the handshake completes, which does not
+                // mean the listener's accept queue has been populated yet —
+                // Linux does it inside `connect`, macOS often does not. A single
+                // non-blocking accept would therefore assert on the scheduler
+                // rather than on the transfer. Retry, as `recv_blocking` does:
+                // the claim is that the passed socket accepts at all.
+                let accepted = (0..1000).find_map(|_| match got.accept() {
+                    Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                        None
+                    }
+                    other => Some(other),
+                });
+                assert!(
+                    matches!(accepted, Some(Ok(_))),
+                    "accept on passed socket failed: {accepted:?}"
+                );
             }
             _ => panic!("expected a listener"),
         }

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -3,7 +3,7 @@
 // break here is exactly the kind of regression that's hard to spot in a
 // running app because the backend silently no-ops on unknown commands.
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { setMockInvoke, resetMockInvoke } from "./test/tauri-mock";
 import { api } from "./api";
 
@@ -112,6 +112,52 @@ describe("contexts + connect", () => {
       name: "default::ctx-a",
       error: 'User "a@b.io" ... Forbidden',
     });
+  });
+
+  it("cloudLoginOpen → 'cloud_login_open' with cluster + account + channel", async () => {
+    const cap = captureNext("t7");
+    const onData = vi.fn();
+    const onExit = vi.fn();
+    const opened = await api.cloudLoginOpen(
+      "default::ctx-a",
+      "a@b.io",
+      onData,
+      onExit,
+    );
+
+    expect(opened.sessionId).toBe("t7");
+    expect(cap.calls[0]?.cmd).toBe("cloud_login_open");
+    const args = cap.calls[0]?.args as Record<string, unknown>;
+    expect(args.clusterId).toBe("default::ctx-a");
+    // The account reaches the backend as-is; it validates before it lands in an
+    // argv element.
+    expect(args.account).toBe("a@b.io");
+
+    // Frames route to the right callback, and `close` detaches so a late frame
+    // after unmount can't reach a torn-down component.
+    const channel = args.onEvent as { onmessage: (m: unknown) => void };
+    channel.onmessage({ kind: "data", b64: "aGk=" });
+    channel.onmessage({ kind: "exit", code: 0 });
+    expect(onData).toHaveBeenCalledWith("aGk=");
+    expect(onExit).toHaveBeenCalledWith(0);
+    opened.close();
+    channel.onmessage({ kind: "exit", code: 1 });
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("cloudLoginOpen passes a null account for an unpinned context", async () => {
+    // gcloud then renews whichever account is active — the same one the unpinned
+    // context would have used. Sending "" instead would be a different request.
+    const cap = captureNext("t8");
+    await api.cloudLoginOpen(
+      "default::ctx-a",
+      null,
+      () => {},
+      () => {},
+    );
+    expect(
+      (cap.calls[0]?.args as Record<string, unknown>).account,
+    ).toBeNull();
   });
 
   it("pinCloudIdentity → 'pin_cloud_identity_cmd' with name + identity", async () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -986,6 +986,33 @@ export const api = {
     };
   },
 
+  // Open a PTY running `gcloud auth login` to renew a lapsed cloud session.
+  // Same event plumbing as the other terminal sessions, but no cluster and no
+  // kubeconfig: this runs *because* the connect failed. `account` is the one the
+  // failing context pins, or null to renew whichever account gcloud has active.
+  cloudLoginOpen: async (
+    clusterId: string,
+    account: string | null,
+    onData: (b64: string) => void,
+    onExit: (code: number) => void,
+  ): Promise<{ sessionId: string; close: () => void }> => {
+    const channel = new Channel<TerminalEvent>();
+    channel.onmessage = (evt) => {
+      if (evt.kind === "data") onData(evt.b64);
+      else onExit(evt.code);
+    };
+    const sessionId = await invoke<string>("cloud_login_open", {
+      clusterId,
+      account,
+      onEvent: channel,
+    });
+    return {
+      sessionId,
+      close: () => {
+        channel.onmessage = () => {};
+      },
+    };
+  },
   terminalWrite: (sessionId: string, b64: string) =>
     invoke<void>("terminal_write", { sessionId, b64 }),
   terminalResize: (sessionId: string, cols: number, rows: number) =>

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -23,6 +23,7 @@ const GCLOUD: ConnectHint = {
       "delete ~/.kube/gke_gcloud_auth_plugin_cache",
     ],
   },
+  reauth: null,
 };
 
 const AWS: ConnectHint = {
@@ -39,6 +40,7 @@ const AWS: ConnectHint = {
       "keep a .ferrisscope-backup copy of the kubeconfig",
     ],
   },
+  reauth: null,
 };
 
 const AZURE: ConnectHint = {
@@ -51,6 +53,24 @@ const AZURE: ConnectHint = {
   active_identity: "ops@example.net",
   // The whole point of the Azure case: nothing to write, so no button.
   pin: null,
+  reauth: null,
+};
+
+// A lapsed Google session: the plugin never produced a token, so there is no
+// apiserver identity to report and nothing a pin could fix.
+const REAUTH: ConnectHint = {
+  provider: "gcloud",
+  title: "Google session expired",
+  detail:
+    "The Google session for ops@example.net has expired, so gke-gcloud-auth-plugin could not mint a token. Run the command below in a terminal, then reconnect.",
+  authenticated_as: null,
+  identities: ["dev@example.com", "ops@example.net"],
+  active_identity: "dev@example.com",
+  pin: null,
+  reauth: {
+    command: "gcloud auth login --account=ops@example.net",
+    account: "ops@example.net",
+  },
 };
 
 const REASON =
@@ -410,5 +430,51 @@ describe("CloudIdentityNote", () => {
       expect(screen.getByText(/kubeconfig is read-only/)).toBeInTheDocument();
     });
     expect(screen.getByText(/Unpinned Google account/)).toBeInTheDocument();
+  });
+  it("offers the login command and a retry when the session lapsed", async () => {
+    setMockInvoke((cmd) => {
+      expect(cmd).toBe("connect_hint_cmd");
+      return REAUTH;
+    });
+    const onReconnect = vi.fn();
+
+    renderNote(onReconnect);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Google session expired/)).toBeInTheDocument();
+    });
+    const note = screen.getByRole("note");
+    // The exact command, including the account flag — an operator with several
+    // accounts renewing the wrong one is back where they started.
+    expect(note).toHaveTextContent("gcloud auth login --account=ops@example.net");
+    // No pin offered: the account is fine, its session isn't, and pinning would
+    // edit the kubeconfig for nothing.
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^pin/i }),
+    ).not.toBeInTheDocument();
+    // And no "apiserver saw" row: the plugin failed before any apiserver call.
+    expect(note).not.toHaveTextContent("apiserver saw");
+
+    fireEvent.click(screen.getByRole("button", { name: /retry connect/i }));
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("copies the login command on click", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    setMockInvoke(() => REAUTH);
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Google session expired/)).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByText("gcloud auth login --account=ops@example.net"),
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      "gcloud auth login --account=ops@example.net",
+    );
   });
 });

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -597,6 +597,116 @@ describe("CloudIdentityNote", () => {
       screen.queryByRole("button", { name: /^log in$/i }),
     ).not.toBeInTheDocument();
   });
+  it("closes the login session when the note unmounts mid-login", async () => {
+    // Cluster switch, or a reconnect that succeeded from another path: the
+    // note is gone but gcloud is still waiting on a browser. Without a close
+    // the registry entry (and the live child) survives until the cluster
+    // disconnects — and while it does, the terminal token slot is never
+    // reclaimed.
+    const closed: unknown[] = [];
+    setMockInvoke((cmd, args) => {
+      if (cmd === "connect_hint_cmd") return REAUTH;
+      if (cmd === "cloud_login_open") return "t7";
+      expect(cmd).toBe("terminal_close");
+      closed.push(args);
+      return undefined;
+    });
+
+    const view = renderNote();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^log in$/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /waiting for browser/i }),
+      ).toBeDisabled();
+    });
+
+    view.unmount();
+    // Whichever side loses the race — unmount before or after the open ack —
+    // exactly one close must land.
+    await waitFor(() => expect(closed).toEqual([{ sessionId: "t7" }]));
+  });
+
+  it("closes the session even when the exit frame outruns the open ack", async () => {
+    // A spawn that dies instantly can deliver its exit frame before the invoke
+    // promise resolves. The session id only exists on that promise, so the
+    // close has to happen when the ack finally lands — otherwise the registry
+    // entry leaks and a later Log in click overwrites the only reference.
+    const closed: unknown[] = [];
+    setMockInvoke((cmd, args) => {
+      if (cmd === "connect_hint_cmd") return REAUTH;
+      if (cmd === "terminal_close") {
+        closed.push(args);
+        return undefined;
+      }
+      expect(cmd).toBe("cloud_login_open");
+      const channel = args?.onEvent as { onmessage: (m: unknown) => void };
+      channel.onmessage({ kind: "exit", code: 1 });
+      return "t8";
+    });
+
+    renderNote();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^log in$/i }));
+
+    await waitFor(() => expect(closed).toEqual([{ sessionId: "t8" }]));
+    // And the surface recovered: failure reported, button back for a retry.
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "[gcloud exited with code 1]",
+    );
+    expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+  });
+
+  it("closes an in-flight login when the failure context changes", async () => {
+    // A new connect error re-runs the hint lookup and resets the note's state.
+    // Forgetting the session id without closing it would orphan the previous
+    // attempt's PTY.
+    const closed: unknown[] = [];
+    setMockInvoke((cmd, args) => {
+      if (cmd === "connect_hint_cmd") return REAUTH;
+      if (cmd === "cloud_login_open") return "t10";
+      expect(cmd).toBe("terminal_close");
+      closed.push(args);
+      return undefined;
+    });
+
+    const view = render(
+      <CloudIdentityNote
+        t={t}
+        contextId="default::prod"
+        reason={REASON}
+        onReconnect={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^log in$/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /waiting for browser/i }),
+      ).toBeDisabled();
+    });
+
+    view.rerender(
+      <CloudIdentityNote
+        t={t}
+        contextId="default::prod"
+        reason={`${REASON} (attempt 2)`}
+        onReconnect={() => {}}
+      />,
+    );
+    await waitFor(() => expect(closed).toEqual([{ sessionId: "t10" }]));
+    // The reset also unsticks the button for the fresh failure.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+  });
+
   it("can abandon a login that is going nowhere", async () => {
     // gcloud can sit on a question this surface cannot answer, so the operator
     // needs a way out that doesn't leave a PTY running or the button stuck.

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -431,7 +431,7 @@ describe("CloudIdentityNote", () => {
     });
     expect(screen.getByText(/Unpinned Google account/)).toBeInTheDocument();
   });
-  it("offers the login command and a retry when the session lapsed", async () => {
+  it("offers the login command when the session lapsed", async () => {
     setMockInvoke((cmd) => {
       expect(cmd).toBe("connect_hint_cmd");
       return REAUTH;
@@ -455,9 +455,12 @@ describe("CloudIdentityNote", () => {
     ).not.toBeInTheDocument();
     // And no "apiserver saw" row: the plugin failed before any apiserver call.
     expect(note).not.toHaveTextContent("apiserver saw");
-
-    fireEvent.click(screen.getByRole("button", { name: /retry connect/i }));
-    expect(onReconnect).toHaveBeenCalledTimes(1);
+    // No retry button of its own — the enclosing banner already carries
+    // Reconnect, wired to this same callback.
+    expect(
+      screen.queryByRole("button", { name: /retry connect/i }),
+    ).not.toBeInTheDocument();
+    expect(onReconnect).not.toHaveBeenCalled();
   });
 
   it("copies the login command on click", async () => {
@@ -476,5 +479,140 @@ describe("CloudIdentityNote", () => {
     expect(writeText).toHaveBeenCalledWith(
       "gcloud auth login --account=ops@example.net",
     );
+  });
+  it("runs the login in a PTY and reconnects when gcloud exits cleanly", async () => {
+    let channel: { onmessage: (m: unknown) => void } | undefined;
+    let loginArgs: Record<string, unknown> | undefined;
+    setMockInvoke((cmd, args) => {
+      if (cmd === "connect_hint_cmd") return REAUTH;
+      expect(cmd).toBe("cloud_login_open");
+      loginArgs = args;
+      channel = args?.onEvent as { onmessage: (m: unknown) => void };
+      return "t1";
+    });
+    const onReconnect = vi.fn();
+
+    renderNote(onReconnect);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^log in$/i }));
+
+    await waitFor(() => expect(channel).toBeDefined());
+    // The failing context's own account, not the CLI's active one.
+    expect(loginArgs?.clusterId).toBe("default::prod");
+    expect(loginArgs?.account).toBe("ops@example.net");
+    // Button locks while the browser round trip is outstanding, so a second
+    // click can't spawn a second gcloud.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /waiting for browser/i }),
+      ).toBeDisabled();
+    });
+
+    // gcloud's own output is shown verbatim ("aGk=" is "hi").
+    channel?.onmessage({ kind: "data", b64: "aGk=" });
+    await waitFor(() => {
+      expect(screen.getByRole("note")).toHaveTextContent("hi");
+    });
+
+    channel?.onmessage({ kind: "exit", code: 0 });
+    await waitFor(() => expect(onReconnect).toHaveBeenCalledTimes(1));
+  });
+
+  it("keeps the failure visible and does not reconnect when gcloud fails", async () => {
+    let channel: { onmessage: (m: unknown) => void } | undefined;
+    setMockInvoke((cmd, args) => {
+      if (cmd === "connect_hint_cmd") return REAUTH;
+      channel = args?.onEvent as { onmessage: (m: unknown) => void };
+      return "t2";
+    });
+    const onReconnect = vi.fn();
+
+    renderNote(onReconnect);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^log in$/i }));
+    await waitFor(() => expect(channel).toBeDefined());
+
+    channel?.onmessage({ kind: "exit", code: 1 });
+
+    await waitFor(() => {
+      expect(screen.getByRole("note")).toHaveTextContent(
+        "[gcloud exited with code 1]",
+      );
+    });
+    expect(onReconnect).not.toHaveBeenCalled();
+    // Retryable: the button comes back rather than staying stuck on "Waiting".
+    expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    // The copyable command is still there as the manual fallback.
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "gcloud auth login --account=ops@example.net",
+    );
+  });
+
+  it("shows the spawn error when gcloud can't be started at all", async () => {
+    // e.g. the account failed validation, or gcloud isn't on the PATH the app
+    // sees. Without this the button would spin forever on a rejected promise.
+    setMockInvoke((cmd) => {
+      if (cmd === "connect_hint_cmd") return REAUTH;
+      throw new Error("spawn: No such file or directory (os error 2)");
+    });
+
+    renderNote();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^log in$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("note")).toHaveTextContent("No such file");
+    });
+    expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+  });
+
+  it("offers no login button when the failure is drift, not a lapsed session", async () => {
+    setMockInvoke(() => GCLOUD);
+    renderNote();
+    await waitFor(() => {
+      expect(screen.getByText(/Unpinned Google account/)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: /^log in$/i }),
+    ).not.toBeInTheDocument();
+  });
+  it("can abandon a login that is going nowhere", async () => {
+    // gcloud can sit on a question this surface cannot answer, so the operator
+    // needs a way out that doesn't leave a PTY running or the button stuck.
+    const closed: unknown[] = [];
+    setMockInvoke((cmd, args) => {
+      if (cmd === "connect_hint_cmd") return REAUTH;
+      if (cmd === "cloud_login_open") return "t9";
+      expect(cmd).toBe("terminal_close");
+      closed.push(args);
+      return undefined;
+    });
+
+    renderNote();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^log in$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^cancel$/i })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(closed).toEqual([{ sessionId: "t9" }]);
+    });
+    // Back to the offer, not stuck on "Waiting for browser…", and the Cancel
+    // that only belongs to an in-flight login is gone.
+    expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
+    expect(
+      screen.queryByRole("button", { name: /^cancel$/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -483,8 +483,13 @@ describe("CloudIdentityNote", () => {
   it("runs the login in a PTY and reconnects when gcloud exits cleanly", async () => {
     let channel: { onmessage: (m: unknown) => void } | undefined;
     let loginArgs: Record<string, unknown> | undefined;
+    const closed: unknown[] = [];
     setMockInvoke((cmd, args) => {
       if (cmd === "connect_hint_cmd") return REAUTH;
+      if (cmd === "terminal_close") {
+        closed.push(args);
+        return undefined;
+      }
       expect(cmd).toBe("cloud_login_open");
       loginArgs = args;
       channel = args?.onEvent as { onmessage: (m: unknown) => void };
@@ -518,12 +523,21 @@ describe("CloudIdentityNote", () => {
 
     channel?.onmessage({ kind: "exit", code: 0 });
     await waitFor(() => expect(onReconnect).toHaveBeenCalledTimes(1));
+    // The session must be closed, not merely detached: the backend keeps its
+    // registry entry otherwise, which both leaks the gcloud child and stops the
+    // terminal token slot from ever being reclaimed.
+    await waitFor(() => expect(closed).toEqual([{ sessionId: "t1" }]));
   });
 
   it("keeps the failure visible and does not reconnect when gcloud fails", async () => {
     let channel: { onmessage: (m: unknown) => void } | undefined;
+    const closed: unknown[] = [];
     setMockInvoke((cmd, args) => {
       if (cmd === "connect_hint_cmd") return REAUTH;
+      if (cmd === "terminal_close") {
+        closed.push(args);
+        return undefined;
+      }
       channel = args?.onEvent as { onmessage: (m: unknown) => void };
       return "t2";
     });
@@ -544,6 +558,7 @@ describe("CloudIdentityNote", () => {
       );
     });
     expect(onReconnect).not.toHaveBeenCalled();
+    await waitFor(() => expect(closed).toEqual([{ sessionId: "t2" }]));
     // Retryable: the button comes back rather than staying stuck on "Waiting".
     expect(screen.getByRole("button", { name: /^log in$/i })).toBeEnabled();
     // The copyable command is still there as the manual fallback.

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -16,6 +16,16 @@ function decodeB64(b64: string): string {
   return new TextDecoder().decode(bytes);
 }
 
+/// Release a login PTY in the backend registry. Fire-and-forget by design:
+/// every caller sits on a teardown path where nothing useful can be done with a
+/// failure, and the registry reaps leftovers with the cluster anyway. The close
+/// matters even when the child already exited — the registry entry it leaves
+/// behind keeps the terminal token slot from ever being reclaimed.
+function closeLoginSession(sessionId: string | null): void {
+  if (!sessionId) return;
+  void api.terminalClose(sessionId).catch(() => {});
+}
+
 // Small amber note under a failed connect, shown when the backend recognises the
 // cause as a cloud-credential problem. Two of them today:
 //
@@ -67,6 +77,12 @@ export function CloudIdentityNote({
   // sit on a question this surface has no way to answer, and the note offers no
   // input. Closing kills the PTY child.
   const loginSessionRef = useRef<string | null>(null);
+  // Monotonic id of the current login attempt. Cancel, a context change, and
+  // unmount all invalidate the attempt by bumping it; a handler that finds its
+  // attempt stale limits itself to cleanup. A boolean can't express this — a
+  // new attempt can begin while a previous attempt's open ack is still in
+  // flight, and that ack must not adopt the new attempt's session slot.
+  const loginAttemptRef = useRef(0);
   // The pin outlives the hint effect's own `live` flag: it can still be in
   // flight when the operator switches cluster and unmounts this note. Guard its
   // settle handlers with a mount flag so a resolved (or rejected) pin doesn't
@@ -76,6 +92,13 @@ export function CloudIdentityNote({
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      // A login can still be in flight when the note unmounts (cluster switch,
+      // or a reconnect that succeeded from another path). The backend registry
+      // entry — and the live gcloud waiting on its browser — outlives this
+      // component unless closed here; nothing else ever would.
+      loginAttemptRef.current += 1;
+      closeLoginSession(loginSessionRef.current);
+      loginSessionRef.current = null;
     };
   }, []);
 
@@ -87,6 +110,10 @@ export function CloudIdentityNote({
     setPinError(null);
     setLoggingIn(false);
     setLoginLog("");
+    // A context/reason change mid-login orphans the old attempt — close its
+    // session rather than just forgetting the id.
+    loginAttemptRef.current += 1;
+    closeLoginSession(loginSessionRef.current);
     loginSessionRef.current = null;
     api
       .connectHint(contextId, reason)
@@ -132,29 +159,33 @@ export function CloudIdentityNote({
     if (!reauth || loggingIn) return;
     setLoggingIn(true);
     setLoginLog("");
+    const attempt = loginAttemptRef.current;
     let opened: { sessionId: string; close: () => void } | null = null;
+    let exited = false;
     api
       .cloudLoginOpen(
         contextId,
         reauth.account,
         (b64) => {
-          if (!mountedRef.current) return;
+          if (loginAttemptRef.current !== attempt) return;
           // Tail only: this is a progress surface, not a terminal, and gcloud's
           // browser-launch line is the part worth seeing.
           setLoginLog((prev) => (prev + decodeB64(b64)).slice(-2000));
         },
         (code) => {
-          if (!mountedRef.current) return;
-          setLoggingIn(false);
-          const sessionId = loginSessionRef.current;
-          loginSessionRef.current = null;
+          exited = true;
           opened?.close();
+          if (loginAttemptRef.current !== attempt) return;
           // Detaching the channel is not enough: the backend keeps the session
           // in its registry until told otherwise, and while any entry remains
           // the terminal token slot is never reclaimed (and this gcloud child is
           // never reaped). The exit frame means the process is gone, so this is
-          // bookkeeping, not a kill.
-          if (sessionId) void api.terminalClose(sessionId).catch(() => {});
+          // bookkeeping, not a kill. Null here when the frame outran the open
+          // ack — the `.then` below closes for us in that case.
+          const sessionId = loginSessionRef.current;
+          loginSessionRef.current = null;
+          closeLoginSession(sessionId);
+          setLoggingIn(false);
           if (code === 0) onReconnect();
           else
             setLoginLog(
@@ -164,18 +195,20 @@ export function CloudIdentityNote({
       )
       .then((session) => {
         opened = session;
-        loginSessionRef.current = session.sessionId;
-        // The note can unmount mid-login (cluster switch, or a reconnect that
-        // succeeded from another path). Close the session rather than only
-        // detaching, so the registry doesn't keep an entry no one can reach.
-        if (!mountedRef.current) {
+        // The ack can arrive too late to matter in two ways: the exit frame
+        // outran it (a spawn that died instantly), or the attempt was
+        // invalidated under it (cancel, context change, unmount). Either way
+        // the handlers that normally own the session have already run without
+        // the id, so close here and never store it.
+        if (exited || loginAttemptRef.current !== attempt) {
           session.close();
-          loginSessionRef.current = null;
-          void api.terminalClose(session.sessionId).catch(() => {});
+          closeLoginSession(session.sessionId);
+          return;
         }
+        loginSessionRef.current = session.sessionId;
       })
       .catch((e: unknown) => {
-        if (!mountedRef.current) return;
+        if (loginAttemptRef.current !== attempt) return;
         setLoggingIn(false);
         loginSessionRef.current = null;
         setLoginLog(String(e));
@@ -183,14 +216,17 @@ export function CloudIdentityNote({
   };
 
   const cancelLogin = () => {
+    // Invalidate first: the exit frame that follows the kill finds a stale
+    // attempt and stays silent instead of reporting a code for a login the
+    // operator already walked away from.
+    loginAttemptRef.current += 1;
     const sessionId = loginSessionRef.current;
     setLoggingIn(false);
     loginSessionRef.current = null;
-    if (!sessionId) return;
-    // Fire and forget: the exit frame that follows is ignored because
-    // `loggingIn` is already false, and a failed close leaves a PTY the backend
-    // reaps with the cluster anyway.
-    void api.terminalClose(sessionId).catch(() => {});
+    // Fire and forget — a failed close leaves a PTY the backend reaps with the
+    // cluster anyway. A null id means the open ack hasn't landed; its `.then`
+    // sees the stale attempt and closes.
+    closeLoginSession(sessionId);
   };
 
   const doPin = () => {

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -146,8 +146,15 @@ export function CloudIdentityNote({
         (code) => {
           if (!mountedRef.current) return;
           setLoggingIn(false);
+          const sessionId = loginSessionRef.current;
           loginSessionRef.current = null;
           opened?.close();
+          // Detaching the channel is not enough: the backend keeps the session
+          // in its registry until told otherwise, and while any entry remains
+          // the terminal token slot is never reclaimed (and this gcloud child is
+          // never reaped). The exit frame means the process is gone, so this is
+          // bookkeeping, not a kill.
+          if (sessionId) void api.terminalClose(sessionId).catch(() => {});
           if (code === 0) onReconnect();
           else
             setLoginLog(
@@ -158,10 +165,14 @@ export function CloudIdentityNote({
       .then((session) => {
         opened = session;
         loginSessionRef.current = session.sessionId;
-        // The session can outlive this note (cluster switch, successful
-        // reconnect). Detaching the channel is enough — the PTY is owned by the
-        // backend and torn down with the cluster.
-        if (!mountedRef.current) session.close();
+        // The note can unmount mid-login (cluster switch, or a reconnect that
+        // succeeded from another path). Close the session rather than only
+        // detaching, so the registry doesn't keep an entry no one can reach.
+        if (!mountedRef.current) {
+          session.close();
+          loginSessionRef.current = null;
+          void api.terminalClose(session.sessionId).catch(() => {});
+        }
       })
       .catch((e: unknown) => {
         if (!mountedRef.current) return;

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -4,7 +4,7 @@ import type { ConnectHint } from "../types";
 import type { Tokens } from "../theme";
 import { FS_SM } from "../theme";
 import { Btn, Chip, Select } from "./ui";
-import { Mono } from "./detail/primitives";
+import { Copyable, Mono } from "./detail/primitives";
 
 // Small amber note under a failed connect, shown only when the backend
 // recognises cloud identity drift: a context whose exec entry pins no
@@ -152,6 +152,27 @@ export function CloudIdentityNote({
               </Chip>
             </>
           )}
+        </div>
+      )}
+
+      {/* A lapsed cloud session, not identity drift: there is nothing to write,
+          so the note hands over the command and a way back. The command is
+          copyable rather than a button that runs it — gcloud needs a real
+          terminal (and usually a browser) for the challenge, and the app has no
+          terminal surface before a cluster is connected. */}
+      {hint.reauth && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <Copyable text={hint.reauth.command}>
+            <Mono>{hint.reauth.command}</Mono>
+          </Copyable>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Btn t={t} variant="primary" size="sm" onClick={onReconnect}>
+              Retry connect
+            </Btn>
+            <span style={{ color: t.textDim }}>
+              after the login completes in your terminal
+            </span>
+          </div>
         </div>
       )}
 

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -6,10 +6,27 @@ import { FS_SM } from "../theme";
 import { Btn, Chip, Select } from "./ui";
 import { Copyable, Mono } from "./detail/primitives";
 
-// Small amber note under a failed connect, shown only when the backend
-// recognises cloud identity drift: a context whose exec entry pins no
-// account/profile, so it authenticates as whichever identity the cloud CLI last
-// selected — and that changes under the operator.
+/// PTY frames arrive base64-encoded, same as the Dock's terminal. Decoded as
+/// UTF-8 so gcloud's URL line survives; a frame that splits a multi-byte
+/// sequence degrades to a replacement char rather than throwing.
+function decodeB64(b64: string): string {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+// Small amber note under a failed connect, shown when the backend recognises the
+// cause as a cloud-credential problem. Two of them today:
+//
+//   * identity drift — a context whose exec entry pins no account/profile, so it
+//     authenticates as whichever identity the cloud CLI last selected, and that
+//     changes under the operator. Remedy: a pin.
+//   * a lapsed session — the credential plugin could not mint a token at all
+//     because the provider wants an identity challenge. Remedy: an interactive
+//     login, which `hint.reauth` describes and the Log in button runs.
+//
+// The two are mutually exclusive, and which one arrives is the backend's call.
 //
 // Provider-neutral by construction. Every string that differs between GKE, EKS
 // and AKS (the noun, the prose, what a pin would write) arrives in the hint;
@@ -33,7 +50,10 @@ export function CloudIdentityNote({
   /// The connect error, verbatim. The backend parses the authenticated identity
   /// out of it, so it must not be pre-cleaned.
   reason: string;
-  /// Called after a successful pin so the caller can retry the connection.
+  /// Called once the note has fixed the cause — a successful pin, or a login
+  /// that renewed a lapsed session — so the caller can retry the connection.
+  /// The same callback the enclosing banner's Reconnect button uses, which is
+  /// why this note offers no retry of its own.
   onReconnect: () => void;
 }) {
   const [hint, setHint] = useState<ConnectHint | null>(null);
@@ -41,6 +61,12 @@ export function CloudIdentityNote({
   const [confirming, setConfirming] = useState(false);
   const [pinning, setPinning] = useState(false);
   const [pinError, setPinError] = useState<string | null>(null);
+  const [loggingIn, setLoggingIn] = useState(false);
+  const [loginLog, setLoginLog] = useState("");
+  // Held so the operator can abandon a login that is going nowhere — gcloud can
+  // sit on a question this surface has no way to answer, and the note offers no
+  // input. Closing kills the PTY child.
+  const loginSessionRef = useRef<string | null>(null);
   // The pin outlives the hint effect's own `live` flag: it can still be in
   // flight when the operator switches cluster and unmounts this note. Guard its
   // settle handlers with a mount flag so a resolved (or rejected) pin doesn't
@@ -59,6 +85,9 @@ export function CloudIdentityNote({
     setIdentity(null);
     setConfirming(false);
     setPinError(null);
+    setLoggingIn(false);
+    setLoginLog("");
+    loginSessionRef.current = null;
     api
       .connectHint(contextId, reason)
       .then((h) => {
@@ -94,6 +123,65 @@ export function CloudIdentityNote({
   if (!hint) return null;
 
   const pin = hint.pin;
+
+  // Renew a lapsed session in one of our PTYs. gcloud opens a browser, writes a
+  // line or two, and exits; on a clean exit we reconnect for the operator, which
+  // is the only reason they were looking at this note.
+  const doLogin = () => {
+    const reauth = hint.reauth;
+    if (!reauth || loggingIn) return;
+    setLoggingIn(true);
+    setLoginLog("");
+    let opened: { sessionId: string; close: () => void } | null = null;
+    api
+      .cloudLoginOpen(
+        contextId,
+        reauth.account,
+        (b64) => {
+          if (!mountedRef.current) return;
+          // Tail only: this is a progress surface, not a terminal, and gcloud's
+          // browser-launch line is the part worth seeing.
+          setLoginLog((prev) => (prev + decodeB64(b64)).slice(-2000));
+        },
+        (code) => {
+          if (!mountedRef.current) return;
+          setLoggingIn(false);
+          loginSessionRef.current = null;
+          opened?.close();
+          if (code === 0) onReconnect();
+          else
+            setLoginLog(
+              (prev) => `${prev}\n[gcloud exited with code ${code}]`.trim(),
+            );
+        },
+      )
+      .then((session) => {
+        opened = session;
+        loginSessionRef.current = session.sessionId;
+        // The session can outlive this note (cluster switch, successful
+        // reconnect). Detaching the channel is enough — the PTY is owned by the
+        // backend and torn down with the cluster.
+        if (!mountedRef.current) session.close();
+      })
+      .catch((e: unknown) => {
+        if (!mountedRef.current) return;
+        setLoggingIn(false);
+        loginSessionRef.current = null;
+        setLoginLog(String(e));
+      });
+  };
+
+  const cancelLogin = () => {
+    const sessionId = loginSessionRef.current;
+    setLoggingIn(false);
+    loginSessionRef.current = null;
+    if (!sessionId) return;
+    // Fire and forget: the exit frame that follows is ignored because
+    // `loggingIn` is already false, and a failed close leaves a PTY the backend
+    // reaps with the cluster anyway.
+    void api.terminalClose(sessionId).catch(() => {});
+  };
+
   const doPin = () => {
     if (!identity) return;
     setPinning(true);
@@ -155,24 +243,70 @@ export function CloudIdentityNote({
         </div>
       )}
 
-      {/* A lapsed cloud session, not identity drift: there is nothing to write,
-          so the note hands over the command and a way back. The command is
-          copyable rather than a button that runs it — gcloud needs a real
-          terminal (and usually a browser) for the challenge, and the app has no
-          terminal surface before a cluster is connected. */}
+      {/* A lapsed cloud session, not identity drift: nothing for a pin to write.
+          The button runs the login in one of our own PTYs, which is the whole
+          reason the failure exists — gcloud will not perform an identity
+          challenge without a terminal. The command stays copyable so an operator
+          who would rather run it themselves (or whose browser can't be launched
+          from here) has the exact string. Reconnect is deliberately absent — the
+          enclosing banner already offers it. */}
       {hint.reauth && (
         <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
           <Copyable text={hint.reauth.command}>
             <Mono>{hint.reauth.command}</Mono>
           </Copyable>
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <Btn t={t} variant="primary" size="sm" onClick={onReconnect}>
-              Retry connect
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Btn
+              t={t}
+              variant="primary"
+              size="sm"
+              disabled={loggingIn}
+              onClick={doLogin}
+            >
+              {loggingIn ? "Waiting for browser…" : "Log in"}
             </Btn>
+            {/* No retry button here: the banner this note sits inside already
+                carries Reconnect, wired to the same callback. */}
+            {loggingIn && (
+              <Btn t={t} variant="secondary" size="sm" onClick={cancelLogin}>
+                Cancel
+              </Btn>
+            )}
             <span style={{ color: t.textDim }}>
-              after the login completes in your terminal
+              {loggingIn
+                ? "finish the sign-in in your browser"
+                : "opens your browser, then reconnects on its own"}
             </span>
           </div>
+          {/* gcloud's own output, verbatim. On success this is a line or two and
+              the reconnect fires anyway; when it fails this is the only place
+              the reason exists. */}
+          {loginLog && (
+            <pre
+              style={{
+                margin: 0,
+                padding: "6px 8px",
+                maxHeight: 120,
+                overflow: "auto",
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+                borderRadius: "var(--fs-radius-sm, 4px)",
+                background: t.bg,
+                color: t.textDim,
+                fontFamily: "var(--fs-font-mono, monospace)",
+                fontSize: FS_SM,
+              }}
+            >
+              {loginLog}
+            </pre>
+          )}
         </div>
       )}
 

--- a/ui/src/components/ui/atoms.test.tsx
+++ b/ui/src/components/ui/atoms.test.tsx
@@ -436,6 +436,34 @@ describe("ErrorBlock — classification branches", () => {
     expect(getByText(/the pod/i)).toBeInTheDocument();
   });
 
+  it("lapsed cloud session → 'Cloud session expired', not 'Auth plugin failed'", () => {
+    // Ordering-sensitive: this message names gke-gcloud-auth-plugin, which the
+    // exec-plugin branch below also matches. That branch's advice ("check the
+    // plugin runs cleanly from your terminal") points at the wrong thing — the
+    // plugin ran fine, the org's session policy lapsed.
+    const { getByText, queryByText } = render(
+      <ErrorBlock
+        t={t}
+        message="cloud session expired for a@example.com — run `gcloud auth login --account=a@example.com` in a terminal (ERROR: (gcloud.config.config-helper) There was a problem refreshing your current auth tokens: Reauthentication failed. cannot prompt during non-interactive execution.)"
+        kindLabel="cluster"
+      />,
+    );
+    expect(getByText("Cloud session expired")).toBeInTheDocument();
+    expect(queryByText("Auth plugin failed")).not.toBeInTheDocument();
+  });
+
+  it("raw plugin reauth stderr also classifies as a lapsed session", () => {
+    // The same failure can reach the UI unwrapped, straight from the plugin.
+    const { getByText } = render(
+      <ErrorBlock
+        t={t}
+        message="exec credential plugin 'gke-gcloud-auth-plugin' failed (exit 1) — Reauthentication failed. cannot prompt during non-interactive execution."
+        kindLabel="cluster"
+      />,
+    );
+    expect(getByText("Cloud session expired")).toBeInTheDocument();
+  });
+
   it("exec-plugin 'not found on PATH' → 'Auth plugin not found', not 'cluster doesn't exist'", () => {
     const { getByText, queryByText } = render(
       <ErrorBlock

--- a/ui/src/components/ui/atoms.tsx
+++ b/ui/src/components/ui/atoms.tsx
@@ -1596,6 +1596,20 @@ function classifyDetailError(
       raw: trimmed,
     };
   }
+  // A lapsed cloud session, which is a *credential* failure rather than a
+  // plugin failure: the binary is installed and ran, the account is fine, and
+  // the provider simply wants an identity challenge the app has no terminal to
+  // host. MUST precede the exec-plugin branch below, whose "check the plugin
+  // runs cleanly from your terminal" advice would send the operator looking at
+  // the wrong thing. `CloudIdentityNote` renders the account and the exact
+  // command underneath this banner.
+  if (/cloud session expired|reauthentication failed|cannot prompt during non-interactive/.test(m)) {
+    return {
+      title: "Cloud session expired",
+      body: "Your cloud CLI session needs renewing — run `gcloud auth login` (with `--account=…` if this context pins one) in a terminal, then reconnect. Credentials are intact; only the session lapsed.",
+      raw: trimmed,
+    };
+  }
   // Auth / exec-credential plugin failures (gke-gcloud-auth-plugin,
   // aws-iam-authenticator, kubelogin, …). MUST come before the generic 404
   // branch: a missing plugin or its stderr often contains "not found" (e.g.

--- a/ui/src/lib/connectFailure.test.ts
+++ b/ui/src/lib/connectFailure.test.ts
@@ -62,4 +62,25 @@ describe("isPermanentConnectFailure", () => {
       isPermanentConnectFailure("spec.selector: Forbidden: field is immutable"),
     ).toBe(false);
   });
+  it("treats a lapsed cloud session as permanent", () => {
+    // Retrying cannot renew a session — only an interactive login can — and the
+    // retry banner hides the note that says so.
+    for (const msg of [
+      "cloud session expired for a@example.com — run `gcloud auth login --account=a@example.com` in a terminal",
+      "ERROR: (gcloud.config.config-helper) There was a problem refreshing your current auth tokens: Reauthentication failed. cannot prompt during non-interactive execution.",
+    ]) {
+      expect(isPermanentConnectFailure(msg), msg).toBe(true);
+    }
+  });
+
+  it("still retries a plain expired token", () => {
+    // A 401 heals on reconnect: `Config` is rebuilt and the credential plugin
+    // re-runs. Only the reauth wording above is terminal.
+    for (const msg of [
+      "Unauthorized (401)",
+      "the server has asked for the client to provide credentials",
+    ]) {
+      expect(isPermanentConnectFailure(msg), msg).toBe(false);
+    }
+  });
 });

--- a/ui/src/lib/connectFailure.ts
+++ b/ui/src/lib/connectFailure.ts
@@ -29,6 +29,18 @@
 /// costs four minutes behind a spinner that explains nothing.
 export function isPermanentConnectFailure(message: string): boolean {
   const m = message.toLowerCase();
+  // A lapsed cloud session is as deterministic as a 403, and for the same
+  // reason: nothing about a retry changes it. The credential plugin refuses to
+  // mint a token until the operator completes an identity challenge in a
+  // terminal, so ten attempts produce ten identical failures — while hiding the
+  // one note that names the account and the command to run.
+  if (
+    m.includes("cloud session expired") ||
+    m.includes("reauthentication failed") ||
+    m.includes("cannot prompt during non-interactive")
+  ) {
+    return true;
+  }
   // Kubernetes embeds "Forbidden:" *inside* HTTP 422 validation messages to
   // mean "this field can't be changed". That is not an authorization failure
   // and must be excluded first — the same ordering guard `classifyDetailError`

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -168,6 +168,21 @@ export type PinOffer = {
   effects: string[];
 };
 
+/// What renews a lapsed cloud session. Mirrors
+/// `ferrisscope_core::cloud_identity::ReauthOffer`.
+///
+/// There is nothing for the app to write here — unlike a pin. The provider wants
+/// an identity challenge (usually a browser), and the app runs the credential
+/// plugin without a terminal, so gcloud refuses to prompt. The operator runs
+/// `command`, then reconnects.
+export type ReauthOffer = {
+  /// Verbatim command to run, with the account flag when the context pins one.
+  command: string;
+  /// Account whose session lapsed; null for an unpinned context, where the CLI's
+  /// active account is the one to renew.
+  account: string | null;
+};
+
 /// Actionable note attached to a failed connect when the cause looks like cloud
 /// identity drift — a context whose exec entry pins no account/profile, so it
 /// inherits whichever one the cloud CLI last selected.
@@ -185,6 +200,9 @@ export type ConnectHint = {
   /// null when the provider has no per-context pin at all (Azure): the note
   /// then explains the CLI command to run instead.
   pin: PinOffer | null;
+  /// Set instead of `pin` when the session lapsed rather than the identity
+  /// drifting. Pinning cannot fix that, so the two never arrive together.
+  reauth: ReauthOffer | null;
 };
 
 export type KubeconfigSourceKind = "file" | "folder" | "ssh";


### PR DESCRIPTION
## Problem

A GKE cluster would fail to connect with a generic **"Auth plugin failed"** banner and no cause. The real error was only ever visible in the app's stderr:

```
cred.go:145] print credential failed with error: Failed to retrieve access token::
failure while executing gcloud, with args [config config-helper --format=json --account=…]:
exit status 1 (err: ERROR: (gcloud.config.config-helper) There was a problem refreshing your
current auth tokens: Reauthentication failed. cannot prompt during non-interactive execution.
```

The operator's workaround was to run `kubectl get nodes --context <ctx>` in a terminal, which appeared to "fix the auth". It did — but not for the reason it looks like.

## Root cause

Two mechanics combined.

**1. The real error is invisible to us.** kube-rs inherits the exec plugin's stderr whenever `interactiveMode` isn't `Never` (`auth/mod.rs`), so `AuthError::AuthExecRun` arrives with an empty `stderr` and our redaction helper renders `(plugin produced no output)`.

**2. One token cache slot serves every account.** `gke-gcloud-auth-plugin` mints nothing itself — it shells out to `gcloud config config-helper` and caches the result beside whichever kubeconfig it resolves (`filepath.Dir` of client-go's `GetDefaultFilename()`), keyed on `(current_context, extra_args, expiry)`. On a plain `~/.kube/config` setup that is a single slot for every account, so a machine with several gcloud accounts evicts its own token on every cluster switch. Each miss is a fresh `gcloud`, multiplied by the number of `Client`s built from one `Config` — kube-rs mints a separate `RefreshableToken` per `auth_layer()` call. Observed in journald: **5–14 plugin spawns within the same second**, each producing an identical, invisible failure.

The `kubectl` workaround worked because a terminal has a TTY, so client-go hands the plugin stdin and gcloud can complete the identity challenge; the refreshed token then landed in the shared slot the app also read.

## What this changes

**`crates/core/src/exec_auth.rs` (new)** — runs the plugin once ourselves before any client is built: stdin closed, stderr piped, hard timeout. Two payoffs: the real failure becomes readable, and a success warms the slot the subsequent kube-rs spawns read instead of each shelling out to gcloud. Only `Failed`/`Missing` abort a connect; a timeout or an odd spawn error is `Inconclusive` and the connect proceeds, so this can never make a working cluster unreachable.

**Per-identity cache slots** — a scratch kubeconfig per account, injected as a `KUBECONFIG` entry in the *in-memory* exec `env` block that kube-rs forwards to the child. Nothing is written to the operator's kubeconfig. Its `current-context` is a **constant**: that field is half the plugin's cache key, so writing the target context there would invalidate the slot on every switch between two clusters on one account. A gcloud access token is account-scoped, not cluster-scoped, so one warm token per identity is both cheaper and correct.

**A lapsed session is its own diagnosis** — new `ExecFailure` classifier, `Error::ExecReauthRequired`, and a `ConnectHint.reauth` offer that names the account and the exact command. It offers no pin: the account is fine, its session isn't, and pinning would rewrite the kubeconfig for nothing. `isPermanentConnectFailure` also treats it as terminal, so the retry loop stops hiding the note for four minutes.

**A Log in button** — runs `gcloud auth login --quiet [--account=X]` in one of our own PTYs and reconnects when it exits cleanly. `--quiet` matters: the account always already has credentials here (only its session lapsed), so gcloud would otherwise stop on *"you are already authenticated, continue (Y/n)?"*. The argv is built in Rust and the account validated at the command boundary, so a kubeconfig value can't smuggle a second flag. Cancel closes the PTY; the command stays copyable as a manual fallback.

**Terminal token slot hygiene** — a Dock terminal's `kubectl` writes its own slot beside its scratch kubeconfig. That slot is now cleared when the last session closes, on app exit, and on an identity pin (which core can't reach, and which previously left a Dock terminal serving the pre-pin identity's token for up to an hour).

## Measured

Against a real GKE context, with the real plugin:

| case | before | after |
|---|---|---|
| connect, cold slot | ~1.2 s × N spawns | 1.17 s once, then 3 ms |
| second cluster, same account | full re-mint | 3 ms |
| 6 concurrent clients | 6 × gcloud | 4 ms total |
| fleet connect, one account | one gcloud per member | one, waiters hit the warm cache |

## Testing

- 26 `exec_auth` tests: slot preparation and env injection, non-gcloud plugins left untouched, the constant slot context, owner-only permissions, single-flight (verified to fail with the lock removed), the timeout arm, stderr classification, and the redaction helpers.
- Terminal: argv shape including flag-injection, slot cleanup lifetimes, and the exit-code reaper via a fake `Child`.
- Frontend: hint gating, the reauth surface, login success/failure/cancel/spawn-error paths, and the new "Cloud session expired" classification branch.
- `cargo fmt --check`, `clippy --workspace -D warnings`, full workspace tests, 1424 UI tests, `tsc --noEmit`. Cross-checked that the `cfg(windows)` path compiles for `x86_64-pc-windows-gnu`.

A code review of the branch caught one real bug before this PR: `forward_output` hard-coded `Exit { code: 0 }` and never called `wait()`, so the login button's auto-reconnect fired on failed logins too. Fixed by polling `try_wait` (not `wait`, which would block holding the child lock `kill_child` needs), reporting `-1` when the status can't be established so unknown never reads as success.

## Deliberately not done

- **No shared warming with the operator's own `kubectl`.** Doing so needs the slot's key to match their `current-context`'s, which only holds when the pin state matches; it also re-introduces cross-account eviction. The saving is ~1.2 s once an hour on an interactive command.
- **No shared token per cluster.** kube-rs builds one `RefreshableToken` per `auth_layer()` call and we call it per client, so a connect still spawns the plugin several times — they're 3 ms cache hits now. Sharing needs no upstream change: `AuthLayer::layer` takes `&self` and `RefreshableToken` is `Clone`, so hoisting one `auth_layer()` out of `build_compressed_client` and stamping every watcher-pool client with it would share a single token per cluster today. Deferred because the saving here is N × 3 ms — but it would cut real spawn cost for the aws/kubelogin plugins, which get no slot warming by design. Follow-up material.
- **gcloud family only.** `aws-iam-authenticator` and `kubelogin` paths are byte-identical to before: no preflight, no slot, no injected env. Their cache and session semantics differ and matching prose would be invention.
- **No preflight on SSH-sourced contexts** — remote kubeconfig, local plugin, separate question.

