### PR TITLE
fix(auth): explain and unblock a macOS-guarded gcloud SDK

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -495,6 +495,28 @@ pub(crate) async fn connect_hint_cmd(
     .map_err(|e| e.to_string())
 }
 
+/// Open the System Settings pane holding the per-app folder grants — the
+/// remedy for a TCC-blocked auth plugin (`ConnectHint.unblock`).
+///
+/// The URL is a compile-time constant rather than an argument on purpose: an
+/// open-any-URL command reachable from the webview would bypass the opener
+/// capability's scope, and this pane is the only OS-settings surface the note
+/// needs. macOS-only by nature; elsewhere the scheme has no handler, so refuse
+/// with a message instead of letting the opener fail opaquely.
+#[tauri::command]
+pub(crate) async fn open_privacy_settings_cmd(app: tauri::AppHandle) -> Result<(), String> {
+    if !cfg!(target_os = "macos") {
+        return Err("privacy settings deep link is only available on macOS".to_owned());
+    }
+    use tauri_plugin_opener::OpenerExt;
+    app.opener()
+        .open_url(
+            ferrisscope_core::cloud_identity::gcloud::MACOS_PRIVACY_SETTINGS_URL,
+            None::<&str>,
+        )
+        .map_err(|e| format!("could not open System Settings: {e}"))
+}
+
 /// Pin a context's exec entry to an explicit cloud identity — a gcloud
 /// `--account` or an AWS `AWS_PROFILE`, whichever the exec command calls for.
 ///

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use ferrisscope_core::cluster::{Cluster, ClusterInfo};
 use ferrisscope_core::fleet::{self, ClusterProbe};
@@ -515,101 +515,6 @@ pub(crate) async fn open_privacy_settings_cmd(app: tauri::AppHandle) -> Result<(
             None::<&str>,
         )
         .map_err(|e| format!("could not open System Settings: {e}"))
-}
-
-/// `<...>/Foo.app` from `<...>/Foo.app/Contents/MacOS/<binary>`, or `None` when
-/// the executable isn't inside a bundle (a `cargo run` / `tauri dev` build).
-/// Split out so the layout check is testable without a bundle on disk.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn macos_bundle_root(exe: &Path) -> Option<PathBuf> {
-    let macos_dir = exe.parent()?;
-    if macos_dir.file_name()? != "MacOS" {
-        return None;
-    }
-    let contents = macos_dir.parent()?;
-    if contents.file_name()? != "Contents" {
-        return None;
-    }
-    let root = contents.parent()?;
-    root.extension()
-        .is_some_and(|e| e.eq_ignore_ascii_case("app"))
-        .then(|| root.to_path_buf())
-}
-
-/// Wrap a path for `sh -c`. Paths here come from `current_exe`, but an
-/// apostrophe in a volume or folder name would otherwise break out of the
-/// quoting and run as a command.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-fn sh_single_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', r"'\''"))
-}
-
-/// Relaunch the app so a just-granted TCC folder permission takes effect.
-///
-/// macOS decides a process's file-access rights when it starts: granting
-/// Downloads/Desktop/Documents access while the app is running does *not* reach
-/// the running instance, and every subsequent plugin spawn keeps being refused.
-/// Reconnecting cannot fix that — only a fresh process can — so the blocked and
-/// hidden-helper notes offer this alongside the grant, and the copy says
-/// "restart", not "reconnect".
-///
-/// Not [`tauri::AppHandle::restart`]: on macOS that spawns the replacement as a
-/// *child of this process*, and TCC judges a child by its responsible process —
-/// so the new instance inherits exactly the stale decision we are restarting to
-/// escape. Measured: the button relaunched but the refusal persisted, while
-/// quitting and reopening from the Dock fixed it. Going through LaunchServices
-/// (`open`) makes the new instance its own responsible process, which is the
-/// whole point.
-///
-/// The relaunch is handed to a detached shell that waits for this PID to go
-/// away first: the single-instance plugin would otherwise just focus the
-/// still-live old window and never start a new process.
-#[tauri::command]
-pub(crate) fn restart_app_cmd(app: tauri::AppHandle) {
-    tracing::info!(
-        target: "ferrisscope::auth",
-        "restarting to pick up a newly granted folder permission"
-    );
-    #[cfg(target_os = "macos")]
-    {
-        if let Some(bundle) = std::env::current_exe()
-            .ok()
-            .as_deref()
-            .and_then(macos_bundle_root)
-        {
-            let script = format!(
-                "while kill -0 {pid} 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open {bundle}",
-                pid = std::process::id(),
-                bundle = sh_single_quote(&bundle.to_string_lossy()),
-            );
-            match std::process::Command::new("/bin/sh")
-                .arg("-c")
-                .arg(&script)
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .spawn()
-            {
-                // Exit cleanly rather than `restart()`: Tauri's shutdown still
-                // runs (port-forwards, chats, watchers), and the waiter brings
-                // us back through LaunchServices once we are gone.
-                Ok(_) => app.exit(0),
-                Err(e) => {
-                    // Better a same-responsibility relaunch than none: the
-                    // operator can still quit manually, and the note says so.
-                    tracing::warn!(
-                        target: "ferrisscope::auth",
-                        "could not schedule a LaunchServices relaunch ({e}) — falling back"
-                    );
-                    app.restart();
-                }
-            }
-        } else {
-            app.restart();
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    app.restart();
 }
 
 /// Pin a context's exec entry to an explicit cloud identity — a gcloud
@@ -4687,55 +4592,6 @@ fn emit_prom_changed(app: &AppHandle, cluster_id: &str, entry: Option<&PromCache
 mod tests {
     use super::{health_status_triggers_teardown, resource_event_name, sanitize_event_segment};
     use ferrisscope_core::health::ClusterHealthStatus;
-
-    #[test]
-    fn bundle_root_is_found_only_from_a_real_bundle_layout() {
-        use super::macos_bundle_root;
-        use std::path::{Path, PathBuf};
-
-        assert_eq!(
-            macos_bundle_root(Path::new(
-                "/Applications/FerrisScope.app/Contents/MacOS/ferrisscope"
-            )),
-            Some(PathBuf::from("/Applications/FerrisScope.app"))
-        );
-        // A dev build (`target/release/ferrisscope`) is not in a bundle, so
-        // there is nothing for LaunchServices to open — the caller must fall
-        // back rather than hand `open` a bare binary.
-        assert_eq!(
-            macos_bundle_root(Path::new("/repo/target/release/ferrisscope")),
-            None
-        );
-        // Right depth, wrong layout: must not walk up blindly.
-        assert_eq!(
-            macos_bundle_root(Path::new("/somewhere/Contents/MacOS/x")),
-            None
-        );
-        assert_eq!(
-            macos_bundle_root(Path::new("/x/Foo.app/Resources/MacOS/ferrisscope")),
-            None
-        );
-    }
-
-    #[test]
-    fn bundle_paths_are_quoted_against_shell_injection() {
-        use super::sh_single_quote;
-
-        assert_eq!(
-            sh_single_quote("/Applications/A.app"),
-            "'/Applications/A.app'"
-        );
-        // An apostrophe in a volume or folder name would otherwise close the
-        // quote and let the remainder run as a command.
-        assert_eq!(
-            sh_single_quote("/Volumes/Yurii's Disk/A.app"),
-            r"'/Volumes/Yurii'\''s Disk/A.app'"
-        );
-        assert_eq!(
-            sh_single_quote("/tmp/a'; rm -rf /tmp/x; echo '"),
-            r"'/tmp/a'\''; rm -rf /tmp/x; echo '\'''"
-        );
-    }
 
     #[test]
     fn detail_cmd_invocations_forward_to_same_stem_inner_fn() {

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use ferrisscope_core::cluster::{Cluster, ClusterInfo};
 use ferrisscope_core::fleet::{self, ClusterProbe};
@@ -517,20 +517,98 @@ pub(crate) async fn open_privacy_settings_cmd(app: tauri::AppHandle) -> Result<(
         .map_err(|e| format!("could not open System Settings: {e}"))
 }
 
+/// `<...>/Foo.app` from `<...>/Foo.app/Contents/MacOS/<binary>`, or `None` when
+/// the executable isn't inside a bundle (a `cargo run` / `tauri dev` build).
+/// Split out so the layout check is testable without a bundle on disk.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn macos_bundle_root(exe: &Path) -> Option<PathBuf> {
+    let macos_dir = exe.parent()?;
+    if macos_dir.file_name()? != "MacOS" {
+        return None;
+    }
+    let contents = macos_dir.parent()?;
+    if contents.file_name()? != "Contents" {
+        return None;
+    }
+    let root = contents.parent()?;
+    root.extension()
+        .is_some_and(|e| e.eq_ignore_ascii_case("app"))
+        .then(|| root.to_path_buf())
+}
+
+/// Wrap a path for `sh -c`. Paths here come from `current_exe`, but an
+/// apostrophe in a volume or folder name would otherwise break out of the
+/// quoting and run as a command.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn sh_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
 /// Relaunch the app so a just-granted TCC folder permission takes effect.
 ///
 /// macOS decides a process's file-access rights when it starts: granting
 /// Downloads/Desktop/Documents access while the app is running does *not* reach
 /// the running instance, and every subsequent plugin spawn keeps being refused.
-/// Reconnecting cannot fix that — only a fresh process can — so the blocked
-/// note offers this alongside the grant, and the copy says "restart", not
-/// "reconnect". Diverges: the process is replaced.
+/// Reconnecting cannot fix that — only a fresh process can — so the blocked and
+/// hidden-helper notes offer this alongside the grant, and the copy says
+/// "restart", not "reconnect".
+///
+/// Not [`tauri::AppHandle::restart`]: on macOS that spawns the replacement as a
+/// *child of this process*, and TCC judges a child by its responsible process —
+/// so the new instance inherits exactly the stale decision we are restarting to
+/// escape. Measured: the button relaunched but the refusal persisted, while
+/// quitting and reopening from the Dock fixed it. Going through LaunchServices
+/// (`open`) makes the new instance its own responsible process, which is the
+/// whole point.
+///
+/// The relaunch is handed to a detached shell that waits for this PID to go
+/// away first: the single-instance plugin would otherwise just focus the
+/// still-live old window and never start a new process.
 #[tauri::command]
 pub(crate) fn restart_app_cmd(app: tauri::AppHandle) {
     tracing::info!(
         target: "ferrisscope::auth",
         "restarting to pick up a newly granted folder permission"
     );
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(bundle) = std::env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(macos_bundle_root)
+        {
+            let script = format!(
+                "while kill -0 {pid} 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open {bundle}",
+                pid = std::process::id(),
+                bundle = sh_single_quote(&bundle.to_string_lossy()),
+            );
+            match std::process::Command::new("/bin/sh")
+                .arg("-c")
+                .arg(&script)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+            {
+                // Exit cleanly rather than `restart()`: Tauri's shutdown still
+                // runs (port-forwards, chats, watchers), and the waiter brings
+                // us back through LaunchServices once we are gone.
+                Ok(_) => app.exit(0),
+                Err(e) => {
+                    // Better a same-responsibility relaunch than none: the
+                    // operator can still quit manually, and the note says so.
+                    tracing::warn!(
+                        target: "ferrisscope::auth",
+                        "could not schedule a LaunchServices relaunch ({e}) — falling back"
+                    );
+                    app.restart();
+                }
+            }
+        } else {
+            app.restart();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
     app.restart();
 }
 
@@ -4609,6 +4687,55 @@ fn emit_prom_changed(app: &AppHandle, cluster_id: &str, entry: Option<&PromCache
 mod tests {
     use super::{health_status_triggers_teardown, resource_event_name, sanitize_event_segment};
     use ferrisscope_core::health::ClusterHealthStatus;
+
+    #[test]
+    fn bundle_root_is_found_only_from_a_real_bundle_layout() {
+        use super::macos_bundle_root;
+        use std::path::{Path, PathBuf};
+
+        assert_eq!(
+            macos_bundle_root(Path::new(
+                "/Applications/FerrisScope.app/Contents/MacOS/ferrisscope"
+            )),
+            Some(PathBuf::from("/Applications/FerrisScope.app"))
+        );
+        // A dev build (`target/release/ferrisscope`) is not in a bundle, so
+        // there is nothing for LaunchServices to open — the caller must fall
+        // back rather than hand `open` a bare binary.
+        assert_eq!(
+            macos_bundle_root(Path::new("/repo/target/release/ferrisscope")),
+            None
+        );
+        // Right depth, wrong layout: must not walk up blindly.
+        assert_eq!(
+            macos_bundle_root(Path::new("/somewhere/Contents/MacOS/x")),
+            None
+        );
+        assert_eq!(
+            macos_bundle_root(Path::new("/x/Foo.app/Resources/MacOS/ferrisscope")),
+            None
+        );
+    }
+
+    #[test]
+    fn bundle_paths_are_quoted_against_shell_injection() {
+        use super::sh_single_quote;
+
+        assert_eq!(
+            sh_single_quote("/Applications/A.app"),
+            "'/Applications/A.app'"
+        );
+        // An apostrophe in a volume or folder name would otherwise close the
+        // quote and let the remainder run as a command.
+        assert_eq!(
+            sh_single_quote("/Volumes/Yurii's Disk/A.app"),
+            r"'/Volumes/Yurii'\''s Disk/A.app'"
+        );
+        assert_eq!(
+            sh_single_quote("/tmp/a'; rm -rf /tmp/x; echo '"),
+            r"'/tmp/a'\''; rm -rf /tmp/x; echo '\'''"
+        );
+    }
 
     #[test]
     fn detail_cmd_invocations_forward_to_same_stem_inner_fn() {

--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -517,6 +517,23 @@ pub(crate) async fn open_privacy_settings_cmd(app: tauri::AppHandle) -> Result<(
         .map_err(|e| format!("could not open System Settings: {e}"))
 }
 
+/// Relaunch the app so a just-granted TCC folder permission takes effect.
+///
+/// macOS decides a process's file-access rights when it starts: granting
+/// Downloads/Desktop/Documents access while the app is running does *not* reach
+/// the running instance, and every subsequent plugin spawn keeps being refused.
+/// Reconnecting cannot fix that — only a fresh process can — so the blocked
+/// note offers this alongside the grant, and the copy says "restart", not
+/// "reconnect". Diverges: the process is replaced.
+#[tauri::command]
+pub(crate) fn restart_app_cmd(app: tauri::AppHandle) {
+    tracing::info!(
+        target: "ferrisscope::auth",
+        "restarting to pick up a newly granted folder permission"
+    );
+    app.restart();
+}
+
 /// Pin a context's exec entry to an explicit cloud identity — a gcloud
 /// `--account` or an AWS `AWS_PROFILE`, whichever the exec command calls for.
 ///

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -160,6 +160,7 @@ fn main() {
             commands::diagnose_connection_cmd,
             commands::connect_hint_cmd,
             commands::pin_cloud_identity_cmd,
+            commands::open_privacy_settings_cmd,
             commands::cancel_connect,
             commands::list_resource_kinds,
             commands::list_custom_resource_kinds,

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -161,7 +161,6 @@ fn main() {
             commands::connect_hint_cmd,
             commands::pin_cloud_identity_cmd,
             commands::open_privacy_settings_cmd,
-            commands::restart_app_cmd,
             commands::cancel_connect,
             commands::list_resource_kinds,
             commands::list_custom_resource_kinds,

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -161,6 +161,7 @@ fn main() {
             commands::connect_hint_cmd,
             commands::pin_cloud_identity_cmd,
             commands::open_privacy_settings_cmd,
+            commands::restart_app_cmd,
             commands::cancel_connect,
             commands::list_resource_kinds,
             commands::list_custom_resource_kinds,

--- a/crates/core/src/cloud_identity/aws.rs
+++ b/crates/core/src/cloud_identity/aws.rs
@@ -191,6 +191,7 @@ pub fn compose_hint(error: &str, profiles: &Identities) -> Option<ConnectHint> {
             ],
         }),
         reauth: None,
+        unblock: None,
     })
 }
 

--- a/crates/core/src/cloud_identity/azure.rs
+++ b/crates/core/src/cloud_identity/azure.rs
@@ -160,6 +160,7 @@ pub fn compose_hint(error: &str, accounts: &Identities) -> Option<ConnectHint> {
         // kubeconfig edit.
         pin: None,
         reauth: None,
+        unblock: None,
     })
 }
 

--- a/crates/core/src/cloud_identity/gcloud.rs
+++ b/crates/core/src/cloud_identity/gcloud.rs
@@ -226,6 +226,7 @@ pub fn compose_hint(error: &str, accounts: &Identities) -> Option<ConnectHint> {
             ],
         }),
         reauth: None,
+        unblock: None,
     })
 }
 
@@ -273,6 +274,7 @@ pub fn compose_reauth_hint(account: Option<&str>, accounts: &Identities) -> Conn
             command,
             account: account.map(str::to_owned),
         }),
+        unblock: None,
     }
 }
 
@@ -287,6 +289,10 @@ pub enum ExecFailure {
     /// No usable credentials for that account at all — never logged in, or the
     /// grant was revoked.
     CredentialsInvalid,
+    /// The OS refused to execute the plugin or its gcloud helper ("Operation
+    /// not permitted"): macOS TCC guarding a Downloads/Desktop/Documents
+    /// install, or a quarantine xattr. No gcloud command cures this.
+    ExecBlocked,
     /// Anything else: a broken plugin, a bad `--account`, gcloud not installed.
     Other,
 }
@@ -295,7 +301,10 @@ pub enum ExecFailure {
 ///
 /// Reauth is tested first and wins: gcloud prints the same "Please run: $ gcloud
 /// auth login" footer for a lapsed session as for absent credentials, so the
-/// footer distinguishes nothing while the reauth sentence does.
+/// footer distinguishes nothing while the reauth sentence does. The blocked
+/// test comes last for the same kind of reason — its phrase is the OS's
+/// generic EPERM string, so a message carrying both a reauth sentence and an
+/// EPERM must resolve to the remedy that is actually actionable (login).
 #[must_use]
 pub fn classify_exec_failure(stderr: &str) -> ExecFailure {
     let m = stderr.to_ascii_lowercase();
@@ -314,8 +323,98 @@ pub fn classify_exec_failure(stderr: &str) -> ExecFailure {
     {
         return ExecFailure::CredentialsInvalid;
     }
+    // "Operation not permitted" alone is any EPERM — a macOS firewall refusing
+    // an outbound connect produces the same words, and this classifier also
+    // runs over whole connect-error strings via `looks_like_exec_blocked`.
+    // Require a marker tying the refusal to the exec plugin: the plugin's own
+    // wrapper ("failure while executing gcloud" / its `cred.go` log prefix),
+    // the shell's can't-exec report, exit 126, or our own error renderings
+    // ("exec credential plugin …").
+    if m.contains("operation not permitted")
+        && (m.contains("credential plugin")
+            || m.contains("while executing")
+            || m.contains("cred.go")
+            || m.contains("/bin/sh:")
+            || m.contains("exit status 126"))
+    {
+        return ExecFailure::ExecBlocked;
+    }
     ExecFailure::Other
 }
+
+/// The absolute path the OS refused to execute, when the stderr names one.
+///
+/// The plugin wraps the shell's report — `… (err: /bin/sh:
+/// /path/to/gcloud: Operation not permitted` — so the path is the `": "`-token
+/// immediately before the marker. `None` unless that token is an absolute Unix
+/// path of sane length: a relative token is the shell's own name or prose, and
+/// this string ends up rendered in the hint.
+#[must_use]
+pub fn blocked_path(stderr: &str) -> Option<String> {
+    // Last occurrence: our own `Error::ExecPluginBlocked` rendering repeats
+    // the phrase in its header, and only the embedded stderr's occurrence has
+    // the path in front of it.
+    let lower = stderr.to_ascii_lowercase();
+    let at = lower.rfind("operation not permitted")?;
+    let before = stderr[..at].trim_end().trim_end_matches(':');
+    let candidate = before.rsplit(": ").next()?.trim();
+    (candidate.starts_with('/') && candidate.len() <= 512 && !candidate.contains(['\n', '\r']))
+        .then(|| candidate.to_owned())
+}
+
+/// Build the "the OS blocked the plugin" note.
+///
+/// Like [`compose_reauth_hint`] there are no gates: the stderr said exactly
+/// what happened. Offers no pin and no reauth — neither touches the cause. The
+/// [`super::UnblockOffer`] carries the two real remedies: a macOS privacy
+/// grant (Settings deep link) and a quarantine strip (copyable `xattr`).
+#[must_use]
+pub fn compose_blocked_hint(path: Option<&str>) -> ConnectHint {
+    let what = path.map_or_else(|| "the gcloud SDK".to_owned(), |p| format!("`{p}`"));
+    // `<sdk>/bin/gcloud` → strip the quarantine off the whole SDK, not one
+    // file — gcloud is a launcher that execs siblings, each quarantined too.
+    let quarantine_target = path.map(|p| {
+        let pb = std::path::Path::new(p);
+        pb.parent()
+            .filter(|bin| bin.file_name().is_some_and(|n| n == "bin"))
+            .and_then(std::path::Path::parent)
+            .filter(|root| !root.as_os_str().is_empty())
+            .map_or_else(|| p.to_owned(), |root| root.to_string_lossy().into_owned())
+    });
+    ConnectHint {
+        provider: Provider::Gcloud,
+        title: "macOS blocked the auth plugin".to_owned(),
+        detail: format!(
+            "The OS refused to run {what} (\"Operation not permitted\"), so no token could be \
+             minted. Two common causes: the SDK sits in a location macOS guards per-app \
+             (Downloads, Desktop, Documents, iCloud Drive, network or removable volumes) and \
+             this app has no grant for it, or the SDK still carries the quarantine flag from \
+             being downloaded as an archive. Grant access in System Settings → Privacy & \
+             Security → Files and Folders, or clear the quarantine with the command below — \
+             moving the SDK to an unguarded location fixes it for every app at once."
+        ),
+        authenticated_as: None,
+        identities: Vec::new(),
+        active_identity: None,
+        pin: None,
+        reauth: None,
+        unblock: Some(super::UnblockOffer {
+            path: path.map(str::to_owned),
+            settings_url: MACOS_PRIVACY_SETTINGS_URL.to_owned(),
+            command: quarantine_target.map(|t| {
+                format!(
+                    "xattr -r -d com.apple.quarantine '{}'",
+                    t.replace('\'', "'\\''")
+                )
+            }),
+        }),
+    }
+}
+
+/// Deep link to the pane holding the per-app folder grants. The legacy pane id
+/// still resolves on Ventura+ System Settings.
+pub const MACOS_PRIVACY_SETTINGS_URL: &str =
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders";
 
 /// Write `--account=<identity>` into an exec mapping, replacing any prior form.
 ///
@@ -471,6 +570,115 @@ mod tests {
         assert_eq!(
             classify_exec_failure("invalid credentials for project foo"),
             ExecFailure::Other
+        );
+    }
+
+    /// Verbatim stderr from a macOS install where the SDK sits in ~/Downloads
+    /// and TCC denies the exec (client report, account/user preserved in
+    /// shape). The exact wording is what the classifier and path parser key
+    /// on, so a paraphrase would test nothing.
+    const BLOCKED_STDERR: &str = "print credential failed with error: Failed to retrieve access \
+         token:: failure while executing gcloud, with args [config config-helper --format=json \
+         --account=a@example.com]: exit status 126 (err: /bin/sh: \
+         /Users/u/Downloads/google-cloud-sdk/bin/gcloud: Operation not permitted\n)";
+
+    #[test]
+    fn an_os_exec_refusal_is_classified_as_blocked() {
+        assert_eq!(
+            classify_exec_failure(BLOCKED_STDERR),
+            ExecFailure::ExecBlocked
+        );
+        // The bare shell report, without the plugin's wrapper.
+        assert_eq!(
+            classify_exec_failure(
+                "/bin/sh: /Users/u/Downloads/sdk/bin/gcloud: Operation not permitted"
+            ),
+            ExecFailure::ExecBlocked
+        );
+        // Reauth wording wins when both could match — its remedy is cheaper
+        // and its sentence is the more specific signal.
+        assert_eq!(
+            classify_exec_failure(
+                "Reauthentication failed. cannot prompt during non-interactive execution. \
+                 Operation not permitted"
+            ),
+            ExecFailure::ReauthRequired
+        );
+        // A bare EPERM with no exec-plugin marker is any OS refusal — a macOS
+        // firewall blocking an outbound connect says the same words. This
+        // classifier also runs over whole connect-error strings, so the phrase
+        // alone must not claim the SDK is blocked.
+        assert_eq!(
+            classify_exec_failure("dial tcp 10.0.0.1:443: connect: operation not permitted"),
+            ExecFailure::Other
+        );
+        assert_eq!(
+            classify_exec_failure("Operation not permitted"),
+            ExecFailure::Other
+        );
+        // Our own `ExecPluginFailed` rendering of a kube-rs-spawned failure
+        // carries the marker, so the enriched path still classifies.
+        assert_eq!(
+            classify_exec_failure(
+                "exec credential plugin 'gke-gcloud-auth-plugin' failed (exit 1) — \
+                 gcloud: Operation not permitted"
+            ),
+            ExecFailure::ExecBlocked
+        );
+    }
+
+    #[test]
+    fn blocked_path_extracts_the_refused_binary() {
+        assert_eq!(
+            blocked_path(BLOCKED_STDERR).as_deref(),
+            Some("/Users/u/Downloads/google-cloud-sdk/bin/gcloud")
+        );
+        // No path named — e.g. a kernel-level EPERM without the shell wrapper.
+        assert_eq!(blocked_path("gcloud: Operation not permitted"), None);
+        assert_eq!(blocked_path("Operation not permitted"), None);
+        // A relative token is the shell's own name, not a path.
+        assert_eq!(blocked_path("sh: gcloud: Operation not permitted"), None);
+    }
+
+    #[test]
+    fn the_blocked_note_offers_a_grant_and_a_quarantine_strip() {
+        let hint = compose_blocked_hint(Some("/Users/u/Downloads/google-cloud-sdk/bin/gcloud"));
+        assert_eq!(hint.provider, Provider::Gcloud);
+        // Neither a pin nor a login touches an OS exec refusal.
+        assert_eq!(hint.pin, None);
+        assert_eq!(hint.reauth, None);
+        let offer = hint.unblock.expect("unblock offer");
+        assert_eq!(offer.settings_url, MACOS_PRIVACY_SETTINGS_URL);
+        assert_eq!(
+            offer.path.as_deref(),
+            Some("/Users/u/Downloads/google-cloud-sdk/bin/gcloud")
+        );
+        // The strip targets the SDK root, not one file — gcloud execs
+        // quarantined siblings.
+        assert_eq!(
+            offer.command.as_deref(),
+            Some("xattr -r -d com.apple.quarantine '/Users/u/Downloads/google-cloud-sdk'")
+        );
+        assert!(hint.detail.contains("Operation not permitted"));
+    }
+
+    #[test]
+    fn the_blocked_note_survives_an_unparsed_path() {
+        let hint = compose_blocked_hint(None);
+        let offer = hint.unblock.expect("unblock offer");
+        assert_eq!(offer.path, None);
+        // No path → no quarantine target to name; only the grant remedy.
+        assert_eq!(offer.command, None);
+        assert_eq!(offer.settings_url, MACOS_PRIVACY_SETTINGS_URL);
+    }
+
+    #[test]
+    fn the_quarantine_target_falls_back_to_the_file_outside_a_bin_layout() {
+        let hint = compose_blocked_hint(Some("/opt/gcloud"));
+        let offer = hint.unblock.expect("unblock offer");
+        assert_eq!(
+            offer.command.as_deref(),
+            Some("xattr -r -d com.apple.quarantine '/opt/gcloud'")
         );
     }
 

--- a/crates/core/src/cloud_identity/gcloud.rs
+++ b/crates/core/src/cloud_identity/gcloud.rs
@@ -293,6 +293,17 @@ pub enum ExecFailure {
     /// not permitted"): macOS TCC guarding a Downloads/Desktop/Documents
     /// install, or a quarantine xattr. No gcloud command cures this.
     ExecBlocked,
+    /// The plugin ran but could not find `gcloud` on its own PATH. Because the
+    /// plugin itself executed, the SDK plainly *is* installed, so the helper
+    /// beside it is far more likely hidden than absent: macOS refuses the
+    /// access check on a guarded folder, and Go's `LookPath` reports that as
+    /// "not found" rather than as a denial — losing the EPERM that would have
+    /// classified as [`ExecFailure::ExecBlocked`].
+    ///
+    /// Its own variant because the remedies differ from every neighbour: a
+    /// folder grant *plus a restart*, since macOS applies a grant made while
+    /// the app runs to new processes only.
+    HelperHidden,
     /// Anything else: a broken plugin, a bad `--account`, gcloud not installed.
     Other,
 }
@@ -339,7 +350,52 @@ pub fn classify_exec_failure(stderr: &str) -> ExecFailure {
     {
         return ExecFailure::ExecBlocked;
     }
+    // The plugin ran and reported that *it* could not find its gcloud helper.
+    // Gated on the plugin's own wrapper for the same reason as above: our
+    // `ExecPluginNotFound` rendering says "not found on PATH" about the plugin
+    // itself, and that one really is missing — nothing to grant, nothing to
+    // restart. Only a message carrying the plugin's marker proves it executed,
+    // which is what makes "installed but hidden" the likelier reading.
+    if (m.contains("executable file not found in $path") || m.contains("not found in $path"))
+        && (m.contains("credential plugin")
+            || m.contains("while executing")
+            || m.contains("cred.go"))
+    {
+        return ExecFailure::HelperHidden;
+    }
     ExecFailure::Other
+}
+
+/// Build the "the SDK is installed but this process cannot see it" note.
+///
+/// Offers no quarantine command: nothing named a path, and a strip against a
+/// guess would be worse than silence. The two remedies that fit are a folder
+/// grant and — the one the operator cannot discover alone — a restart, because
+/// a grant made while the app is running reaches new processes only.
+#[must_use]
+pub fn compose_hidden_helper_hint() -> ConnectHint {
+    ConnectHint {
+        provider: Provider::Gcloud,
+        title: "macOS is hiding the gcloud SDK".to_owned(),
+        detail: "The auth plugin ran, so the SDK is installed — but it could not find the \
+                 `gcloud` beside it. On macOS a guarded folder (Downloads, Desktop, Documents, \
+                 iCloud Drive, a network or removable volume) fails the access check, and that \
+                 reads as \"not found\" rather than \"denied\". If you have just granted this app \
+                 access, the grant applies to newly started processes only — restart FerrisScope \
+                 to pick it up, because reconnecting will keep failing. Otherwise grant access \
+                 below, or move the SDK somewhere unguarded."
+            .to_owned(),
+        authenticated_as: None,
+        identities: Vec::new(),
+        active_identity: None,
+        pin: None,
+        reauth: None,
+        unblock: Some(super::UnblockOffer {
+            path: None,
+            settings_url: MACOS_PRIVACY_SETTINGS_URL.to_owned(),
+            command: None,
+        }),
+    }
 }
 
 /// The absolute path the OS refused to execute, when the stderr names one.
@@ -650,6 +706,59 @@ mod tests {
                 "quarantine target should be the SDK root under {root}"
             );
         }
+    }
+
+    /// Verbatim from a macOS reproduction, captured immediately after granting
+    /// the app Downloads access: the grant reached new processes only, so the
+    /// still-stale app spawned a plugin whose `LookPath` access check was
+    /// refused — reported as "not found", with no EPERM anywhere in the string.
+    const HIDDEN_HELPER_STDERR: &str = "exec credential plugin \
+         'gke-gcloud-auth-plugin' failed (exit 1) — F0818 19:20:10.265588 39265 cred.go:150] \
+         print credential failed with error: failed to retrieve access token: failure while \
+         executing gcloud, with args [config config-helper --format=json]: exec: \"gcloud\": \
+         executable file not found in $PATH (err: )";
+
+    #[test]
+    fn a_hidden_gcloud_helper_is_its_own_verdict() {
+        // Not `Other`: that renders the bare plugin-failed banner, whose advice
+        // ("check you're logged in") is useless, and not `ExecBlocked` either —
+        // there is no EPERM and no path to strip a quarantine from.
+        assert_eq!(
+            classify_exec_failure(HIDDEN_HELPER_STDERR),
+            ExecFailure::HelperHidden
+        );
+        // No path was named, so no quarantine command may be invented; the
+        // grant remedy stands alone and the prose carries the restart.
+        let hint = compose_hidden_helper_hint();
+        let unblock = hint.unblock.expect("a grant remedy");
+        assert_eq!(unblock.path, None);
+        assert_eq!(unblock.command, None);
+        assert_eq!(unblock.settings_url, MACOS_PRIVACY_SETTINGS_URL);
+        assert!(
+            hint.detail.to_ascii_lowercase().contains("restart"),
+            "the note must name the one remedy the operator cannot guess"
+        );
+    }
+
+    #[test]
+    fn a_genuinely_missing_plugin_is_not_mistaken_for_a_hidden_helper() {
+        // Our own `ExecPluginNotFound` rendering: the plugin never ran, so the
+        // binary really is absent. Installing it fixes this, and offering a
+        // privacy grant plus a restart would send the operator nowhere.
+        assert_eq!(
+            classify_exec_failure(
+                "exec credential plugin 'gke-gcloud-auth-plugin' not found on PATH — install \
+                 the gcloud CLI and run `gcloud components install gke-gcloud-auth-plugin`"
+            ),
+            ExecFailure::Other
+        );
+        // kube-rs's own spawn failure, likewise with no plugin wrapper.
+        assert_eq!(
+            classify_exec_failure(
+                "exec: \"gke-gcloud-auth-plugin\": executable file not found in $PATH"
+            ),
+            ExecFailure::Other
+        );
     }
 
     #[test]

--- a/crates/core/src/cloud_identity/gcloud.rs
+++ b/crates/core/src/cloud_identity/gcloud.rs
@@ -582,6 +582,76 @@ mod tests {
          --account=a@example.com]: exit status 126 (err: /bin/sh: \
          /Users/u/Downloads/google-cloud-sdk/bin/gcloud: Operation not permitted\n)";
 
+    /// Verbatim stderr captured on a macOS box reproducing the client report:
+    /// the whole SDK downloaded into ~/Downloads, TCC denying this app. Differs
+    /// from [`BLOCKED_STDERR`] in two ways that the parser must tolerate — no
+    /// `--account=` (the context pins no identity, so the plugin omits the
+    /// flag) and the lower-cased single-colon "failed to retrieve access
+    /// token:" wording emitted by this plugin build.
+    const BLOCKED_STDERR_NO_ACCOUNT: &str = "print credential failed with error: failed to \
+         retrieve access token: failure while executing gcloud, with args [config config-helper \
+         --format=json]: exit status 126 (err: /bin/sh: \
+         /Users/u/Downloads/google-cloud-sdk/bin/gcloud: Operation not permitted\n)";
+
+    #[test]
+    fn blocked_without_a_pinned_account_still_classifies_and_offers_the_sdk_root() {
+        assert_eq!(
+            classify_exec_failure(BLOCKED_STDERR_NO_ACCOUNT),
+            ExecFailure::ExecBlocked
+        );
+        let path = blocked_path(BLOCKED_STDERR_NO_ACCOUNT);
+        assert_eq!(
+            path.as_deref(),
+            Some("/Users/u/Downloads/google-cloud-sdk/bin/gcloud")
+        );
+        // The remedy must target the SDK root, not the single refused file:
+        // gcloud is a launcher that execs its siblings, each equally guarded.
+        let hint = compose_blocked_hint(path.as_deref());
+        assert_eq!(
+            hint.unblock.and_then(|u| u.command).as_deref(),
+            Some("xattr -r -d com.apple.quarantine '/Users/u/Downloads/google-cloud-sdk'")
+        );
+    }
+
+    /// TCC guards far more than the well-known trio, and its coverage shifts
+    /// per OS release: iCloud mirrors, network shares, removable volumes, and
+    /// (with Full Disk Access withheld) plenty besides. Nothing in the blocked
+    /// path may key on a location allowlist — the OS already decided by the
+    /// time this stderr exists, so every guarded prefix must classify and yield
+    /// its own SDK root.
+    #[test]
+    fn any_guarded_location_classifies_not_just_downloads() {
+        for root in [
+            "/Users/u/Downloads/google-cloud-sdk",
+            "/Users/u/Desktop/google-cloud-sdk",
+            "/Users/u/Documents/google-cloud-sdk",
+            "/Users/u/Library/Mobile Documents/com~apple~CloudDocs/google-cloud-sdk",
+            "/Volumes/Backup SSD/sdks/google-cloud-sdk",
+            "/Users/u/some/entirely/unexpected/place/google-cloud-sdk",
+        ] {
+            let stderr = format!(
+                "print credential failed with error: failed to retrieve access token: failure \
+                 while executing gcloud, with args [config config-helper --format=json]: exit \
+                 status 126 (err: /bin/sh: {root}/bin/gcloud: Operation not permitted\n)"
+            );
+            assert_eq!(
+                classify_exec_failure(&stderr),
+                ExecFailure::ExecBlocked,
+                "should classify under {root}"
+            );
+            let path = blocked_path(&stderr);
+            assert_eq!(path.as_deref(), Some(format!("{root}/bin/gcloud").as_str()));
+            assert_eq!(
+                compose_blocked_hint(path.as_deref())
+                    .unblock
+                    .and_then(|u| u.command)
+                    .as_deref(),
+                Some(format!("xattr -r -d com.apple.quarantine '{root}'").as_str()),
+                "quarantine target should be the SDK root under {root}"
+            );
+        }
+    }
+
     #[test]
     fn an_os_exec_refusal_is_classified_as_blocked() {
         assert_eq!(

--- a/crates/core/src/cloud_identity/gcloud.rs
+++ b/crates/core/src/cloud_identity/gcloud.rs
@@ -381,9 +381,9 @@ pub fn compose_hidden_helper_hint() -> ConnectHint {
                  `gcloud` beside it. On macOS a guarded folder (Downloads, Desktop, Documents, \
                  iCloud Drive, a network or removable volume) fails the access check, and that \
                  reads as \"not found\" rather than \"denied\". If you have just granted this app \
-                 access, the grant applies to newly started processes only — restart FerrisScope \
-                 to pick it up, because reconnecting will keep failing. Otherwise grant access \
-                 below, or move the SDK somewhere unguarded."
+                 access: quit FerrisScope completely and open it again — macOS applies a new \
+                 grant only to a freshly launched app, so reconnecting keeps failing. Otherwise \
+                 grant access below, or move the SDK somewhere unguarded."
             .to_owned(),
         authenticated_as: None,
         identities: Vec::new(),
@@ -446,8 +446,10 @@ pub fn compose_blocked_hint(path: Option<&str>) -> ConnectHint {
              (Downloads, Desktop, Documents, iCloud Drive, network or removable volumes) and \
              this app has no grant for it, or the SDK still carries the quarantine flag from \
              being downloaded as an archive. Grant access in System Settings → Privacy & \
-             Security → Files and Folders, or clear the quarantine with the command below — \
-             moving the SDK to an unguarded location fixes it for every app at once."
+             Security → Files and Folders and then quit FerrisScope completely and open it \
+             again — macOS applies a new grant only to a freshly launched app, so reconnecting \
+             keeps failing. Or clear the quarantine with the command below; moving the SDK to \
+             an unguarded location fixes it for every app at once."
         ),
         authenticated_as: None,
         identities: Vec::new(),
@@ -734,9 +736,18 @@ mod tests {
         assert_eq!(unblock.path, None);
         assert_eq!(unblock.command, None);
         assert_eq!(unblock.settings_url, MACOS_PRIVACY_SETTINGS_URL);
+        // The remedy the operator cannot guess, and it has to be a full
+        // quit-and-reopen: macOS applies the grant to a freshly launched app
+        // only, and an in-app relaunch inherits this process's TCC decision.
+        let detail = hint.detail.to_ascii_lowercase();
         assert!(
-            hint.detail.to_ascii_lowercase().contains("restart"),
-            "the note must name the one remedy the operator cannot guess"
+            detail.contains("quit ferrisscope completely and open it again"),
+            "the note must spell out the quit-and-reopen remedy, got: {}",
+            hint.detail
+        );
+        assert!(
+            detail.contains("reconnecting keeps failing"),
+            "and must say why reconnecting is not the remedy"
         );
     }
 

--- a/crates/core/src/cloud_identity/mod.rs
+++ b/crates/core/src/cloud_identity/mod.rs
@@ -93,6 +93,25 @@ pub struct ReauthOffer {
     pub account: Option<String>,
 }
 
+/// What clears an OS refusal to execute the credential plugin's helper
+/// (macOS TCC or a quarantine xattr — "Operation not permitted").
+///
+/// Separate from [`ReauthOffer`] because no cloud command is involved: the
+/// remedies are a per-app privacy grant (the deep link) or stripping the
+/// quarantine flag (the command), both outside the provider's CLI entirely.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct UnblockOffer {
+    /// The binary the OS refused, when the plugin's stderr named it.
+    pub path: Option<String>,
+    /// Deep link to the System Settings pane holding the per-app folder
+    /// grants. Rendered as a button; also copyable for operators on an OS
+    /// where the scheme doesn't resolve.
+    pub settings_url: String,
+    /// Verbatim quarantine-strip command for the SDK root, when the blocked
+    /// path was parseable. `None` leaves only the grant remedy.
+    pub command: Option<String>,
+}
+
 /// An actionable note to render alongside a failed connect.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ConnectHint {
@@ -114,6 +133,10 @@ pub struct ConnectHint {
     /// rather than identity drift. Pinning cannot fix that — only an interactive
     /// login can — so the two are mutually exclusive in practice.
     pub reauth: Option<ReauthOffer>,
+    /// Set when the OS refused to execute the plugin's helper. Mutually
+    /// exclusive with both [`Self::pin`] and [`Self::reauth`] — neither a pin
+    /// nor a login touches an exec refusal.
+    pub unblock: Option<UnblockOffer>,
 }
 
 /// Pull the identity out of an apiserver RBAC denial (`User "x" cannot …`).
@@ -172,6 +195,16 @@ pub fn looks_like_reauth(message: &str) -> bool {
         || message
             .to_ascii_lowercase()
             .contains("cloud session expired")
+}
+
+/// Does this error look like the OS refusing to execute the plugin's helper?
+///
+/// Matches both the plugin's stderr and our rendering of
+/// [`crate::Error::ExecPluginBlocked`] — both carry "operation not permitted",
+/// so one test covers whichever layer formatted the string.
+#[must_use]
+pub fn looks_like_exec_blocked(message: &str) -> bool {
+    gcloud::classify_exec_failure(message) == gcloud::ExecFailure::ExecBlocked
 }
 
 /// Does this error string look like a genuine RBAC 403?
@@ -335,13 +368,15 @@ fn hint_for_context_with(
     error: &str,
     probe: &dyn Fn(Provider) -> Identities,
 ) -> Result<Option<ConnectHint>> {
-    // Two different failures reach here. A 403 means the connect *authenticated*
-    // and was refused, which is where identity drift shows up. A lapsed cloud
-    // session never gets that far — the exec plugin refuses to produce a token
-    // at all — so it needs its own gate, and it must come first: the reauth
-    // message is not a 403 and would otherwise be dropped by the check below.
+    // Three different failures reach here. A 403 means the connect
+    // *authenticated* and was refused, which is where identity drift shows up.
+    // A lapsed cloud session never gets that far — the exec plugin refuses to
+    // produce a token at all — and an OS exec refusal never even runs the
+    // helper. The last two need their own gates, and they must come first:
+    // neither message is a 403 and both would otherwise be dropped below.
     let reauth = looks_like_reauth(error);
-    if !reauth && !is_forbidden(error) {
+    let blocked = looks_like_exec_blocked(error);
+    if !reauth && !blocked && !is_forbidden(error) {
         return Ok(None);
     }
     let Some(spec) = crate::cluster::exec_spec_for_context(context_name, source_path)? else {
@@ -350,6 +385,17 @@ fn hint_for_context_with(
     let Some((provider, binding)) = classify(&spec.command, &spec.args, &spec.env) else {
         return Ok(None);
     };
+    if blocked {
+        // Only gcloud: the classifier that produced `blocked` is gcloud's, and
+        // the note's prose names the gcloud SDK layout. Another provider's
+        // EPERM would get confident prose about the wrong SDK.
+        if provider != Provider::Gcloud {
+            return Ok(None);
+        }
+        return Ok(Some(gcloud::compose_blocked_hint(
+            gcloud::blocked_path(error).as_deref(),
+        )));
+    }
     if reauth {
         // Only gcloud is claimed here. AWS mints per call (no session to lapse),
         // and kubelogin's device/interactive modes fail differently — inventing
@@ -948,6 +994,41 @@ mod tests {
         assert_eq!(offer.account.as_deref(), Some("a@example.com"));
         assert_eq!(offer.command, "gcloud auth login --account=a@example.com");
         assert!(hint.detail.contains("terminal"));
+    }
+
+    /// Verbatim from `Error::ExecPluginBlocked`'s rendering — the string the
+    /// frontend hands back to `connect_hint` after a TCC-blocked preflight.
+    const BLOCKED_ERROR: &str = "the OS blocked the exec credential plugin \
+         'gke-gcloud-auth-plugin' — operation not permitted executing \
+         /Users/u/Downloads/google-cloud-sdk/bin/gcloud (print credential failed with error: \
+         Failed to retrieve access token:: failure while executing gcloud: exit status 126 \
+         (err: /bin/sh: /Users/u/Downloads/google-cloud-sdk/bin/gcloud: Operation not permitted))";
+
+    #[test]
+    fn a_blocked_plugin_gets_an_unblock_note_without_probing() {
+        // Never reaches the apiserver (no 403) and never ran gcloud (no reauth
+        // wording) — only the blocked gate can admit it. The probe must stay
+        // unconsulted: no account list changes the remedy for an OS refusal.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        let hint = hint_for_context_with("gke", Some(&path), BLOCKED_ERROR, &no_probe)
+            .expect("hint")
+            .expect("an unblock note");
+
+        assert_eq!(hint.provider, Provider::Gcloud);
+        assert_eq!(hint.pin, None);
+        assert_eq!(hint.reauth, None);
+        let offer = hint.unblock.expect("unblock offer");
+        assert_eq!(
+            offer.path.as_deref(),
+            Some("/Users/u/Downloads/google-cloud-sdk/bin/gcloud")
+        );
+        assert_eq!(offer.settings_url, gcloud::MACOS_PRIVACY_SETTINGS_URL);
+        // A context with no exec plugin can't have had its plugin blocked.
+        assert_eq!(
+            hint_for_context_with("plain", Some(&path), BLOCKED_ERROR, &no_probe).expect("hint"),
+            None
+        );
     }
 
     #[test]

--- a/crates/core/src/cloud_identity/mod.rs
+++ b/crates/core/src/cloud_identity/mod.rs
@@ -207,6 +207,16 @@ pub fn looks_like_exec_blocked(message: &str) -> bool {
     gcloud::classify_exec_failure(message) == gcloud::ExecFailure::ExecBlocked
 }
 
+/// Did the plugin run but fail to find its `gcloud` helper?
+///
+/// A guarded folder fails macOS's access check, and Go's `LookPath` renders
+/// that as "not found" instead of a denial — so this failure carries no EPERM
+/// to classify on, yet its remedy is the permission one (grant, then restart).
+#[must_use]
+pub fn looks_like_helper_hidden(message: &str) -> bool {
+    gcloud::classify_exec_failure(message) == gcloud::ExecFailure::HelperHidden
+}
+
 /// Does this error string look like a genuine RBAC 403?
 ///
 /// Kubernetes also embeds `Forbidden:` *inside* HTTP 422 validation messages to
@@ -376,7 +386,8 @@ fn hint_for_context_with(
     // neither message is a 403 and both would otherwise be dropped below.
     let reauth = looks_like_reauth(error);
     let blocked = looks_like_exec_blocked(error);
-    if !reauth && !blocked && !is_forbidden(error) {
+    let helper_hidden = looks_like_helper_hidden(error);
+    if !reauth && !blocked && !helper_hidden && !is_forbidden(error) {
         return Ok(None);
     }
     let Some(spec) = crate::cluster::exec_spec_for_context(context_name, source_path)? else {
@@ -395,6 +406,15 @@ fn hint_for_context_with(
         return Ok(Some(gcloud::compose_blocked_hint(
             gcloud::blocked_path(error).as_deref(),
         )));
+    }
+    if helper_hidden {
+        // Same restriction as `blocked`: the classifier and the note's prose are
+        // both gcloud's, so another provider would get confident advice about an
+        // SDK it does not use.
+        if provider != Provider::Gcloud {
+            return Ok(None);
+        }
+        return Ok(Some(gcloud::compose_hidden_helper_hint()));
     }
     if reauth {
         // Only gcloud is claimed here. AWS mints per call (no session to lapse),

--- a/crates/core/src/cloud_identity/mod.rs
+++ b/crates/core/src/cloud_identity/mod.rs
@@ -362,6 +362,7 @@ pub fn hint_for_context(
             Provider::Aws => aws::probe(),
             Provider::Azure => azure::probe().unwrap_or_default(),
         },
+        cfg!(target_os = "macos"),
     )
 }
 
@@ -372,11 +373,20 @@ pub fn hint_for_context(
 /// consulted *after* every refusal, which is the property most worth pinning:
 /// a test that had to stub a real config directory to reach those branches
 /// wouldn't be testing them.
+///
+/// `on_macos` is injected for the same reason. The blocked and hidden-helper
+/// notes are macOS diagnoses — their prose names TCC and quarantine, and their
+/// offer opens System Settings — but their stderr shapes are cross-platform:
+/// the same Go plugin says "not found in $PATH" on a Linux box whose gcloud is
+/// off the app's PATH, and an EPERM can come from a noexec mount. On any other
+/// platform those must fall through to the generic banner rather than tell the
+/// operator about an OS they aren't running.
 fn hint_for_context_with(
     context_name: &str,
     source_path: Option<&Path>,
     error: &str,
     probe: &dyn Fn(Provider) -> Identities,
+    on_macos: bool,
 ) -> Result<Option<ConnectHint>> {
     // Three different failures reach here. A 403 means the connect
     // *authenticated* and was refused, which is where identity drift shows up.
@@ -399,8 +409,10 @@ fn hint_for_context_with(
     if blocked {
         // Only gcloud: the classifier that produced `blocked` is gcloud's, and
         // the note's prose names the gcloud SDK layout. Another provider's
-        // EPERM would get confident prose about the wrong SDK.
-        if provider != Provider::Gcloud {
+        // EPERM would get confident prose about the wrong SDK. And only on
+        // macOS: a Linux noexec mount produces the same words, and TCC prose
+        // plus an xattr command would send that operator nowhere.
+        if provider != Provider::Gcloud || !on_macos {
             return Ok(None);
         }
         return Ok(Some(gcloud::compose_blocked_hint(
@@ -408,10 +420,11 @@ fn hint_for_context_with(
         )));
     }
     if helper_hidden {
-        // Same restriction as `blocked`: the classifier and the note's prose are
-        // both gcloud's, so another provider would get confident advice about an
-        // SDK it does not use.
-        if provider != Provider::Gcloud {
+        // Same restrictions as `blocked`: the note's prose is gcloud's and
+        // macOS's. The identical "not found in $PATH" wrapper on Linux or
+        // Windows means gcloud genuinely absent from the app's PATH — a real
+        // problem, but not this note's problem.
+        if provider != Provider::Gcloud || !on_macos {
             return Ok(None);
         }
         return Ok(Some(gcloud::compose_hidden_helper_hint()));
@@ -960,7 +973,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
         let hint = |ctx: &str, err: &str, probe: &dyn Fn(Provider) -> Identities| {
-            hint_for_context_with(ctx, Some(&path), err, probe)
+            hint_for_context_with(ctx, Some(&path), err, probe, true)
         };
 
         // Not a 403 at all — the overwhelmingly common case, and the reason the
@@ -1004,7 +1017,7 @@ mod tests {
             "      command: gke-gcloud-auth-plugin\n      args: [\"--account=a@example.com\"]",
         );
         let path = kubeconfig_fixture(tmp.path(), &pinned);
-        let hint = hint_for_context_with("gke", Some(&path), REAUTH_ERROR, &two_accounts)
+        let hint = hint_for_context_with("gke", Some(&path), REAUTH_ERROR, &two_accounts, true)
             .expect("hint")
             .expect("a reauth note");
 
@@ -1031,7 +1044,7 @@ mod tests {
         // unconsulted: no account list changes the remedy for an OS refusal.
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
-        let hint = hint_for_context_with("gke", Some(&path), BLOCKED_ERROR, &no_probe)
+        let hint = hint_for_context_with("gke", Some(&path), BLOCKED_ERROR, &no_probe, true)
             .expect("hint")
             .expect("an unblock note");
 
@@ -1046,9 +1059,40 @@ mod tests {
         assert_eq!(offer.settings_url, gcloud::MACOS_PRIVACY_SETTINGS_URL);
         // A context with no exec plugin can't have had its plugin blocked.
         assert_eq!(
-            hint_for_context_with("plain", Some(&path), BLOCKED_ERROR, &no_probe).expect("hint"),
+            hint_for_context_with("plain", Some(&path), BLOCKED_ERROR, &no_probe, true)
+                .expect("hint"),
             None
         );
+    }
+
+    #[test]
+    fn the_macos_notes_stay_silent_off_macos() {
+        // The stderr shapes are cross-platform — the same Go plugin says
+        // "not found in $PATH" on a Linux box whose gcloud is off the app's
+        // PATH, and an EPERM can come from a noexec mount — but the notes'
+        // prose names TCC, quarantine, and System Settings. Off macOS both
+        // must fall through to the generic banner rather than describe an OS
+        // the operator isn't running.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
+        const HIDDEN_ERROR: &str = "exec credential plugin 'gke-gcloud-auth-plugin' failed \
+             (exit 1) — print credential failed with error: failure while executing gcloud: \
+             exec: \"gcloud\": executable file not found in $PATH";
+        for err in [BLOCKED_ERROR, HIDDEN_ERROR] {
+            assert_eq!(
+                hint_for_context_with("gke", Some(&path), err, &no_probe, false).expect("hint"),
+                None,
+                "off macOS, no note for: {err}"
+            );
+            // And the same error still produces its note on macOS — the gate
+            // is the platform, not the message.
+            assert!(
+                hint_for_context_with("gke", Some(&path), err, &no_probe, true)
+                    .expect("hint")
+                    .is_some(),
+                "on macOS, a note for: {err}"
+            );
+        }
     }
 
     #[test]
@@ -1060,6 +1104,7 @@ mod tests {
             Some(&path),
             "Reauthentication failed. cannot prompt during non-interactive execution.",
             &two_accounts,
+            true,
         )
         .expect("hint")
         .expect("a reauth note");
@@ -1085,14 +1130,16 @@ mod tests {
         let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
         for ctx in ["eks", "aks"] {
             assert_eq!(
-                hint_for_context_with(ctx, Some(&path), REAUTH_ERROR, &two_accounts).expect("hint"),
+                hint_for_context_with(ctx, Some(&path), REAUTH_ERROR, &two_accounts, true)
+                    .expect("hint"),
                 None,
                 "{ctx} must not be handed gcloud's reauth wording"
             );
         }
         // Nor does a context with no exec plugin at all.
         assert_eq!(
-            hint_for_context_with("plain", Some(&path), REAUTH_ERROR, &no_probe).expect("hint"),
+            hint_for_context_with("plain", Some(&path), REAUTH_ERROR, &no_probe, true)
+                .expect("hint"),
             None
         );
     }
@@ -1103,7 +1150,7 @@ mod tests {
         // pin, with no reauth offer attached.
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
-        let hint = hint_for_context_with("gke", Some(&path), FORBIDDEN_403, &two_accounts)
+        let hint = hint_for_context_with("gke", Some(&path), FORBIDDEN_403, &two_accounts, true)
             .expect("hint")
             .expect("a drift note");
         assert!(hint.pin.is_some());
@@ -1123,7 +1170,8 @@ mod tests {
         );
         let path = kubeconfig_fixture(tmp.path(), &pinned);
         assert_eq!(
-            hint_for_context_with("gke", Some(&path), FORBIDDEN_403, &no_probe).expect("hint"),
+            hint_for_context_with("gke", Some(&path), FORBIDDEN_403, &no_probe, true)
+                .expect("hint"),
             None
         );
     }
@@ -1136,7 +1184,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let path = kubeconfig_fixture(tmp.path(), KUBECONFIG_YAML);
         let hint = |ctx: &str| {
-            hint_for_context_with(ctx, Some(&path), FORBIDDEN_403, &two_accounts)
+            hint_for_context_with(ctx, Some(&path), FORBIDDEN_403, &two_accounts, true)
                 .expect("hint")
                 .expect("a hint for an unpinned context")
         };

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -42,6 +42,19 @@ pub enum Error {
         message: String,
     },
 
+    /// The OS refused to execute the plugin's helper (macOS TCC on a
+    /// Downloads/Desktop/Documents install, or a quarantine xattr). Separate
+    /// from [`Error::ExecPluginFailed`] because no gcloud command fixes it —
+    /// the remedy is a privacy grant or moving the SDK.
+    #[error("the OS blocked the exec credential plugin '{command}' — operation not permitted{} ({message})",
+        path.as_ref().map(|p| format!(" executing {p}")).unwrap_or_default())]
+    ExecPluginBlocked {
+        command: String,
+        /// The blocked binary, when the plugin's stderr named it.
+        path: Option<String>,
+        message: String,
+    },
+
     #[error("context not found: {0}")]
     ContextNotFound(String),
 

--- a/crates/core/src/exec_auth.rs
+++ b/crates/core/src/exec_auth.rs
@@ -251,7 +251,7 @@ pub async fn preflight_with_budget(prepared: &PreparedExec, budget: Duration) ->
 /// connect forever — on timeout the spawn proceeds, fails, and the
 /// blocked-plugin note carries the remedies instead.
 #[cfg(target_os = "macos")]
-const CONSENT_PROMPT_TIMEOUT: Duration = Duration::from_secs(60);
+const CONSENT_PROMPT_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// Resolve a command the way the spawn will: paths as given, bare names
 /// through `path_var`. Canonicalized, so a symlink into a protected folder is

--- a/crates/core/src/exec_auth.rs
+++ b/crates/core/src/exec_auth.rs
@@ -207,6 +207,9 @@ pub async fn preflight_with_budget(prepared: &PreparedExec, budget: Duration) ->
     let lock = slot_lock(prepared.cache_dir.as_deref());
     let _guard = lock.lock().await;
 
+    #[cfg(target_os = "macos")]
+    nudge_tcc_consent(prepared).await;
+
     let mut cmd = tokio::process::Command::new(&prepared.command);
     cmd.args(&prepared.args)
         .envs(prepared.env.iter().map(|(k, v)| (k.as_str(), v.as_str())))
@@ -243,6 +246,98 @@ pub async fn preflight_with_budget(prepared: &PreparedExec, budget: Duration) ->
     }
 }
 
+/// How long the consent read may hold up a preflight. The read blocks for as
+/// long as the dialog is on screen, and an unanswered dialog must not hang the
+/// connect forever — on timeout the spawn proceeds, fails, and the
+/// blocked-plugin note carries the remedies instead.
+#[cfg(target_os = "macos")]
+const CONSENT_PROMPT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Resolve a command the way the spawn will: paths as given, bare names
+/// through `path_var`. Canonicalized, so a symlink into a protected folder is
+/// judged by where it points, not where it sits.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn resolve_command(command: &str, path_var: Option<&str>) -> Option<PathBuf> {
+    let p = Path::new(command);
+    if p.components().count() > 1 {
+        return p.canonicalize().ok();
+    }
+    std::env::split_paths(path_var?)
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .find_map(|dir| {
+            dir.join(command)
+                .canonicalize()
+                .ok()
+                .filter(|c| c.is_file())
+        })
+}
+
+/// Directories a consent-nudging read should touch before this preflight: the
+/// parent of every candidate binary the spawn will involve. Candidates are
+/// the plugin itself and `gcloud`, which the plugin shells out to — either
+/// alone can be the one inside a protected folder.
+///
+/// Deliberately *not* filtered against a list of protected locations: TCC's
+/// coverage is per-OS-release and wider than the well-known trio (Downloads /
+/// Desktop / Documents also come as iCloud mirrors, network shares, removable
+/// volumes). Reading an unprotected directory is a no-op costing microseconds,
+/// so the OS itself gets to be the judge of whether a prompt is due.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn consent_read_targets(prepared: &PreparedExec) -> Vec<PathBuf> {
+    // The spawn sees the exec block's env layered over ours, so a PATH there
+    // wins for resolution too.
+    let path_var = prepared
+        .env
+        .iter()
+        .find(|(k, _)| k == "PATH")
+        .map(|(_, v)| v.clone())
+        .or_else(|| std::env::var("PATH").ok());
+    let mut targets: Vec<PathBuf> = [prepared.command.as_str(), "gcloud"]
+        .iter()
+        .filter_map(|cmd| resolve_command(cmd, path_var.as_deref()))
+        .filter_map(|bin| bin.parent().map(Path::to_path_buf))
+        .collect();
+    targets.dedup();
+    targets
+}
+
+/// Fire the TCC consent prompt for a gated SDK location, bounded by
+/// [`CONSENT_PROMPT_TIMEOUT`]. Executing a binary inside a TCC-protected
+/// folder from a GUI app fails with EPERM *without* showing the prompt, while
+/// a plain directory read from the app process *does* show it — so read the
+/// directories the spawn will involve first. Unprotected paths return
+/// instantly and prompt nothing. Best-effort by design: every failure mode
+/// ends in "the spawn proceeds and its own error is handled".
+#[cfg(target_os = "macos")]
+async fn nudge_tcc_consent(prepared: &PreparedExec) {
+    let targets = consent_read_targets(prepared);
+    if targets.is_empty() {
+        return;
+    }
+    tracing::debug!(
+        target: "ferrisscope::auth",
+        ?targets,
+        "touching the auth plugin's directories so a TCC consent prompt can fire"
+    );
+    let read = tokio::task::spawn_blocking(move || {
+        for dir in targets {
+            // Consume one entry: opening the directory alone may not count as
+            // an access for TCC's purposes.
+            let _ = std::fs::read_dir(&dir).map(|mut it| it.next());
+        }
+    });
+    if tokio::time::timeout(CONSENT_PROMPT_TIMEOUT, read)
+        .await
+        .is_err()
+    {
+        tracing::info!(
+            target: "ferrisscope::auth",
+            "consent prompt unanswered after {}s — continuing without it",
+            CONSENT_PROMPT_TIMEOUT.as_secs()
+        );
+    }
+}
+
 /// Turn a [`PreflightOutcome::Failed`] into the most specific error we can
 /// justify. A lapsed cloud session is its own variant because the remedy
 /// (interactive login) is nothing like the remedy for a broken plugin.
@@ -252,6 +347,11 @@ pub fn failure_error(prepared: &PreparedExec, code: String, stderr: String) -> E
         gcloud::ExecFailure::ReauthRequired => Error::ExecReauthRequired {
             command: prepared.command.clone(),
             account: prepared.identity.clone(),
+            message: stderr,
+        },
+        gcloud::ExecFailure::ExecBlocked => Error::ExecPluginBlocked {
+            command: prepared.command.clone(),
+            path: gcloud::blocked_path(&stderr),
             message: stderr,
         },
         _ => Error::ExecPluginFailed {
@@ -816,6 +916,82 @@ users:
     }
 
     #[cfg(unix)]
+    mod consent {
+        use super::*;
+
+        #[test]
+        fn resolve_follows_path_and_symlinks() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            let real = tmp.path().join("home/Downloads/sdk/bin");
+            std::fs::create_dir_all(&real).expect("mkdir");
+            std::fs::write(real.join("gcloud"), "#!/bin/sh\n").expect("write");
+            let elsewhere = tmp.path().join("usr-local-bin");
+            std::fs::create_dir_all(&elsewhere).expect("mkdir");
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(real.join("gcloud"), elsewhere.join("gcloud"))
+                .expect("symlink");
+
+            let path_var = elsewhere.to_string_lossy().into_owned();
+            // A bare name resolves through PATH, and the symlink is judged by
+            // where it points — the client's `/usr/local/bin` → Downloads case.
+            #[cfg(unix)]
+            {
+                let resolved = resolve_command("gcloud", Some(&path_var)).expect("resolved");
+                let canon_home = tmp.path().join("home").canonicalize().expect("canon");
+                assert!(resolved.starts_with(canon_home.join("Downloads")));
+            }
+            assert_eq!(resolve_command("gcloud", None), None);
+            assert_eq!(resolve_command("not-there", Some(&path_var)), None);
+        }
+
+        #[test]
+        fn targets_are_the_dirs_of_every_binary_the_spawn_involves() {
+            let tmp = tempfile::tempdir().expect("tempdir");
+            // Plugin and gcloud in *different* directories — both matter: the
+            // plugin can sit somewhere sane while the gcloud it shells out to
+            // is the one inside a gated folder (the client's case, inverted).
+            let plugin_bin = tmp.path().join("Downloads/google-cloud-sdk/bin");
+            std::fs::create_dir_all(&plugin_bin).expect("mkdir");
+            std::fs::write(plugin_bin.join("gke-gcloud-auth-plugin"), "").expect("write");
+            let gcloud_bin = tmp.path().join("iCloud/sdk/bin");
+            std::fs::create_dir_all(&gcloud_bin).expect("mkdir");
+            std::fs::write(gcloud_bin.join("gcloud"), "").expect("write");
+
+            let p = PreparedExec {
+                command: plugin_bin
+                    .join("gke-gcloud-auth-plugin")
+                    .to_string_lossy()
+                    .into_owned(),
+                args: Vec::new(),
+                // `gcloud` resolves through the exec env's PATH, which wins
+                // over the process's own.
+                env: vec![("PATH".to_owned(), gcloud_bin.to_string_lossy().into_owned())],
+                identity: None,
+                api_version: None,
+                cache_dir: None,
+            };
+            let targets = consent_read_targets(&p);
+            assert_eq!(
+                targets,
+                vec![
+                    plugin_bin.canonicalize().expect("canon plugin bin"),
+                    gcloud_bin.canonicalize().expect("canon gcloud bin"),
+                ]
+            );
+
+            // Both in one directory → one read, not two. No protected-folder
+            // list is consulted: the OS judges, a plain dir read is free.
+            let p2 = PreparedExec {
+                command: gcloud_bin.join("gcloud").to_string_lossy().into_owned(),
+                ..p
+            };
+            assert_eq!(
+                consent_read_targets(&p2),
+                vec![gcloud_bin.canonicalize().expect("canon gcloud bin")]
+            );
+        }
+    }
+
     mod spawned {
         use super::*;
 
@@ -861,6 +1037,34 @@ users:
                     assert!(message.contains("Reauthentication failed"));
                 }
                 other => panic!("expected ExecReauthRequired, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn a_tcc_blocked_helper_maps_to_the_blocked_error() {
+            // The client-reported macOS shape: the plugin runs, its gcloud
+            // helper is refused by the OS, and the plugin wraps the shell's
+            // report. Must not fall into the generic bucket — the note built
+            // from this variant is the one carrying the remedies.
+            let p = plugin(
+                "echo 'print credential failed with error: Failed to retrieve access token:: \
+                 failure while executing gcloud: exit status 126 (err: /bin/sh: \
+                 /Users/u/Downloads/google-cloud-sdk/bin/gcloud: Operation not permitted' 1>&2; \
+                 exit 1",
+            );
+            let out = preflight(&p).await;
+            let PreflightOutcome::Failed { code, stderr } = out else {
+                panic!("expected Failed, got {out:?}");
+            };
+            match failure_error(&p, code, stderr) {
+                Error::ExecPluginBlocked { path, message, .. } => {
+                    assert_eq!(
+                        path.as_deref(),
+                        Some("/Users/u/Downloads/google-cloud-sdk/bin/gcloud")
+                    );
+                    assert!(message.contains("Operation not permitted"));
+                }
+                other => panic!("expected ExecPluginBlocked, got {other:?}"),
             }
         }
 

--- a/crates/core/src/exec_auth.rs
+++ b/crates/core/src/exec_auth.rs
@@ -992,6 +992,7 @@ users:
         }
     }
 
+    #[cfg(unix)]
     mod spawned {
         use super::*;
 

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -167,6 +167,13 @@ describe("contexts + connect", () => {
     expect(cap.calls[0]?.args).toBeUndefined();
   });
 
+  it("restartApp → 'restart_app_cmd' with no args", async () => {
+    const cap = captureNext(undefined);
+    await api.restartApp();
+    expect(cap.calls[0]?.cmd).toBe("restart_app_cmd");
+    expect(cap.calls[0]?.args).toBeUndefined();
+  });
+
   it("pinCloudIdentity → 'pin_cloud_identity_cmd' with name + identity", async () => {
     const cap = captureNext(undefined);
     await api.pinCloudIdentity("default::ctx-a", "a@b.io");

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -167,13 +167,6 @@ describe("contexts + connect", () => {
     expect(cap.calls[0]?.args).toBeUndefined();
   });
 
-  it("restartApp → 'restart_app_cmd' with no args", async () => {
-    const cap = captureNext(undefined);
-    await api.restartApp();
-    expect(cap.calls[0]?.cmd).toBe("restart_app_cmd");
-    expect(cap.calls[0]?.args).toBeUndefined();
-  });
-
   it("pinCloudIdentity → 'pin_cloud_identity_cmd' with name + identity", async () => {
     const cap = captureNext(undefined);
     await api.pinCloudIdentity("default::ctx-a", "a@b.io");

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -160,6 +160,13 @@ describe("contexts + connect", () => {
     ).toBeNull();
   });
 
+  it("openPrivacySettings → 'open_privacy_settings_cmd' with no args", async () => {
+    const cap = captureNext(undefined);
+    await api.openPrivacySettings();
+    expect(cap.calls[0]?.cmd).toBe("open_privacy_settings_cmd");
+    expect(cap.calls[0]?.args).toBeUndefined();
+  });
+
   it("pinCloudIdentity → 'pin_cloud_identity_cmd' with name + identity", async () => {
     const cap = captureNext(undefined);
     await api.pinCloudIdentity("default::ctx-a", "a@b.io");

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -152,6 +152,10 @@ export const api = {
   /// is cleared alongside — is the backend's call, per provider.
   pinCloudIdentity: (name: string, identity: string) =>
     invoke<void>("pin_cloud_identity_cmd", { name, identity }),
+  /// Open the macOS Files-and-Folders privacy pane — the remedy button for a
+  /// TCC-blocked auth plugin (`ConnectHint.unblock`). The target URL is a
+  /// backend constant, not an argument, so this is not a general URL opener.
+  openPrivacySettings: () => invoke<void>("open_privacy_settings_cmd"),
 
   listResourceKinds: () => invoke<ResourceKind[]>("list_resource_kinds"),
   // CRD-derived dynamic kinds. Per-cluster (CRDs are cluster-local), so

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -157,6 +157,11 @@ export const api = {
   /// backend constant, not an argument, so this is not a general URL opener.
   openPrivacySettings: () => invoke<void>("open_privacy_settings_cmd"),
 
+  /// Relaunch the app. A TCC folder grant only reaches a freshly started
+  /// process, so reconnecting after granting keeps failing — see
+  /// `restart_app_cmd`.
+  restartApp: () => invoke<void>("restart_app_cmd"),
+
   listResourceKinds: () => invoke<ResourceKind[]>("list_resource_kinds"),
   // CRD-derived dynamic kinds. Per-cluster (CRDs are cluster-local), so
   // unlike `listResourceKinds` this needs a connected `clusterId`.

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -157,11 +157,6 @@ export const api = {
   /// backend constant, not an argument, so this is not a general URL opener.
   openPrivacySettings: () => invoke<void>("open_privacy_settings_cmd"),
 
-  /// Relaunch the app. A TCC folder grant only reaches a freshly started
-  /// process, so reconnecting after granting keeps failing — see
-  /// `restart_app_cmd`.
-  restartApp: () => invoke<void>("restart_app_cmd"),
-
   listResourceKinds: () => invoke<ResourceKind[]>("list_resource_kinds"),
   // CRD-derived dynamic kinds. Per-cluster (CRDs are cluster-local), so
   // unlike `listResourceKinds` this needs a connected `clusterId`.

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -827,15 +827,18 @@ describe("CloudIdentityNote", () => {
       screen.getByRole("button", { name: /open privacy settings/i }),
     ).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /restart ferrisscope/i }),
-    );
-    await waitFor(() => {
-      expect(openCalls).toEqual(["restart_app_cmd"]);
-    });
+    // No in-app restart button: a relaunch from inside the app spawns a child,
+    // and TCC judges a child by its responsible process, so it inherits the
+    // stale decision. Only a full quit-and-reopen escapes it, so the note says
+    // exactly that rather than offering a control that cannot deliver.
+    expect(
+      screen.queryByRole("button", { name: /restart ferrisscope/i }),
+    ).not.toBeInTheDocument();
+    expect(note).toHaveTextContent(/quit FerrisScope completely and open it again/i);
+    expect(openCalls).toEqual([]);
   });
 
-  it("offers a restart on the blocked note, because a grant misses this process", async () => {
+  it("tells the operator to quit and reopen on the blocked note, not to reconnect", async () => {
     const openCalls: string[] = [];
     setMockInvoke((cmd) => {
       if (cmd === "connect_hint_cmd") return BLOCKED;
@@ -852,15 +855,11 @@ describe("CloudIdentityNote", () => {
     // the running app. Telling the operator to "reconnect" sends them in a
     // loop that always refuses; the copy has to say restart.
     const note = screen.getByRole("note");
-    expect(note).toHaveTextContent(/restart/i);
+    expect(note).toHaveTextContent(/quit FerrisScope completely and open it again/i);
+    // The old copy said "then reconnect", which is the one thing that cannot
+    // work: the grant never reaches the running process.
     expect(note).not.toHaveTextContent(/then reconnect/i);
-
-    fireEvent.click(
-      screen.getByRole("button", { name: /restart ferrisscope/i }),
-    );
-    await waitFor(() => {
-      expect(openCalls).toEqual(["restart_app_cmd"]);
-    });
+    expect(openCalls).toEqual([]);
   });
 
   it("drops the strip command from the blocked note when no path was parsed", async () => {

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -797,6 +797,44 @@ describe("CloudIdentityNote", () => {
     });
   });
 
+  it("offers grant + restart, and no invented xattr, when the helper is hidden", async () => {
+    // The plugin ran but could not see its gcloud: no path was named, so a
+    // quarantine strip would have to be guessed. Grant and restart are the
+    // honest remedies.
+    const HIDDEN: ConnectHint = {
+      ...BLOCKED,
+      title: "macOS is hiding the gcloud SDK",
+      detail:
+        "The auth plugin ran, so the SDK is installed — but it could not find the `gcloud` beside it. If you have just granted this app access, restart FerrisScope to pick it up, because reconnecting will keep failing.",
+      unblock: { path: null, settings_url: BLOCKED.unblock!.settings_url, command: null },
+    };
+    const openCalls: string[] = [];
+    setMockInvoke((cmd) => {
+      if (cmd === "connect_hint_cmd") return HIDDEN;
+      openCalls.push(cmd);
+      return undefined;
+    });
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(screen.getByText(/hiding the gcloud SDK/)).toBeInTheDocument();
+    });
+    const note = screen.getByRole("note");
+    expect(note).not.toHaveTextContent("xattr");
+    expect(note).toHaveTextContent(/restart/i);
+    expect(
+      screen.getByRole("button", { name: /open privacy settings/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /restart ferrisscope/i }),
+    );
+    await waitFor(() => {
+      expect(openCalls).toEqual(["restart_app_cmd"]);
+    });
+  });
+
   it("offers a restart on the blocked note, because a grant misses this process", async () => {
     const openCalls: string[] = [];
     setMockInvoke((cmd) => {

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -24,6 +24,7 @@ const GCLOUD: ConnectHint = {
     ],
   },
   reauth: null,
+  unblock: null,
 };
 
 const AWS: ConnectHint = {
@@ -41,6 +42,7 @@ const AWS: ConnectHint = {
     ],
   },
   reauth: null,
+  unblock: null,
 };
 
 const AZURE: ConnectHint = {
@@ -54,6 +56,7 @@ const AZURE: ConnectHint = {
   // The whole point of the Azure case: nothing to write, so no button.
   pin: null,
   reauth: null,
+  unblock: null,
 };
 
 // A lapsed Google session: the plugin never produced a token, so there is no
@@ -70,6 +73,26 @@ const REAUTH: ConnectHint = {
   reauth: {
     command: "gcloud auth login --account=ops@example.net",
     account: "ops@example.net",
+  },
+  unblock: null,
+};
+
+const BLOCKED: ConnectHint = {
+  provider: "gcloud",
+  title: "macOS blocked the auth plugin",
+  detail:
+    'The OS refused to run `/Users/u/Downloads/google-cloud-sdk/bin/gcloud` ("Operation not permitted"), so no token could be minted.',
+  authenticated_as: null,
+  identities: [],
+  active_identity: null,
+  pin: null,
+  reauth: null,
+  unblock: {
+    path: "/Users/u/Downloads/google-cloud-sdk/bin/gcloud",
+    settings_url:
+      "x-apple.systempreferences:com.apple.preference.security?Privacy_FilesAndFolders",
+    command:
+      "xattr -r -d com.apple.quarantine '/Users/u/Downloads/google-cloud-sdk'",
   },
 };
 
@@ -739,5 +762,56 @@ describe("CloudIdentityNote", () => {
     expect(
       screen.queryByRole("button", { name: /^cancel$/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("offers the privacy grant and quarantine strip when the OS blocked the plugin", async () => {
+    const openCalls: string[] = [];
+    setMockInvoke((cmd) => {
+      if (cmd === "connect_hint_cmd") return BLOCKED;
+      openCalls.push(cmd);
+      return undefined;
+    });
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(screen.getByText(/macOS blocked the auth plugin/)).toBeInTheDocument();
+    });
+    const note = screen.getByRole("note");
+    // The exact strip command, targeting the SDK root — copyable verbatim.
+    expect(note).toHaveTextContent(
+      "xattr -r -d com.apple.quarantine '/Users/u/Downloads/google-cloud-sdk'",
+    );
+    // Neither a pin nor a login belongs here: no account choice and no gcloud
+    // command changes an OS exec refusal.
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /log in/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /open privacy settings/i }),
+    );
+    await waitFor(() => {
+      expect(openCalls).toEqual(["open_privacy_settings_cmd"]);
+    });
+  });
+
+  it("drops the strip command from the blocked note when no path was parsed", async () => {
+    setMockInvoke(() => ({
+      ...BLOCKED,
+      unblock: { ...BLOCKED.unblock!, path: null, command: null },
+    }));
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(screen.getByText(/macOS blocked the auth plugin/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("note")).not.toHaveTextContent("xattr");
+    // The grant remedy stands on its own.
+    expect(
+      screen.getByRole("button", { name: /open privacy settings/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/src/components/CloudIdentityNote.test.tsx
+++ b/ui/src/components/CloudIdentityNote.test.tsx
@@ -797,6 +797,34 @@ describe("CloudIdentityNote", () => {
     });
   });
 
+  it("offers a restart on the blocked note, because a grant misses this process", async () => {
+    const openCalls: string[] = [];
+    setMockInvoke((cmd) => {
+      if (cmd === "connect_hint_cmd") return BLOCKED;
+      openCalls.push(cmd);
+      return undefined;
+    });
+
+    renderNote();
+
+    await waitFor(() => {
+      expect(screen.getByText(/macOS blocked the auth plugin/)).toBeInTheDocument();
+    });
+    // macOS fixes file-access rights at launch, so granting now cannot reach
+    // the running app. Telling the operator to "reconnect" sends them in a
+    // loop that always refuses; the copy has to say restart.
+    const note = screen.getByRole("note");
+    expect(note).toHaveTextContent(/restart/i);
+    expect(note).not.toHaveTextContent(/then reconnect/i);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /restart ferrisscope/i }),
+    );
+    await waitFor(() => {
+      expect(openCalls).toEqual(["restart_app_cmd"]);
+    });
+  });
+
   it("drops the strip command from the blocked note when no path was parsed", async () => {
     setMockInvoke(() => ({
       ...BLOCKED,

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -394,8 +394,28 @@ export function CloudIdentityNote({
             >
               Open Privacy Settings
             </Btn>
+            {/* macOS fixes a process's file-access rights at launch, so a grant
+                made now does not reach this instance — reconnecting refuses
+                identically and the operator concludes the grant did not work.
+                Only a fresh process picks it up, hence "restart" rather than
+                "reconnect", and a button so it is one click. */}
+            <Btn
+              t={t}
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setSettingsError(null);
+                api.restartApp().catch((e: unknown) => {
+                  setSettingsError(String(e));
+                });
+              }}
+            >
+              Restart FerrisScope
+            </Btn>
             <span style={{ color: t.textDim }}>
-              allow FerrisScope under Files and Folders, then reconnect
+              allow FerrisScope under Files and Folders, then restart — a new
+              grant only reaches a freshly started app, so reconnecting alone
+              keeps failing
             </span>
           </div>
           {settingsError && (

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -395,27 +395,18 @@ export function CloudIdentityNote({
               Open Privacy Settings
             </Btn>
             {/* macOS fixes a process's file-access rights at launch, so a grant
-                made now does not reach this instance — reconnecting refuses
-                identically and the operator concludes the grant did not work.
-                Only a fresh process picks it up, hence "restart" rather than
-                "reconnect", and a button so it is one click. */}
-            <Btn
-              t={t}
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                setSettingsError(null);
-                api.restartApp().catch((e: unknown) => {
-                  setSettingsError(String(e));
-                });
-              }}
-            >
-              Restart FerrisScope
-            </Btn>
+                made now never reaches this instance — reconnecting refuses
+                identically and the operator concludes the grant failed. It has
+                to be a full quit-and-reopen: an in-app relaunch spawns the
+                replacement as this process's child, and TCC judges a child by
+                its responsible process, so the stale decision is inherited.
+                Said as text rather than offered as a button, because no button
+                we can implement actually escapes it. */}
             <span style={{ color: t.textDim }}>
-              allow FerrisScope under Files and Folders, then restart — a new
-              grant only reaches a freshly started app, so reconnecting alone
-              keeps failing
+              allow FerrisScope under Files and Folders, then <b>quit
+              FerrisScope completely and open it again</b> — macOS only applies
+              a new grant to a freshly launched app, so reconnecting (or
+              restarting from inside the app) keeps failing
             </span>
           </div>
           {settingsError && (

--- a/ui/src/components/CloudIdentityNote.tsx
+++ b/ui/src/components/CloudIdentityNote.tsx
@@ -27,7 +27,7 @@ function closeLoginSession(sessionId: string | null): void {
 }
 
 // Small amber note under a failed connect, shown when the backend recognises the
-// cause as a cloud-credential problem. Two of them today:
+// cause as a cloud-credential problem. Three of them today:
 //
 //   * identity drift — a context whose exec entry pins no account/profile, so it
 //     authenticates as whichever identity the cloud CLI last selected, and that
@@ -35,8 +35,11 @@ function closeLoginSession(sessionId: string | null): void {
 //   * a lapsed session — the credential plugin could not mint a token at all
 //     because the provider wants an identity challenge. Remedy: an interactive
 //     login, which `hint.reauth` describes and the Log in button runs.
+//   * a blocked plugin — the OS refused to execute the plugin's helper (macOS
+//     TCC on a Downloads install, or a quarantine xattr). Remedy: a privacy
+//     grant or a quarantine strip, which `hint.unblock` describes.
 //
-// The two are mutually exclusive, and which one arrives is the backend's call.
+// All mutually exclusive, and which one arrives is the backend's call.
 //
 // Provider-neutral by construction. Every string that differs between GKE, EKS
 // and AKS (the noun, the prose, what a pin would write) arrives in the hint;
@@ -73,6 +76,7 @@ export function CloudIdentityNote({
   const [pinError, setPinError] = useState<string | null>(null);
   const [loggingIn, setLoggingIn] = useState(false);
   const [loginLog, setLoginLog] = useState("");
+  const [settingsError, setSettingsError] = useState<string | null>(null);
   // Held so the operator can abandon a login that is going nowhere — gcloud can
   // sit on a question this surface has no way to answer, and the note offers no
   // input. Closing kills the PTY child.
@@ -353,6 +357,49 @@ export function CloudIdentityNote({
             >
               {loginLog}
             </pre>
+          )}
+        </div>
+      )}
+
+      {/* The OS refused to execute the plugin's helper (macOS TCC or a
+          quarantine xattr) — nothing for a pin or a login to fix. The button
+          lands on the Files-and-Folders privacy pane; the xattr command stays
+          copyable for the quarantine case, same shape as the reauth command
+          above. */}
+      {hint.unblock && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {hint.unblock.command && (
+            <Copyable text={hint.unblock.command}>
+              <Mono>{hint.unblock.command}</Mono>
+            </Copyable>
+          )}
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <Btn
+              t={t}
+              variant="primary"
+              size="sm"
+              onClick={() => {
+                setSettingsError(null);
+                api.openPrivacySettings().catch((e: unknown) => {
+                  setSettingsError(String(e));
+                });
+              }}
+            >
+              Open Privacy Settings
+            </Btn>
+            <span style={{ color: t.textDim }}>
+              allow FerrisScope under Files and Folders, then reconnect
+            </span>
+          </div>
+          {settingsError && (
+            <div style={{ color: t.bad }}>{settingsError}</div>
           )}
         </div>
       )}

--- a/ui/src/lib/connectFailure.test.ts
+++ b/ui/src/lib/connectFailure.test.ts
@@ -84,6 +84,28 @@ describe("isPermanentConnectFailure", () => {
     ).toBe(true);
   });
 
+  it("treats a hidden gcloud helper as permanent", () => {
+    // Captured after granting the app Downloads access: the grant reached new
+    // processes only, so the stale app's plugin had its access check refused —
+    // surfaced as "not found", with no EPERM to match on. Just as terminal, and
+    // its note carries the restart the operator cannot guess.
+    expect(
+      isPermanentConnectFailure(
+        "exec credential plugin 'gke-gcloud-auth-plugin' failed (exit 1) — cred.go:150] failure while executing gcloud, with args [config config-helper --format=json]: exec: \"gcloud\": executable file not found in $PATH (err: )",
+      ),
+    ).toBe(true);
+  });
+
+  it("still retries a genuinely missing plugin, which installing does fix", () => {
+    // No plugin wrapper: the plugin never ran, so it really is absent. This
+    // must not inherit the permanence (or the grant/restart advice) above.
+    expect(
+      isPermanentConnectFailure(
+        'exec: "gke-gcloud-auth-plugin": executable file not found in $PATH',
+      ),
+    ).toBe(false);
+  });
+
   it("still retries a plain expired token", () => {
     // A 401 heals on reconnect: `Config` is rebuilt and the credential plugin
     // re-runs. Only the reauth wording above is terminal.

--- a/ui/src/lib/connectFailure.test.ts
+++ b/ui/src/lib/connectFailure.test.ts
@@ -73,6 +73,17 @@ describe("isPermanentConnectFailure", () => {
     }
   });
 
+  it("treats an OS exec refusal as permanent", () => {
+    // macOS TCC (or a quarantine xattr) refusing to run the plugin's helper
+    // heals only when the operator grants access or moves the SDK — the banner
+    // behind this flag is the one carrying those remedies.
+    expect(
+      isPermanentConnectFailure(
+        "the OS blocked the exec credential plugin 'gke-gcloud-auth-plugin' — operation not permitted executing /Users/u/Downloads/google-cloud-sdk/bin/gcloud",
+      ),
+    ).toBe(true);
+  });
+
   it("still retries a plain expired token", () => {
     // A 401 heals on reconnect: `Config` is rebuilt and the credential plugin
     // re-runs. Only the reauth wording above is terminal.

--- a/ui/src/lib/connectFailure.ts
+++ b/ui/src/lib/connectFailure.ts
@@ -41,6 +41,26 @@ export function isPermanentConnectFailure(message: string): boolean {
   ) {
     return true;
   }
+  // The OS refusing to execute the credential plugin's helper (macOS TCC on a
+  // Downloads install, or a quarantine xattr) is equally deterministic: it
+  // heals only when the operator grants access or moves the SDK, and the
+  // banner under this flag is the one carrying those remedies. Not the phrase
+  // alone — "operation not permitted" is any EPERM (a macOS firewall refusing
+  // an outbound connect says the same words, and that one heals on retry), so
+  // require a marker tying it to the exec plugin. Both backend renderings
+  // (`ExecPluginBlocked`, `ExecPluginFailed`) carry "credential plugin"; the
+  // raw plugin stderr carries its own wrapper. Kept in step with
+  // `cloud_identity::gcloud::classify_exec_failure`.
+  if (
+    m.includes("operation not permitted") &&
+    (m.includes("credential plugin") ||
+      m.includes("while executing") ||
+      m.includes("cred.go") ||
+      m.includes("/bin/sh:") ||
+      m.includes("exit status 126"))
+  ) {
+    return true;
+  }
   // Kubernetes embeds "Forbidden:" *inside* HTTP 422 validation messages to
   // mean "this field can't be changed". That is not an authorization failure
   // and must be excluded first — the same ordering guard `classifyDetailError`

--- a/ui/src/lib/connectFailure.ts
+++ b/ui/src/lib/connectFailure.ts
@@ -61,6 +61,22 @@ export function isPermanentConnectFailure(message: string): boolean {
   ) {
     return true;
   }
+  // The plugin ran but could not find its gcloud helper. A guarded folder fails
+  // macOS's access check and Go's LookPath calls that "not found", so this
+  // carries no EPERM — but it is just as terminal, and its note holds the one
+  // remedy an operator cannot guess (restart, because a grant made while the
+  // app runs reaches new processes only). Requires the plugin's own marker: our
+  // "plugin not found on PATH" rendering is about the plugin itself, which
+  // really is absent and really does heal once installed.
+  // Kept in step with `cloud_identity::gcloud::classify_exec_failure`.
+  if (
+    m.includes("not found in $path") &&
+    (m.includes("credential plugin") ||
+      m.includes("while executing") ||
+      m.includes("cred.go"))
+  ) {
+    return true;
+  }
   // Kubernetes embeds "Forbidden:" *inside* HTTP 422 validation messages to
   // mean "this field can't be changed". That is not an authorization failure
   // and must be excluded first — the same ordering guard `classifyDetailError`

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -183,6 +183,19 @@ export type ReauthOffer = {
   account: string | null;
 };
 
+/// What clears an OS refusal to execute the credential plugin's helper (macOS
+/// TCC or a quarantine xattr). Mirrors
+/// `ferrisscope_core::cloud_identity::UnblockOffer`.
+export type UnblockOffer = {
+  /// The binary the OS refused, when the plugin's stderr named it.
+  path: string | null;
+  /// Deep link to the System Settings pane with the per-app folder grants.
+  settings_url: string;
+  /// Verbatim quarantine-strip command for the SDK root; null when the blocked
+  /// path was unparseable.
+  command: string | null;
+};
+
 /// Actionable note attached to a failed connect when the cause looks like cloud
 /// identity drift — a context whose exec entry pins no account/profile, so it
 /// inherits whichever one the cloud CLI last selected.
@@ -203,6 +216,9 @@ export type ConnectHint = {
   /// Set instead of `pin` when the session lapsed rather than the identity
   /// drifting. Pinning cannot fix that, so the two never arrive together.
   reauth: ReauthOffer | null;
+  /// Set when the OS refused to execute the plugin's helper. Mutually
+  /// exclusive with both `pin` and `reauth`.
+  unblock: UnblockOffer | null;
 };
 
 export type KubeconfigSourceKind = "file" | "folder" | "ssh";


### PR DESCRIPTION
A client on macOS could not connect to GKE after upgrading: the gcloud SDK
lived in `~/Downloads`, macOS TCC refused the exec, and the app rendered the
generic "Auth plugin failed" banner whose advice (`gcloud auth login`) cannot
fix a permission refusal.

Reproduced end to end on a macOS box, which turned up a second failure shape
nobody predicted from the Linux side.

## What lands

**Nudge the consent prompt** (`crates/core/src/exec_auth.rs`). Before the
preflight spawn, resolve the plugin binary and the `gcloud` it shells out to —
through the exec env's PATH, canonicalized so a symlink is judged by where it
points — and read their directories from the app process. A directory read
raises the TCC dialog where a child `exec` is refused silently. No hardcoded
folder list: an unguarded path is a microsecond no-op and the OS decides what
is gated. Bounded by 60s so an unanswered dialog cannot hang the connect.

**Explain an EPERM refusal.** `ExecFailure::ExecBlocked` →
`Error::ExecPluginBlocked` → a note carrying the blocked path, a copyable
`xattr -r -d com.apple.quarantine '<sdk-root>'`, and an *Open Privacy Settings*
button (`open_privacy_settings_cmd`, URL is a backend constant so this is not a
general URL opener). Classification requires an exec-plugin marker alongside
"operation not permitted" — the phrase alone is any EPERM, e.g. a firewall
refusing an outbound connect, which is transient and must stay retryable.

**Explain a hidden helper.** Granting folder access while the app runs reaches
new processes only, so the stale process spawns a plugin whose `LookPath`
access check is refused — and Go reports that as *"not found"*, with no EPERM
anywhere in the string. That fell through to the generic banner.
`ExecFailure::HelperHidden` gives it its own verdict and note.

**Say quit-and-reopen, not reconnect.** A grant cannot reach the running
process. A Restart button was built, measured, and deleted: `AppHandle::restart()`
spawns the replacement as this process's child and TCC judges a child by its
responsible process, so the stale decision is inherited; a LaunchServices
relaunch worked but needed a detached PID-polling shell. Both notes now say
plainly to quit and reopen, and why reconnecting keeps failing.

**Both notes are macOS-gated.** The stderr shapes are not: the same Go plugin
prints "not found in $PATH" on a Linux box whose gcloud is off the app's PATH,
and an EPERM can come from a noexec mount. `hint_for_context_with` takes an
injected `on_macos` (same DI pattern as the existing probe) so off macOS both
fall through to the generic banner, while the Linux-runnable tests still cover
the positive path.

## Verification

`cargo fmt --all -- --check`, `cargo clippy -p ferrisscope-core -p ferrisscope-app`
clean, core suite 250 tests, UI suite 1437 tests, Windows cross-check on core.
Manual reproduction on macOS: repro confirmed on the old build, consent dialog
fires on the new one, deny path renders the blocked note, post-grant stale
process renders the hidden-helper note, quit-and-reopen recovers.