### PR TITLE
fix(cluster): recover a wedged cluster without leaving the tab

### DIFF
--- a/crates/app/src/commands.rs
+++ b/crates/app/src/commands.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use ferrisscope_core::cluster::{Cluster, ClusterInfo};
 use ferrisscope_core::fleet::{self, ClusterProbe};
-use ferrisscope_core::health::ClusterHealthStatus;
+use ferrisscope_core::health::{ClusterHealthEvent, ClusterHealthStatus};
 use ferrisscope_core::kubeconfig::{self, ContextInfo};
 use ferrisscope_core::logs::{LogEvent, LogStream};
 use ferrisscope_core::metrics::{MetricsService, MetricsSnapshot};
@@ -703,7 +703,13 @@ pub(crate) async fn connect_context(
             // Cache the connected cluster so the next `state.entry(...)` call
             // (e.g. inside `subscribe_resource` when the operator clicks a
             // kind) reuses this client instead of re-running `Cluster::connect`.
-            let entry = state.insert_connected(name.clone(), cluster).await;
+            // A wedged entry is swapped out here instead of winning, which is
+            // what makes re-entering a dead cluster (tab switch, remount)
+            // recover it — no fleet round trip, no app restart.
+            let (entry, displaced) = state.insert_connected(name.clone(), cluster).await;
+            if let Some(wedged) = displaced {
+                tear_down_displaced(&state, &name, &wedged).await;
+            }
             // Health forwarder is wired separately via its own CAS so
             // it also runs on the lazy-connect path (eager namespaces
             // subscribe before connect_context). Cheap no-op if already
@@ -842,16 +848,25 @@ fn spawn_search_bootstrap(
     });
 }
 
-/// Spawn the health-event forwarder for `cluster_id` exactly once per
-/// `ClusterEntry` lifetime. Safe to call from every command that
-/// touches `state.entry()` — the CAS in `claim_health_wiring` makes
-/// repeat calls cheap no-ops. Without this on lazy-connect paths
-/// (App's eager namespaces subscribe runs before `connect_context`),
-/// the probe runs but its `Unavailable` event never reaches the UI.
+/// Spawn the health-event forwarder for `cluster_id` — once at a time per
+/// `ClusterEntry`. Safe to call from every command that touches
+/// `state.entry()` — the CAS in `claim_health_wiring` makes repeat calls
+/// cheap no-ops. Without this on lazy-connect paths (App's eager namespaces
+/// subscribe runs before `connect_context`), the probe runs but its
+/// `Unavailable` event never reaches the UI.
+///
+/// The claim is *released* when a forwarder exits, so a subsequent call
+/// re-spawns one and replays the current snapshot. That's what gets an
+/// `Unavailable` to a frontend listener that attached after the one-shot
+/// emit (operator returning to a background tab).
 fn wire_cluster_health(app: &AppHandle, cluster_id: &str, entry: Arc<crate::state::ClusterEntry>) {
     if entry.claim_health_wiring() {
-        let handle =
-            spawn_health_forwarder(app.clone(), cluster_id.to_owned(), entry.health.clone());
+        let handle = spawn_health_forwarder(
+            app.clone(),
+            cluster_id.to_owned(),
+            entry.health.clone(),
+            Arc::downgrade(&entry),
+        );
         // Stash on the entry so teardown paths can abort it. The CAS in
         // `claim_health_wiring` already guarantees we only get here
         // once per entry lifetime, but be defensive — replace any
@@ -1311,6 +1326,14 @@ async fn drop_all_kind_watchers(state: &AppState, cluster_id: &str) -> usize {
     let Some(entry) = state.get_existing(cluster_id).await else {
         return 0;
     };
+    drop_entry_watchers(&entry).await
+}
+
+/// The body of [`drop_all_kind_watchers`], addressed by entry rather than by
+/// id. Needed by the displaced-entry path in `connect_context`: once a wedged
+/// entry has been swapped out of the map, its id resolves to the *replacement*
+/// — tearing down by id there would kill the cluster we just rebuilt.
+async fn drop_entry_watchers(entry: &crate::state::ClusterEntry) -> usize {
     let mut slots = entry.kinds.lock().await;
     let mut dropped = 0;
     for (_kind, slot) in slots.iter_mut() {
@@ -1565,11 +1588,7 @@ pub(crate) async fn reconnect_cluster(
     cluster_id: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    // The fresh `connect_context` rebuilds the kube `Client`; the old log
-    // streams / watches hold the wedged one, so abort them here too.
-    let logs_dropped = state.drop_cluster_logs(&cluster_id).await;
-    let dropped = drop_all_kind_watchers(&state, &cluster_id).await;
-    let removed = state.remove_cluster(&cluster_id).await.is_some();
+    let (logs_dropped, dropped, removed) = evict_cluster_entry(&state, &cluster_id).await;
     tracing::info!(
         cluster_id = %cluster_id,
         logs_dropped,
@@ -1582,6 +1601,92 @@ pub(crate) async fn reconnect_cluster(
     // pre-reconnect high-water.
     ferrisscope_mimalloc_ext::collect(true);
     Ok(())
+}
+
+/// Drop the cached entry for `cluster_id` — log streams, kind watchers,
+/// metrics service, event forwarders, and finally the `ClusterEntry` itself
+/// — so the next `connect_context` rebuilds from a fresh `Cluster`.
+/// Deliberately narrower than `drop_cluster_watchers`: terminals, chats and
+/// port-forwards survive, because this runs on *recovery* paths where the
+/// operator is staying on the cluster. Returns
+/// `(logs_dropped, watchers_dropped, entry_removed)`.
+async fn evict_cluster_entry(state: &AppState, cluster_id: &str) -> (usize, usize, bool) {
+    // The fresh `connect_context` rebuilds the kube `Client`; the old log
+    // streams / watches hold the wedged one, so abort them here too.
+    let logs_dropped = state.drop_cluster_logs(cluster_id).await;
+    let dropped = drop_all_kind_watchers(state, cluster_id).await;
+    let removed = state.remove_cluster(cluster_id).await.is_some();
+    (logs_dropped, dropped, removed)
+}
+
+/// Release a wedged entry that `insert_connected` swapped out of the map.
+/// Addressed by `Arc`, never by id — the id now resolves to the replacement,
+/// so an id-based teardown here would tear down the cluster we just rebuilt.
+/// Log streams ARE dropped by id: they hold the wedged client and the fresh
+/// entry has none yet.
+async fn tear_down_displaced(
+    state: &AppState,
+    cluster_id: &str,
+    wedged: &crate::state::ClusterEntry,
+) {
+    let logs_dropped = state.drop_cluster_logs(cluster_id).await;
+    let dropped = drop_entry_watchers(wedged).await;
+    tracing::warn!(
+        cluster_id = %cluster_id,
+        logs_dropped,
+        dropped,
+        "connect_context: wedged entry replaced, rebuilt from the fresh client"
+    );
+}
+
+/// Current health of `cluster_id` for a frontend that just mounted.
+///
+/// The probe broadcasts `Unavailable` exactly once and the forwarder exits
+/// after emitting it, so a listener attaching later (operator returns to a
+/// background tab, or Tauri's async `listen()` registration lost the race
+/// with the emit) would otherwise never learn the cluster is down. This is
+/// the pull-side counterpart to `cluster-health://` — cheap, non-creating,
+/// and safe to call on every panel mount.
+#[tauri::command]
+pub(crate) async fn get_cluster_health(
+    cluster_id: String,
+    state: State<'_, AppState>,
+) -> Result<ClusterHealthEvent, String> {
+    // Non-creating: an unconnected cluster is "healthy" — there's nothing
+    // wedged to report, and lazily connecting here would spend a full auth
+    // round trip just to answer a status question.
+    let Some(entry) = state.get_existing(&cluster_id).await else {
+        return Ok(healthy_event());
+    };
+    let unavailable = entry.unavailable.load(Ordering::SeqCst);
+    Ok(health_event_for(unavailable, entry.health.snapshot().await))
+}
+
+fn healthy_event() -> ClusterHealthEvent {
+    ClusterHealthEvent {
+        status: ClusterHealthStatus::Healthy,
+        reason: None,
+    }
+}
+
+/// Reconcile the entry's sticky `unavailable` gate with the probe's last
+/// broadcast. The gate is the authority: the probe goes dormant after
+/// declaring the cluster dead, and a rebuilt-but-not-yet-probed snapshot
+/// would otherwise report `Healthy` for a cluster whose data plane is torn
+/// down and whose `subscribe_*` calls all fail.
+fn health_event_for(unavailable: bool, snapshot: ClusterHealthEvent) -> ClusterHealthEvent {
+    if !unavailable {
+        return snapshot;
+    }
+    ClusterHealthEvent {
+        status: ClusterHealthStatus::Unavailable,
+        reason: snapshot.reason.or_else(|| {
+            Some(
+                "No response from the apiserver. Watchers and metrics have been torn down."
+                    .to_owned(),
+            )
+        }),
+    }
 }
 
 /// Permanently delete the per-cluster search index file. Called from the
@@ -3848,6 +3953,18 @@ pub(crate) async fn terminal_close(
     Ok(())
 }
 
+/// Releases `ClusterEntry::health_wired` when the health forwarder's future
+/// is dropped (normal exit *or* abort), re-arming `wire_cluster_health`.
+struct ReleaseHealthWiring(std::sync::Weak<crate::state::ClusterEntry>);
+
+impl Drop for ReleaseHealthWiring {
+    fn drop(&mut self) {
+        if let Some(entry) = self.0.upgrade() {
+            entry.release_health_wiring();
+        }
+    }
+}
+
 /// Bridge the per-cluster `ClusterHealth` broadcast to a Tauri event so
 /// the frontend can flip into an unavailable banner at the same moment
 /// the data plane gets torn down. Spawned once per cluster from the
@@ -3858,7 +3975,8 @@ pub(crate) async fn terminal_close(
 ///
 /// **Lifetime / memory.** Captures `Arc<ClusterHealth>` (not the full
 /// `Arc<ClusterEntry>` we used to take) so a forgotten abort can't pin
-/// the whole `Cluster` + kube `Client` HTTP/2 pool. The returned
+/// the whole `Cluster` + kube `Client` HTTP/2 pool — the entry is held
+/// as a `Weak`, purely to re-arm the wiring claim on exit. The returned
 /// `JoinHandle` is stored on `ClusterEntry::health_forwarder` and
 /// aborted by `drop_cluster_watchers` / `tear_down_unhealthy`; without
 /// the abort the forwarder's `rx.recv()` blocks forever (the only
@@ -3869,10 +3987,18 @@ fn spawn_health_forwarder(
     app: AppHandle,
     cluster_id: String,
     health: Arc<ferrisscope_core::health::ClusterHealth>,
+    entry: std::sync::Weak<crate::state::ClusterEntry>,
 ) -> tauri::async_runtime::JoinHandle<()> {
     let mut rx = health.subscribe();
     let event_name = format!("cluster-health://{}", sanitize_event_segment(&cluster_id));
     tauri::async_runtime::spawn(async move {
+        // Re-arm on every exit path — including abort, which drops this
+        // future and runs the guard — so the next `wire_cluster_health` (any
+        // `subscribe_*` on the cluster) spawns a replacement that replays the
+        // snapshot to whatever listener is attached by then. `Weak`, not
+        // `Arc`, so re-arming can't pin the entry (and its kube `Client`
+        // pool) past teardown; a dropped entry simply has nothing to re-arm.
+        let _rearm = ReleaseHealthWiring(entry);
         // Replay the current health snapshot so a forwarder spawned
         // *after* the probe already declared `Unavailable` (entry was
         // lazily created via `state.entry()` by some non-`connect_context`
@@ -4608,8 +4734,54 @@ fn emit_prom_changed(app: &AppHandle, cluster_id: &str, entry: Option<&PromCache
 
 #[cfg(test)]
 mod tests {
-    use super::{health_status_triggers_teardown, resource_event_name, sanitize_event_segment};
-    use ferrisscope_core::health::ClusterHealthStatus;
+    use super::{
+        health_event_for, health_status_triggers_teardown, healthy_event, resource_event_name,
+        sanitize_event_segment,
+    };
+    use ferrisscope_core::health::{ClusterHealthEvent, ClusterHealthStatus};
+
+    fn snap(status: ClusterHealthStatus, reason: Option<&str>) -> ClusterHealthEvent {
+        ClusterHealthEvent {
+            status,
+            reason: reason.map(str::to_owned),
+        }
+    }
+
+    /// The pull-side `get_cluster_health` must agree with the push-side
+    /// `cluster-health://` event, and the entry's sticky `unavailable` gate is
+    /// what `subscribe_*` actually refuses on — so it, not the dormant probe's
+    /// last broadcast, decides. Regression guard for the dead-end where the
+    /// UI read "healthy" while every subscribe failed with
+    /// "unavailable — reconnect first".
+    #[test]
+    fn unavailable_gate_wins_over_a_stale_healthy_snapshot() {
+        let out = health_event_for(true, snap(ClusterHealthStatus::Healthy, None));
+        assert_eq!(out.status, ClusterHealthStatus::Unavailable);
+        assert!(
+            out.reason.is_some(),
+            "an unavailable answer must carry a reason for the banner to render"
+        );
+    }
+
+    #[test]
+    fn unavailable_keeps_the_probe_reason_verbatim() {
+        let out = health_event_for(
+            true,
+            snap(ClusterHealthStatus::Unavailable, Some("connection reset")),
+        );
+        assert_eq!(out.status, ClusterHealthStatus::Unavailable);
+        assert_eq!(out.reason.as_deref(), Some("connection reset"));
+    }
+
+    #[test]
+    fn healthy_gate_passes_the_snapshot_through() {
+        let out = health_event_for(false, snap(ClusterHealthStatus::Healthy, None));
+        assert_eq!(out.status, ClusterHealthStatus::Healthy);
+        assert_eq!(out.reason, None);
+        // A never-connected cluster answers healthy rather than erroring —
+        // the frontend polls this on every panel mount.
+        assert_eq!(healthy_event().status, ClusterHealthStatus::Healthy);
+    }
 
     #[test]
     fn detail_cmd_invocations_forward_to_same_stem_inner_fn() {

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -168,6 +168,7 @@ fn main() {
             commands::unsubscribe_resource,
             commands::drop_cluster_watchers,
             commands::reconnect_cluster,
+            commands::get_cluster_health,
             commands::forget_cluster_search_index,
             commands::search_cluster_index,
             commands::get_resource_yaml_cmd,

--- a/crates/app/src/state.rs
+++ b/crates/app/src/state.rs
@@ -167,6 +167,16 @@ impl ClusterEntry {
             .is_ok()
     }
 
+    /// Release the health-wiring claim so the next `wire_cluster_health`
+    /// spawns a fresh forwarder. Called when a forwarder exits (it returns
+    /// after emitting `Unavailable`). Without this the claim stays set for
+    /// the entry's lifetime and a frontend listener that attaches *after*
+    /// the emit — a background tab the operator comes back to — never
+    /// receives the snapshot replay.
+    pub(crate) fn release_health_wiring(&self) {
+        self.health_wired.store(false, Ordering::SeqCst);
+    }
+
     /// Atomically claim the right to install the always-on namespaces
     /// subscription. Returns `true` exactly once per `ClusterEntry`
     /// lifetime; subsequent callers no-op. See `namespaces_pinned` for
@@ -394,15 +404,30 @@ impl AppState {
     /// `ClusterEntry::claim_connect_probes` — that's the source of truth
     /// for "have we run the bench / cluster.info for this cluster yet",
     /// not whether `insert_connected` was the one to create the entry.
+    ///
+    /// **Exception: a wedged entry never wins.** `ClusterEntry::unavailable`
+    /// is sticky — the health probe sets it, goes dormant, and every
+    /// `subscribe_*` is refused from then on — so handing one back would
+    /// discard the freshly-proven client and leave the cluster refusing
+    /// everything with no way out but a restart. Such an entry is swapped
+    /// out **under the map lock** (no window for a concurrent
+    /// `state.entry()` to re-cache the wedged one) and returned as
+    /// `displaced` for the caller to tear down off-lock — its watchers,
+    /// forwarders and metrics service still need aborting, and those take
+    /// locks of their own.
     pub(crate) async fn insert_connected(
         &self,
         id: ClusterId,
         cluster: Cluster,
-    ) -> Arc<ClusterEntry> {
+    ) -> (Arc<ClusterEntry>, Option<Arc<ClusterEntry>>) {
         let mut map = self.inner.lock().await;
-        if let Some(existing) = map.get(&id) {
-            return existing.clone();
-        }
+        let displaced = match map.get(&id) {
+            Some(existing) if !existing.unavailable.load(Ordering::SeqCst) => {
+                return (existing.clone(), None);
+            }
+            Some(wedged) => Some(wedged.clone()),
+            None => None,
+        };
         let cluster = Arc::new(cluster);
         let health = ClusterHealth::start(cluster.client());
         let entry = Arc::new(ClusterEntry {
@@ -418,7 +443,7 @@ impl AppState {
             metrics_forwarder: std::sync::Mutex::new(None),
         });
         map.insert(id, entry.clone());
-        entry
+        (entry, displaced)
     }
 
     pub(crate) async fn insert_log_stream(

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -74,6 +74,7 @@ import {
 import { IS_MAC } from "./lib/keyboard";
 import { goToFleet } from "./lib/clusterTabs";
 import { hotkeyIntent, intentPreventsDefault } from "./lib/hotkeys";
+import { isClusterUnavailableError } from "./lib/unavailable";
 import { applyThemeCssVars } from "./lib/themeDom";
 import { Icons } from "./components/ui";
 
@@ -654,9 +655,17 @@ export default function App() {
           // had filtered to (deleted while another scope was active).
           reconcileFilter();
           refresh();
-        } catch {
+        } catch (e) {
           // Best-effort per member: if namespaces aren't available there
-          // the modal still works with the other members' union.
+          // the modal still works with the other members' union. One error
+          // is not best-effort though — a wedged cluster refuses every
+          // subscribe, and this one fires on entering the cluster, so it's
+          // the earliest chance to raise the Reconnect banner.
+          if (isClusterUnavailableError(e)) {
+            useAppStore
+              .getState()
+              .applyClusterHealth(cid, "unavailable", String(e));
+          }
         }
       })();
     }

--- a/ui/src/api.test.ts
+++ b/ui/src/api.test.ts
@@ -510,6 +510,27 @@ describe("resource kinds / search / index", () => {
       namespaces: null,
     });
   });
+
+  it("getClusterHealth → 'get_cluster_health' and returns the event verbatim", async () => {
+    const evt = { status: "unavailable", reason: "connection reset" };
+    const cap = captureNext(evt);
+    const got = await api.getClusterHealth("ctx");
+    expect(cap.calls[0]?.cmd).toBe("get_cluster_health");
+    expect(cap.calls[0]?.args).toEqual({ clusterId: "ctx" });
+    // The reason string is rendered verbatim in the Reconnect banner, so a
+    // wrapper that reshaped it would silently degrade the diagnosis.
+    expect(got).toEqual(evt);
+  });
+
+  it("getClusterHealth passes a healthy answer's null reason through", async () => {
+    // Both halves of `reason: string | null` reach the store: the null one
+    // clears the banner's text, so a wrapper coercing it to "" or dropping
+    // the key would leave a stale reason rendered under a healthy cluster.
+    const cap = captureNext({ status: "healthy", reason: null });
+    const got = await api.getClusterHealth("ctx");
+    expect(cap.calls[0]?.cmd).toBe("get_cluster_health");
+    expect(got).toEqual({ status: "healthy", reason: null });
+  });
 });
 
 describe("node operations", () => {

--- a/ui/src/api.ts
+++ b/ui/src/api.ts
@@ -196,6 +196,13 @@ export const api = {
   // reusing it would just keep failing.
   reconnectCluster: (clusterId: string) =>
     invoke<void>("reconnect_cluster", { clusterId }),
+  // Pull the cluster's current health. The `cluster-health://` event fires
+  // exactly once per wedge and is lost on anyone not listening at that
+  // moment (a background tab has no mounted panel), so every panel mount
+  // asks. Non-creating on the backend: an unconnected cluster answers
+  // healthy instead of paying an auth round trip.
+  getClusterHealth: (clusterId: string) =>
+    invoke<ClusterHealthEvent>("get_cluster_health", { clusterId }),
   // Header-palette full-text search across the cluster's index. Returns up
   // to `limit` hits (FTS5 bm25 ranked) or an empty array if the cluster
   // hasn't been connected yet (or its index failed to open).

--- a/ui/src/components/ClusterBar.test.tsx
+++ b/ui/src/components/ClusterBar.test.tsx
@@ -1,0 +1,89 @@
+// The status pill must describe the CLUSTER, not the socket. `connect_context`
+// can return success against an entry the heartbeat already declared dead (its
+// data plane is torn down and every subscribe is refused), and the bar used to
+// report a green "Running" over exactly that state — the visible half of the
+// dead-end this suite guards.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ClusterBar } from "./ClusterBar";
+import { setMockInvoke, resetMockInvoke } from "../test/tauri-mock";
+import { resetEventMock } from "../test/tauri-event-mock";
+import { useAppStore } from "../store";
+import type { ClusterInfo, ContextInfo } from "../types";
+
+const CID = "default::prod";
+const CTX = {
+  id: CID,
+  name: "prod",
+  cluster: "prod",
+  user: "u",
+  namespace: null,
+  is_current: true,
+  group: "g",
+  source_id: "default",
+  source_path: null,
+} as ContextInfo;
+
+const INFO: ClusterInfo = { server_version: "v1.31.2", node_count: 3 };
+
+const initial = useAppStore.getState();
+
+afterEach(() => {
+  cleanup();
+  resetMockInvoke();
+  resetEventMock();
+  useAppStore.setState({
+    ...initial,
+    clusterHealth: {},
+    clusterHealthReason: {},
+    clusterReconnecting: {},
+  });
+});
+
+function renderBar() {
+  setMockInvoke(() => undefined);
+  render(
+    <ClusterBar mode="dark" context={CTX} state={{ status: "ok", info: INFO }} />,
+  );
+}
+
+describe("ClusterBar status pill", () => {
+  it("reads Running only when the heartbeat agrees", () => {
+    renderBar();
+    expect(screen.getByText("Running")).toBeTruthy();
+  });
+
+  it("reads Unavailable when the heartbeat has declared the cluster dead", () => {
+    useAppStore.setState({
+      clusterHealth: { [CID]: "unavailable" },
+      clusterHealthReason: { [CID]: "apiserver gone" },
+    });
+    renderBar();
+    expect(screen.queryByText("Running")).toBeNull();
+    expect(screen.getByText("Unavailable")).toBeTruthy();
+  });
+
+  it("reads Reconnecting while a retry session is running", () => {
+    // Takes precedence over both: the client is being rebuilt, so neither
+    // "Running" nor "Unavailable" is the honest answer yet.
+    useAppStore.setState({
+      clusterHealth: { [CID]: "unavailable" },
+      clusterReconnecting: { [CID]: true },
+    });
+    renderBar();
+    expect(screen.getByText("Reconnecting")).toBeTruthy();
+  });
+
+  it("keeps the connect-state answers for non-ok connections", () => {
+    setMockInvoke(() => undefined);
+    render(
+      <ClusterBar
+        mode="dark"
+        context={CTX}
+        state={{ status: "error", message: "connection refused" }}
+      />,
+    );
+    expect(screen.getByText("Error")).toBeTruthy();
+  });
+});

--- a/ui/src/components/ClusterBar.tsx
+++ b/ui/src/components/ClusterBar.tsx
@@ -39,6 +39,25 @@ export function ClusterBar({ mode, context, state, style }: Props) {
   const setAddMenuOpen = useAppStore((s) => s.setAddMenuOpen);
   const addDockTab = useAppStore((s) => s.addDockTab);
 
+  // A connected socket is not a live cluster: the heartbeat can declare the
+  // apiserver gone while `connect_context` still reports success (its client
+  // is fresh, the data plane behind it is torn down). Reporting "Running"
+  // there is the lie that hid a dead cluster behind a green pill, so the
+  // pill reads the heartbeat first and the connect state second.
+  const health = useAppStore((s) => s.clusterHealth[context.id] ?? "healthy");
+  const reconnecting = useAppStore(
+    (s) => s.clusterReconnecting[context.id] ?? false,
+  );
+  const statusLabel = reconnecting
+    ? "Reconnecting"
+    : state.status === "ok"
+      ? health === "unavailable"
+        ? "Unavailable"
+        : "Running"
+      : state.status === "error"
+        ? "Error"
+        : "Pending";
+
   // Responsive bar: progressively hide secondary stats as width shrinks so
   // the namespace + add controls (right side) and the cluster name (left
   // side) stay legible. Thresholds picked empirically against long GKE
@@ -102,15 +121,7 @@ export function ClusterBar({ mode, context, state, style }: Props) {
       <Stat
         t={t}
         label="Status"
-        value={
-          state.status === "ok" ? (
-            <StatusPill status="Running" t={t} mode={mode} dense />
-          ) : state.status === "error" ? (
-            <StatusPill status="Error" t={t} mode={mode} dense />
-          ) : (
-            <StatusPill status="Pending" t={t} mode={mode} dense />
-          )
-        }
+        value={<StatusPill status={statusLabel} t={t} mode={mode} dense />}
       />
       {showNodes && (
         <Stat

--- a/ui/src/components/ResourceTable.multi.test.tsx
+++ b/ui/src/components/ResourceTable.multi.test.tsx
@@ -154,6 +154,59 @@ describe("ResourceTable — multi-cluster merge", () => {
     expect(strip.textContent).toContain("connection refused");
   });
 
+  it("a member's 'unavailable' refusal flips that member's health, not its neighbours'", async () => {
+    // The backend refuses every subscribe against a cluster its heartbeat
+    // declared dead. That refusal is often the only signal the UI gets (the
+    // one-shot `cluster-health://` event is lost on anyone not listening at
+    // that instant), so it must land as a health transition — that's what
+    // raises the per-member Reconnect banner instead of a bare error strip.
+    mockSubscribe({
+      [CID_A]: [{ uid: "u1", name: "cm-a", namespace: "default" }],
+      [CID_B]: new Error(
+        `cluster ${CID_B} is unavailable — reconnect first`,
+      ),
+    });
+    await act(async () => {
+      render(
+        <ResourceTable
+          mode="dark"
+          clusters={TWO}
+          viewScopeId="vctx:test"
+          kind={configMapsKind}
+        />,
+      );
+    });
+    await act(async () => {});
+
+    const health = useAppStore.getState().clusterHealth;
+    expect(health[CID_B]).toBe("unavailable");
+    // The healthy member must stay untouched — a merged view degrades one
+    // cluster at a time.
+    expect(health[CID_A]).toBeUndefined();
+    expect(useAppStore.getState().clusterHealthReason[CID_B]).toContain(
+      "reconnect first",
+    );
+  });
+
+  it("an ordinary subscribe failure is not treated as a wedged cluster", async () => {
+    mockSubscribe({
+      [CID_A]: [{ uid: "u1", name: "cm-a", namespace: "default" }],
+      [CID_B]: new Error("configmaps is forbidden: User cannot list"),
+    });
+    await act(async () => {
+      render(
+        <ResourceTable
+          mode="dark"
+          clusters={TWO}
+          viewScopeId="vctx:test"
+          kind={configMapsKind}
+        />,
+      );
+    });
+    await act(async () => {});
+    expect(useAppStore.getState().clusterHealth[CID_B]).toBeUndefined();
+  });
+
   it("full-pane error when every member fails to subscribe", async () => {
     mockSubscribe({
       [CID_A]: new Error("boom-a"),

--- a/ui/src/components/ResourceTable.tsx
+++ b/ui/src/components/ResourceTable.tsx
@@ -65,6 +65,7 @@ import { makeTerminalTab } from "./Dock";
 import { confirm, toast } from "../lib/dialog";
 import { latinLetter } from "../lib/keyboard";
 import { parseTableFilter } from "../lib/tableFilter";
+import { isClusterUnavailableError } from "../lib/unavailable";
 import {
   cellRaw,
   headerWidthFloor,
@@ -354,6 +355,7 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
   // changes on health transitions, so this subscription is near-free.
   const clusterHealth = useAppStore((s) => s.clusterHealth);
   const clusterReconnecting = useAppStore((s) => s.clusterReconnecting);
+  const applyClusterHealth = useAppStore((s) => s.applyClusterHealth);
   const confirmDestructive = useAppStore((s) => s.settings.confirmDestructive);
   const density = useAppStore((s) => s.settings.density);
   const monoTables = useAppStore((s) => s.settings.monoTables);
@@ -552,6 +554,16 @@ export function ResourceTable({ mode, clusters, viewScopeId, kind }: Props) {
       for (const s of settled) {
         if (s.error !== null && !ok.some((o) => o.cid === s.cid)) {
           errs[s.cid] = s.error;
+          // The backend refuses every subscribe against a cluster its health
+          // probe declared dead. That refusal may be the ONLY signal we get
+          // (the `cluster-health://` event fires once and is lost on anyone
+          // not listening then), so treat it as the health transition it is
+          // — the unavailable banner and its Reconnect hang off this state,
+          // per cluster, so a wedged member of a merged view surfaces on its
+          // own row while the healthy members keep serving.
+          if (isClusterUnavailableError(s.error)) {
+            applyClusterHealth(s.cid, "unavailable", s.error);
+          }
         }
       }
 

--- a/ui/src/lib/unavailable.test.ts
+++ b/ui/src/lib/unavailable.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isClusterUnavailableError } from "./unavailable";
+
+describe("isClusterUnavailableError", () => {
+  it("matches the backend refusal verbatim", () => {
+    expect(
+      isClusterUnavailableError(
+        "cluster default::gke_prod-1 is unavailable — reconnect first",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches when Tauri has wrapped it in an Error", () => {
+    expect(
+      isClusterUnavailableError(
+        new Error("cluster kind-kind is unavailable — reconnect first"),
+      ),
+    ).toBe(true);
+  });
+
+  it("is insensitive to the dash style and case", () => {
+    expect(
+      isClusterUnavailableError("Cluster x IS UNAVAILABLE - RECONNECT FIRST"),
+    ).toBe(true);
+  });
+
+  it("ignores unrelated failures", () => {
+    expect(isClusterUnavailableError("unknown kind: widgets")).toBe(false);
+    expect(
+      isClusterUnavailableError('pods is forbidden: User "x" cannot list'),
+    ).toBe(false);
+    // "unavailable" alone is a common apiserver word (503, metrics-server) —
+    // only the paired refusal means the entry gate is closed.
+    expect(
+      isClusterUnavailableError("the server is currently unavailable"),
+    ).toBe(false);
+    expect(isClusterUnavailableError(null)).toBe(false);
+    expect(isClusterUnavailableError(undefined)).toBe(false);
+  });
+});

--- a/ui/src/lib/unavailable.ts
+++ b/ui/src/lib/unavailable.ts
@@ -1,0 +1,19 @@
+// Recognises the backend's "this cluster is wedged" refusal so the UI can
+// flip the cluster into its unavailable state from a *command error* alone.
+//
+// Why it matters: `cluster-health://` is emitted exactly once per wedge and
+// is lost on any client not listening at that instant. The subscribe error
+// is the one signal that arrives on demand, every time — treating it as a
+// health transition is what guarantees a Reconnect affordance instead of a
+// bare "Failed to load".
+//
+// Source of truth: `crates/app/src/commands.rs` —
+// `format!("cluster {cluster_id} is unavailable — reconnect first")`.
+// Matched loosely (em dash and the cluster id are not part of the test) so a
+// reworded backend message doesn't silently drop the banner.
+const UNAVAILABLE_RE = /\bis unavailable\b[\s\S]*\breconnect first\b/i;
+
+export function isClusterUnavailableError(err: unknown): boolean {
+  if (err == null) return false;
+  return UNAVAILABLE_RE.test(typeof err === "string" ? err : String(err));
+}

--- a/ui/src/lib/useClusterConnection.test.ts
+++ b/ui/src/lib/useClusterConnection.test.ts
@@ -10,12 +10,14 @@ let healthHandler: ((evt: ClusterHealthEvent) => void) | null = null;
 const connectContext = vi.fn();
 const cancelConnect = vi.fn().mockResolvedValue(undefined);
 const reconnectCluster = vi.fn().mockResolvedValue(undefined);
+const getClusterHealth = vi.fn();
 
 vi.mock("../api", () => ({
   api: {
     connectContext: (...a: unknown[]) => connectContext(...a),
     cancelConnect: (...a: unknown[]) => cancelConnect(...a),
     reconnectCluster: (...a: unknown[]) => reconnectCluster(...a),
+    getClusterHealth: (...a: unknown[]) => getClusterHealth(...a),
   },
   onClusterHealth: vi.fn((_id: string, h: (e: ClusterHealthEvent) => void) => {
     healthHandler = h;
@@ -60,6 +62,7 @@ function fireHealth(evt: ClusterHealthEvent) {
 }
 
 const UNAVAIL: ClusterHealthEvent = { status: "unavailable", reason: "timeout" };
+const HEALTHY: ClusterHealthEvent = { status: "healthy", reason: null };
 const MAX = 10;
 // Mirror of the hook's capped exponential backoff: 2,4,8,16,30,30,…
 const backoff = (idx: number) => Math.min(2000 * 2 ** idx, 30_000);
@@ -71,6 +74,7 @@ describe("useClusterConnection auto-reconnect", () => {
     connectContext.mockReset().mockResolvedValue({ server_version: "v1" });
     cancelConnect.mockClear();
     reconnectCluster.mockClear().mockResolvedValue(undefined);
+    getClusterHealth.mockReset().mockResolvedValue(HEALTHY);
     useAppStore.setState({
       ...initial,
       clusterHealth: {},
@@ -90,6 +94,102 @@ describe("useClusterConnection auto-reconnect", () => {
     expect(result.current.state.status).toBe("ok");
     expect(result.current.autoReconnect).toBeNull();
     expect(reconnectCluster).not.toHaveBeenCalled();
+  });
+
+  it("recovers an unavailable that was emitted while nothing was listening", async () => {
+    // Regression: the probe broadcasts `unavailable` exactly once and the
+    // forwarder then exits, so a cluster that wedged while its tab sat in the
+    // background had NO listener — coming back showed a green bar over a table
+    // whose every subscribe failed, with no Reconnect button. The mount-time
+    // pull is what closes that hole.
+    getClusterHealth.mockResolvedValue(UNAVAIL);
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    expect(getClusterHealth).toHaveBeenCalledWith(CTX.id);
+    expect(useAppStore.getState().clusterHealth[CTX.id]).toBe("unavailable");
+    expect(useAppStore.getState().clusterHealthReason[CTX.id]).toBe("timeout");
+    // …and it drives the same recovery a live event would.
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+  });
+
+  it("the health pull clears a stale unavailable left over from an earlier wedge", async () => {
+    // `connect_context` evicts a wedged entry and rebuilds it, so a healthy
+    // answer here is authoritative: without applying it the banner would stay
+    // up over a cluster that is already serving again.
+    useAppStore.setState({
+      clusterHealth: { [CTX.id]: "unavailable" },
+      clusterHealthReason: { [CTX.id]: "timeout" },
+    });
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    expect(useAppStore.getState().clusterHealth[CTX.id]).toBe("healthy");
+    expect(result.current.autoReconnect).toBeNull();
+    expect(reconnectCluster).not.toHaveBeenCalled();
+  });
+
+  it("a refused command flipping health starts the same retry session as an event", async () => {
+    // ResourceTable / the namespaces subscribe mark the cluster unavailable
+    // when the backend refuses them ("unavailable — reconnect first"). That
+    // write must drive recovery exactly like a live probe event would —
+    // otherwise the wedge detected by the only signal that still arrives
+    // would sit behind a manual button.
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+    expect(result.current.autoReconnect).toBeNull();
+
+    act(() => {
+      useAppStore
+        .getState()
+        .applyClusterHealth(
+          CTX.id,
+          "unavailable",
+          `cluster ${CTX.id} is unavailable — reconnect first`,
+        );
+    });
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+
+    await flush(2000);
+    expect(reconnectCluster).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls health while connected, so a lost event still surfaces the wedge", async () => {
+    // Worst case for the push channel: the cluster wedges while the operator
+    // sits on an already-loaded table. Nothing re-subscribes, the one-shot
+    // event was missed — only the poll can notice, and it must arrive without
+    // any interaction.
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+    expect(getClusterHealth).toHaveBeenCalledTimes(1); // the mount pull
+
+    getClusterHealth.mockResolvedValue(UNAVAIL);
+    await flush(15_000);
+
+    expect(getClusterHealth).toHaveBeenCalledTimes(2);
+    expect(useAppStore.getState().clusterHealth[CTX.id]).toBe("unavailable");
+    expect(result.current.autoReconnect).toEqual({ attempt: 1, max: MAX });
+  });
+
+  it("stops polling once the panel unmounts", async () => {
+    const { unmount } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+    const afterMount = getClusterHealth.mock.calls.length;
+    unmount();
+    await flush(60_000);
+    expect(getClusterHealth).toHaveBeenCalledTimes(afterMount);
+  });
+
+  it("a failed health pull leaves the connection alone", async () => {
+    // The pull is a diagnostic, not a gate — an IPC hiccup must not fabricate
+    // an outage or blank the view.
+    getClusterHealth.mockRejectedValue(new Error("ipc closed"));
+    const { result } = renderHook(() => useClusterConnection(CTX));
+    await flush();
+
+    expect(result.current.state.status).toBe("ok");
+    expect(useAppStore.getState().clusterHealth[CTX.id]).toBeUndefined();
+    expect(result.current.autoReconnect).toBeNull();
   });
 
   it("on unavailable, schedules the first retry at exactly 2000ms", async () => {
@@ -253,6 +353,7 @@ describe("useClusterConnection permanent-failure gating", () => {
     connectContext.mockReset().mockResolvedValue({ server_version: "v1" });
     cancelConnect.mockClear();
     reconnectCluster.mockClear().mockResolvedValue(undefined);
+    getClusterHealth.mockReset().mockResolvedValue(HEALTHY);
     useAppStore.setState({
       ...initial,
       clusterHealth: {},

--- a/ui/src/lib/useClusterConnection.ts
+++ b/ui/src/lib/useClusterConnection.ts
@@ -1,6 +1,6 @@
 import { logErr } from "./log";
 import { isPermanentConnectFailure } from "./connectFailure";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api, onClusterHealth, onClusterInfoChanged } from "../api";
 import { useAppStore } from "../store";
 import type { ClusterInfo, ContextInfo } from "../types";
@@ -33,6 +33,12 @@ function backoffMs(attemptIdx: number): number {
 // ~30s later (the probe's unhealthy window). We only consider a session truly
 // recovered once it's stayed connected this long with no new unavailable.
 const RECOVERY_DWELL_MS = 60_000;
+// How often a mounted panel re-asks the backend for its cluster's health.
+// Backstop for the one-shot push event, so the gap between a cluster wedging
+// and the banner appearing stays bounded even with zero user interaction.
+// Well under the probe's own 30s unhealthy window — no point polling faster
+// than the state can change.
+const HEALTH_POLL_MS = 15_000;
 
 // Generate a unique connect_id per attempt. crypto.randomUUID is available
 // in Tauri's WebKit; fall back to a timestamp-based id if it ever isn't.
@@ -90,6 +96,18 @@ export function useClusterConnection(context: ContextInfo): {
   const applyClusterHealth = useAppStore((s) => s.applyClusterHealth);
   const clearClusterHealth = useAppStore((s) => s.clearClusterHealth);
   const setClusterReconnecting = useAppStore((s) => s.setClusterReconnecting);
+  // The store — not the event listener — is the single trigger for recovery.
+  // Three different sources write "unavailable" there (the one-shot
+  // `cluster-health://` event, the mount-time health pull, and any command
+  // refused with "unavailable — reconnect first"), and each of them must get
+  // the same silent retry session. Watching the value instead of the event
+  // means a wedge detected by ANY of them recovers the same way.
+  const healthStatus = useAppStore(
+    (s) => s.clusterHealth[context.id] ?? "healthy",
+  );
+  const healthReason = useAppStore(
+    (s) => s.clusterHealthReason[context.id] ?? null,
+  );
 
   // Mutable auto-reconnect session state. Refs, not state, so re-running the
   // connect effect (via setAttempt) never clobbers them.
@@ -99,6 +117,11 @@ export function useClusterConnection(context: ContextInfo): {
   const backoffTimerRef = useRef<number | null>(null);
   const dwellTimerRef = useRef<number | null>(null);
   const mountedRef = useRef(true);
+  // Previous health value, so the watcher below reacts to the *transition*
+  // into unavailable. Seeded from the current value: a cluster whose store
+  // entry is already stale-unavailable at mount must not start retrying
+  // before the health pull has had its say.
+  const prevHealthRef = useRef(healthStatus);
   // Current context id, readable from controller methods that outlive a render.
   const cidRef = useRef(context.id);
   cidRef.current = context.id;
@@ -246,6 +269,10 @@ export function useClusterConnection(context: ContextInfo): {
     attemptsUsedRef.current = 0;
     sessionActiveRef.current = false;
     attemptInFlightRef.current = false;
+    // New cluster, new baseline — otherwise the previous context's health
+    // value would read as a transition on the first render here.
+    prevHealthRef.current =
+      useAppStore.getState().clusterHealth[cid] ?? "healthy";
     if (backoffTimerRef.current != null) {
       window.clearTimeout(backoffTimerRef.current);
       backoffTimerRef.current = null;
@@ -271,6 +298,54 @@ export function useClusterConnection(context: ContextInfo): {
     };
   }, [context.id, setClusterReconnecting]);
 
+  // Ask the backend what it currently thinks of this cluster and write the
+  // answer to the store — the one place recovery is triggered from. `stale`
+  // lets each caller drop a late answer (unmounted, superseded attempt).
+  const pullHealth = useCallback(
+    (stale: () => boolean) => {
+      api
+        .getClusterHealth(context.id)
+        .then((evt) => {
+          if (stale()) return;
+          applyClusterHealth(context.id, evt.status, evt.reason);
+        })
+        .catch(logErr("cluster-connect"));
+    },
+    [context.id, applyClusterHealth],
+  );
+
+  // Heartbeat poll while the panel is up. The push channel is one-shot and
+  // silent afterwards, so without this a cluster that wedges with the
+  // operator sitting on an already-loaded table shows stale rows and no
+  // banner until they happen to touch something that re-subscribes. Costs a
+  // map lookup per tick on the backend — no apiserver traffic — so it stays
+  // cheap even across a large virtual context (one poll per member).
+  useEffect(() => {
+    if (state.status !== "ok") return;
+    let stopped = false;
+    const timer = window.setInterval(
+      () => pullHealth(() => stopped),
+      HEALTH_POLL_MS,
+    );
+    return () => {
+      stopped = true;
+      window.clearInterval(timer);
+    };
+  }, [state.status, pullHealth]);
+
+  // Store-driven recovery. Fires on the transition INTO unavailable, from
+  // whichever source noticed it, and only while the connection itself is up
+  // — a cluster that's still connecting (or already in the error banner) has
+  // its own path through `onConnectResolved`, and retrying underneath it
+  // would cancel the in-flight connect.
+  useEffect(() => {
+    const prev = prevHealthRef.current;
+    prevHealthRef.current = healthStatus;
+    if (prev === healthStatus || healthStatus !== "unavailable") return;
+    if (state.status !== "ok") return;
+    ctlRef.current?.onUnavailable(healthReason);
+  }, [healthStatus, healthReason, state.status]);
+
   useEffect(() => {
     const id = ++reqId.current;
     const connectId = newConnectId();
@@ -279,20 +354,37 @@ export function useClusterConnection(context: ContextInfo): {
     let unlistenHealth: (() => void) | null = null;
     let cancelled = false;
 
-    // Subscribe to the per-cluster health probe before firing connect so
-    // we don't miss the unavailable transition if it lands during the
-    // initial connect window. The backend emits exactly one unavailable
-    // event per cluster lifetime; it's the data plane's "this is dead"
-    // signal that the resource table uses to dim its rows + show the
-    // banner — and our trigger to start silently auto-reconnecting.
+    // Subscribe to the per-cluster health probe before firing connect so we
+    // don't miss the unavailable transition if it lands during the initial
+    // connect window. The fastest of the three detection paths, but not one
+    // to rely on: the backend emits exactly one unavailable event per
+    // cluster lifetime, so anyone not listening at that instant never hears
+    // it. Recovery hangs off the store value (see the watcher effect), so
+    // this only has to record what the backend said.
     onClusterHealth(context.id, (evt) => {
       if (cancelled) return;
       applyClusterHealth(context.id, evt.status, evt.reason);
-      if (evt.status === "unavailable") ctlRef.current?.onUnavailable(evt.reason);
     }).then((fn) => {
       if (cancelled) fn();
       else unlistenHealth = fn;
     });
+
+    // Pull the cluster's current health once the connect has landed. The
+    // backend emits `unavailable` exactly *once* per wedge, so any client
+    // not listening at that instant never learns: a cluster living in a
+    // background tab has no mounted panel, and `listen()` itself registers
+    // asynchronously, so even a mounted panel can lose the race. Without
+    // this pull the operator gets a healthy-looking bar over a table whose
+    // every subscribe fails, and no Reconnect button.
+    //
+    // Ordering matters: this runs AFTER connect resolves, because
+    // `connect_context` evicts a wedged entry and rebuilds it — asking
+    // first would report the pre-eviction state and start a pointless
+    // retry session. Applying the healthy answer also clears a stale
+    // `unavailable` left in the store by an earlier session.
+    const hydrateHealth = (attemptId: number) => {
+      pullHealth(() => cancelled || reqId.current !== attemptId);
+    };
 
     // Listen for the deferred cluster.info result before firing the connect
     // call so we don't miss the event if it arrives between connect_context
@@ -315,6 +407,7 @@ export function useClusterConnection(context: ContextInfo): {
         if (reqId.current === id) {
           setState({ status: "ok", info });
           ctlRef.current?.onConnectResolved("ok");
+          hydrateHealth(id);
         }
       })
       .catch((e: unknown) => {

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -955,6 +955,9 @@ const WARN = new Set([
   "degraded",
   "Updating",
   "Progressing",
+  // Cluster-level, not object-level: a connection being rebuilt after the
+  // health probe declared the apiserver gone.
+  "Reconnecting",
 ]);
 const INFO = new Set([
   "ContainerCreating",
@@ -995,6 +998,7 @@ const TRANSIENT = new Set([
   "Waiting",
   "PodScheduled",
   "ContainerStarting",
+  "Reconnecting",
 ]);
 
 export function statusBucket(status: string): StatusBucket {


### PR DESCRIPTION
## The dead end

A cluster the health probe declared unavailable could get stuck with no way out but closing the tab or restarting the app. The bar showed a green **Running** while every table failed with `cluster … is unavailable — reconnect first`, and no Reconnect banner appeared.


Repro: open cluster A in one tab, cluster B in another, stay on B while A's session expires or its apiserver wedges. The backend tears A's data plane down and sets `unavailable`; switch back to A and it looks connected but serves nothing.

## Why it happened

Three defects stacked:

1. **`unavailable` is sticky and `insert_connected` kept the existing entry.** `connect_context` against a wedged cluster reported success, dropped the client it had just proven alive, and kept refusing every subscribe. `claim_connect_probes` was already claimed on that entry too — which is why NODES/VERSION stayed blank.
2. **The health event is one-shot.** The probe broadcasts `Unavailable` once and the forwarder exits; `claim_health_wiring` never reset, so no replay was possible. Only the active tab's panel listens, so a background cluster's wedge was emitted into the void.
3. **The frontend never mapped the refusal onto health,** rendering it as a generic "Failed to load".

## The fix

- `insert_connected` swaps a wedged entry out **under the map lock** — no window for a concurrent `state.entry()` to re-cache it — and returns it as `displaced`. `connect_context` tears that down off-lock via `tear_down_displaced`, addressed by `Arc`, since the id now resolves to the replacement. `drop_all_kind_watchers` split into a by-id wrapper over a by-entry `drop_entry_watchers`.
- New `get_cluster_health` command (non-creating; the sticky gate wins over the dormant probe's snapshot), plus a `ReleaseHealthWiring` drop guard that re-arms the wiring claim when a forwarder exits — so a listener attaching later still gets a replay.
- `isClusterUnavailableError` maps the refusal onto `applyClusterHealth`, wired into the table's per-cluster subscribe errors and App's eager namespaces subscribe.
- Recovery now triggers off a single **store transition**, so the event, the mount-time pull, and a refused command all start the same silent retry session. A 15s poll while a panel is mounted bounds detection latency when nothing re-subscribes — a map lookup per tick, no apiserver traffic.
- The status pill reads the heartbeat, not the socket: `Running` only when both agree, else `Unavailable` / `Reconnecting`.

**Multi-cluster:** every member of a virtual context runs the same hook, so per-member banners, retries and pill states come along; one wedged member never touches its neighbours.

## Tests

`cargo fmt --check` · `clippy --all-targets -D warnings` · 186 Rust tests · `tsc --noEmit` · 1564 UI tests — all green.

New: 3 Rust (gate reconciliation), `unavailable.test.ts` (5), hook (6 — lost-event recovery, stale-clear, pull failure, error-driven session, poll detects, poll stops on unmount), `ResourceTable.multi` (2 — per-member flip, non-wedge error ignored), `ClusterBar.test.tsx` (4 pill states), api shape (2).

## Not covered

- Never reproduced against a real wedged GKE apiserver; the swap path has compile + unit coverage only, since a real `ClusterEntry` needs a live client. Worth one live check after a token expiry.
- A cluster in a **background** tab still surfaces nothing until you return to it (no mounted panel, no poll). It heals on return; the tab strip won't go red meanwhile.
- Eviction drops that cluster's log streams (already dead); terminals, chats and pinned forwards keep the old client — unchanged behaviour from the manual Reconnect path.
- Fleet cards still reflect connect outcomes only, not a mid-session wedge.

